### PR TITLE
fixed build on win32 x86 platform

### DIFF
--- a/build/Config/APR.pm
+++ b/build/Config/APR.pm
@@ -7,7 +7,7 @@ sub configure {
     
     if ($^O =~ /MSWin32/) {
         if ($config{'make'} eq 'nmake') {
-            if (`cl 2>&1` =~ /80x86/) {
+            if (`cl 2>&1` =~ /x86/) {
                 return (%config,
                     apr_build_line => 'cd 3rdparty/apr && nmake -f Makefile.win ARCH="Win32 Release" buildall',
                     apr_lib => '3rdparty/apr/LibR/apr-1.lib'

--- a/build/Config/BuildEnvironment.pm
+++ b/build/Config/BuildEnvironment.pm
@@ -65,7 +65,7 @@ sub detect {
         }
         
         # On 32-bit, define AO_ASSUME_WINDOWS98.
-        if (`cl 2>&1` =~ /80x86/) {
+        if (`cl 2>&1` =~ /x86/) {
             $config{'cmiscflags'} .= ' -DAO_ASSUME_WINDOWS98';
         }
     }


### PR DESCRIPTION
`cl 2>&1` outputs `x86`, not `80x86` here
