### PR TITLE
fix system detection in triple for cross compilation

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -570,7 +570,7 @@ sub setup_cross {
     my $crossconf = "--build=$build --host=$host";
 
     for (\$build, \$host) {
-        if ($$_ =~ /-(\w+)$/) {
+        if ($$_ =~ /-(\w+)-\w+$/) {
             $$_ = $1;
             if (!exists $::SYSTEMS{$1}) {
                 softfail("unknown OS '$1'");


### PR DESCRIPTION
the scheme for triple is `<arch><sub>-<vendor>-<sys>-<abi>`, so the `sys` is not the last part.

see http://clang.llvm.org/docs/CrossCompilation.html as reference.