### PR TITLE
Fix OS X build by removing -Bstatic/dynamic

### DIFF
--- a/build/Config/BuildEnvironment.pm
+++ b/build/Config/BuildEnvironment.pm
@@ -217,6 +217,7 @@ sub detect {
         );
         options( \%config, $opts );
 
+        $config{llibs} = '-lapr-1 -lpthread -lm' if $^O eq 'darwin' and $compiler eq 'clang';
     }
     else {
         return (excuse => 'No recognized operating system or compiler found.'."  found: $^O");


### PR DESCRIPTION
This introduces an ugly hack to the fairly pretty build system, but
hopefully operating system specific compiler hacks are rare.
