### PR TITLE
fix allocating an empty (no attributes) CPPStruct bug

### DIFF
--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -320,8 +320,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
 
     /* Allocate object body. */
     MVMCPPStructBody *body = (MVMCPPStructBody *)data;
-    body->cppstruct = MVM_malloc(repr_data->struct_size > 0 ? repr_data->struct_size : 1);
-    memset(body->cppstruct, 0, repr_data->struct_size);
+    body->cppstruct = MVM_calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
 
     /* Allocate child obj array. */
     if (repr_data->num_child_objs > 0)

--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -731,7 +731,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                     if (i == 0 && !IS_CONCRETE(value)) {
                         MVMCPPStructREPRData *repr_data = (MVMCPPStructREPRData *)STABLE(res_type)->REPR_data;
                         /* Allocate a full byte aligned area where the C++ structure fits into. */
-                        ptr    = MVM_malloc(repr_data->struct_size);
+                        ptr    = MVM_malloc(repr_data->struct_size > 0 ? repr_data->struct_size : 1);
                         result = MVM_nativecall_make_cppstruct(tc, res_type, ptr);
 
                         dcArgPointer(vm, ptr);


### PR DESCRIPTION
prevent alloc()ing memory of wrong size