### PR TITLE
Fix decodestream_bytes_to_buf eating too much data

### DIFF
--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -309,7 +309,7 @@ MVMint64 MVM_string_decodestream_bytes_to_buf(MVMThreadContext *tc, MVMDecodeStr
                 *buf = malloc(required);
             memcpy(*buf + taken, cur_bytes->bytes + ds->bytes_head_pos, required);
             taken += required;
-            ds->bytes_head_pos += available;
+            ds->bytes_head_pos += required;
         }
     }
     if (ds->bytes_head == NULL)


### PR DESCRIPTION
When decodestream_bytes_to_buf needed less data than available in the
buffer, it was incorrectly updating the pointer to the beginning of the
buffer data. This lead to a loss of data when doing small socket reads,
for example.
