### PR TITLE
Mark callback Str parameters as not to be freed

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -363,7 +363,7 @@ static void * unmarshal_callback(MVMThreadContext *tc, MVMObject *callback, MVMO
             typehash = MVM_repr_at_pos_o(tc, sig_info, i);
             callback_data->types[i] = MVM_repr_at_key_o(tc, typehash,
                 tc->instance->str_consts.typeobj);
-            callback_data->typeinfos[i] = get_arg_type(tc, typehash, 0);
+            callback_data->typeinfos[i] = get_arg_type(tc, typehash, 0) & ~MVM_NATIVECALL_ARG_FREE_STR;
             signature[i - 1] = get_signature_char(callback_data->typeinfos[i]);
             switch (callback_data->typeinfos[i] & MVM_NATIVECALL_ARG_TYPE_MASK) {
                 case MVM_NATIVECALL_ARG_CHAR:


### PR DESCRIPTION
If a library is passing a string to a callback function, it is
very seldom the case that the callback assumes ownership of that
string and responsibility for its destruction.  Until we add traits
to annotate parameters to NativeCall (with regards to memory
management), I think it would be best to assume that callback strings
should _not_ be freed
