### PR TITLE
operands are uninitialized if we have none, check for it

### DIFF
--- a/src/mast/compiler.c
+++ b/src/mast/compiler.c
@@ -576,7 +576,7 @@ void compile_instruction(VM, WriterState *ws, MASTNode *node) {
         ws->current_operand_idx = 0;
 
         /* Ensure argument count matches up. */
-        if (ELEMS(vm, o->operands) != info->num_operands) {
+        if (info->num_operands != 0 && ELEMS(vm, o->operands) != info->num_operands) {
             unsigned int  current_frame_idx = ws->current_frame_idx;
             unsigned int  current_ins_idx = ws->current_ins_idx;
             const char *name = ws->current_op_info->name;


### PR DESCRIPTION
o->operands is uninitialized (either NULL or garbled) if we have no operands, such as for ops no_op. Thus crashes. (VS2012 Win8).
