### PR TITLE
Zero-fill CArrays

### DIFF
--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -82,7 +82,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
     if (!repr_data)
         MVM_exception_throw_adhoc(tc, "CArray type must be composed before use");
 
-    body->storage = MVM_malloc(4 * repr_data->elem_size);
+    body->storage = MVM_calloc(4, repr_data->elem_size);
     body->managed = 1;
 
     /* Don't need child_objs for numerics. */
@@ -182,8 +182,13 @@ static void expand(MVMThreadContext *tc, MVMCArrayREPRData *repr_data, MVMCArray
     if (min_size > next_size)
         next_size = min_size;
 
-    if (body->managed)
+    if (body->managed) {
+        const size_t old_size = body->allocated * repr_data->elem_size;
+        const size_t new_size = next_size * repr_data->elem_size;
+
         body->storage = MVM_realloc(body->storage, next_size * repr_data->elem_size);
+        memset((char *)body->storage + old_size, 0, new_size - old_size);
+    }
 
     is_complex = (repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_CARRAY
                || repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_CPOINTER

--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -186,7 +186,7 @@ static void expand(MVMThreadContext *tc, MVMCArrayREPRData *repr_data, MVMCArray
         const size_t old_size = body->allocated * repr_data->elem_size;
         const size_t new_size = next_size * repr_data->elem_size;
 
-        body->storage = MVM_realloc(body->storage, next_size * repr_data->elem_size);
+        body->storage = MVM_realloc(body->storage, new_size);
         memset((char *)body->storage + old_size, 0, new_size - old_size);
     }
 


### PR DESCRIPTION
See discussion around http://irclog.perlgeek.de/perl6/2015-01-29#i_10027737

I don't know what the performance implications of this are.  One suggestion was to make this default but optional.  I'm not too experienced with either C, or the plumbing to pass/store those options around between zavolaj/nqp/moar, so I didn't do that part yet.  But at least for my uses, this patch solves a couple problems right away, since iterating over a large array from perl 6 code is a major bottleneck.