### PR TITLE
No manual symlinks

### DIFF
--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -41,21 +41,6 @@ static uv_stat_t file_info(MVMThreadContext *tc, MVMString *filename) {
     return req.statbuf;
 }
 
-/* This will modify req and at the end it will be something other than a symlink. */
-MVMint64 MVM_file_stat_follow_symlink(MVMThreadContext *tc, char *filename, uv_fs_t *req) {
-    if (uv_fs_lstat(tc->loop, req, filename, NULL) < 0)
-        return -1;
-
-    if ((req->statbuf.st_mode & S_IFMT) == S_IFLNK) {
-        if (uv_fs_readlink(tc->loop, req, filename, NULL) < 0)
-            return -1;
-
-        return MVM_file_stat_follow_symlink(tc, (char *)req->ptr, req);
-    }
-
-    return 0;
-}
-
 MVMint64 MVM_file_stat(MVMThreadContext *tc, MVMString *filename, MVMint64 status) {
     MVMint64 r = -1;
 

--- a/src/io/fileops.h
+++ b/src/io/fileops.h
@@ -24,7 +24,6 @@
 #define MVM_STAT_PLATFORM_BLOCKSIZE -6
 #define MVM_STAT_PLATFORM_BLOCKS    -7
 
-MVMint64 MVM_file_stat_follow_symlink(MVMThreadContext *tc, char *filename, uv_fs_t *req);
 MVMint64 MVM_file_stat(MVMThreadContext *tc, MVMString *filename, MVMint64 status);
 void MVM_file_copy(MVMThreadContext *tc, MVMString *src, MVMString *dest);
 void MVM_file_rename(MVMThreadContext *tc, MVMString *src, MVMString *dest);


### PR DESCRIPTION
MoarVM has some behavior, when getting a file's size, to resolve symbolic links' paths by hand until a non-link is reached.  Not only does `fstat` itself handle this situation already, but the current behavior will attempt to follow a self-referential link (or a series of them, with the last one pointing at the first) until the program is killed.  This change allows the OS to handle symbolic links itself.
