### PR TITLE
using MVMuint64 in bigint_shr

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -578,8 +578,8 @@ void MVM_bigint_shr(MVMThreadContext *tc, MVMObject *result, MVMObject *a, MVMin
         store_bigint_result(bb, ib);
         clear_temp_bigints(tmp, 1);
     } else {
-        MVMint32 value = ba->u.smallint.value;
-        MVMint32 result = value >> n;
+        MVMuint64 value = ba->u.smallint.value;
+        MVMuint64 result = value >> n;
         store_int64_result(bb, result);
     }
 }


### PR DESCRIPTION
This is so 1 +> 32 returns 0 and not 1.

Not tested much but it should be fine.

I want this in order to translate  http://rosettacode.org/wiki/Elementary_cellular_automaton#C
