### PR TITLE
Update ascii.c

### DIFF
--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -2,7 +2,7 @@
 
 /* Decodes the specified number of bytes of ASCII into an NFG string, creating
  * a result of the specified type. The type must have the MVMString REPR. */
-MVMString * MVM_string_ascii_decode(MVMThreadContext *tc, MVMObject *result_type, const char *ascii, size_t bytes) {
+MVMString * MVM_string_ascii_decode(MVMThreadContext *tc, MVMObject *result_type, const unsigned char *ascii, size_t bytes) {
     MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
     size_t i;
 
@@ -27,7 +27,7 @@ MVMString * MVM_string_ascii_decode(MVMThreadContext *tc, MVMObject *result_type
 
 /* Decodes a NULL-terminated ASCII string into an NFG string, creating
  * a result of the specified type. The type must have the MVMString REPR. */
-MVMString * MVM_string_ascii_decode_nt(MVMThreadContext *tc, MVMObject *result_type, const char *ascii) {
+MVMString * MVM_string_ascii_decode_nt(MVMThreadContext *tc, MVMObject *result_type, const unsigned char *ascii) {
     return MVM_string_ascii_decode(tc, result_type, ascii, strlen(ascii));
 }
 


### PR DESCRIPTION
if ascii[i] must be tested to be above 127, \* ascii should be defined as constant unsigned char*
