### PR TITLE
hard tab is required for gmake.

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -342,7 +342,7 @@ $(LAO_LIB):
 
 # sha1
 $(SHA1_LIB): 3rdparty/sha1/sha1.h
-    cd 3rdparty/sha1 && $(CC) -c $(COUTO)sha1$(O) -I. $(CFLAGS) sha1.c
+	cd 3rdparty/sha1 && $(CC) -c $(COUTO)sha1$(O) -I. $(CFLAGS) sha1.c
 
 test:
 	@echo "Please build nqp-cc and run the tests in there"


### PR DESCRIPTION
8d20e6dc60da66a946bace950538aec80ccd9053 breaks by spaces in my environment.
