### PR TITLE
Don't build APR's dynamic libraries

### DIFF
--- a/build/Config/APR.pm
+++ b/build/Config/APR.pm
@@ -27,13 +27,13 @@ sub configure {
     elsif( $^O =~ /linux/ && can_run('gcc') ) {
         return (%config,
             llibs => '-lapr-1 -lpthread -lm -luuid',
-            apr_build_line => 'cd 3rdparty/apr && ./configure && make',
+            apr_build_line => 'cd 3rdparty/apr && ./configure --disable-shared && make',
             apr_lib => '3rdparty/apr/.libs/libapr-1.a'
         );
     }
     else {
         return (%config,
-            apr_build_line => 'cd 3rdparty/apr && ./configure && make',
+            apr_build_line => 'cd 3rdparty/apr && ./configure --disable-shared && make',
             apr_lib => '3rdparty/apr/.libs/libapr-1.a'
         );
     }


### PR DESCRIPTION
We're trying to use the static version anyway, so don't waste time
building a dynamic library.  And hopefully this will help keep some
versions of ld _cough_OS X_cough_ from trying to use the dynamic
version.  (OS X is especially bad in that at runtime it searches for
where APR says its going to be installed, which is overly confusing.)
