### PR TITLE
Clear fd when closing a file handle to prevent "dangling" descriptors

### DIFF
--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -277,12 +277,15 @@ MVMObject * MVM_file_open_fh(MVMThreadContext *tc, MVMString *filename, MVMStrin
 void MVM_file_close_fh(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle;
     uv_fs_t req;
+    int status;
 
     verify_filehandle_type(tc, oshandle, &handle, "close filehandle");
 
     MVM_checked_free_null(handle->body.filename);
 
-    if (uv_fs_close(tc->loop, &req, handle->body.u.fd, NULL) < 0) {
+    status = uv_fs_close(tc->loop, &req, handle->body.u.fd, NULL);
+    handle->body.u.fd = -1;
+    if (status < 0) {
         MVM_exception_throw_adhoc(tc, "Failed to close filehandle: %s", uv_strerror(req.result));
     }
 }


### PR DESCRIPTION
We can run into a situation with MoarVM where a double close can
close an arbitrary, innocent file.  Consider:

``` perl6
    my $fh := nqp::open($filename); # let's say it's FD 3
    # do stuff
    nqp::close($fh);
    my $other_fh := nqp::open($other_filename); # 3 again!
    nqp::close($fh); # closes 3! o_O
```
