### PR TITLE
Add helper functions so embedders won't need to poke into MVMInstance

### DIFF
--- a/src/moar.c
+++ b/src/moar.c
@@ -310,3 +310,32 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     /* Clear up VM instance memory. */
     MVM_free(instance);
 }
+
+void MVM_vm_set_clargs(MVMInstance *instance, int argc, char **argv) {
+    instance->num_clargs = argc;
+    instance->raw_clargs = argv;
+}
+
+void MVM_vm_set_exec_name(MVMInstance *instance, const char *exec_name) {
+    instance->exec_name = exec_name;
+}
+
+void MVM_vm_set_prog_name(MVMInstance *instance, const char *prog_name) {
+    instance->prog_name = prog_name;
+}
+
+void MVM_vm_set_lib_path(MVMInstance *instance, int count, const char **lib_path) {
+    enum { MAX_COUNT = sizeof instance->lib_path / sizeof *instance->lib_path };
+
+    int i = 0;
+
+    if (count > MAX_COUNT)
+        MVM_panic(1, "Cannot set more than %i library paths", MAX_COUNT);
+
+    for (; i < count; ++i)
+        instance->lib_path[i] = lib_path[i];
+
+    /* Clear remainder to allow repeated calls */
+    for (; i < MAX_COUNT; ++i)
+        instance->lib_path[i] = NULL;
+}

--- a/src/moar.h
+++ b/src/moar.h
@@ -173,6 +173,10 @@ MVM_PUBLIC void MVM_vm_run_file(MVMInstance *instance, const char *filename);
 MVM_PUBLIC void MVM_vm_dump_file(MVMInstance *instance, const char *filename);
 MVM_PUBLIC void MVM_vm_exit(MVMInstance *instance);
 MVM_PUBLIC void MVM_vm_destroy_instance(MVMInstance *instance);
+MVM_PUBLIC void MVM_vm_set_clargs(MVMInstance *instance, int argc, char **argv);
+MVM_PUBLIC void MVM_vm_set_exec_name(MVMInstance *instance, const char *exec_name);
+MVM_PUBLIC void MVM_vm_set_prog_name(MVMInstance *instance, const char *prog_name);
+MVM_PUBLIC void MVM_vm_set_lib_path(MVMInstance *instance, int count, const char **lib_path);
 
 /* Returns original. Use only on AO_t-sized values (including pointers). */
 #define MVM_incr(addr) AO_fetch_and_add1_full((volatile AO_t *)(addr))


### PR DESCRIPTION
Adds the functions

    void MVM_vm_set_clargs(MVMInstance *instance, int argc, char **argv);
    void MVM_vm_set_exec_name(MVMInstance *instance, const char *exec_name);
    void MVM_vm_set_prog_name(MVMInstance *instance, const char *prog_name);
    void MVM_vm_set_lib_path(MVMInstance *instance, int count, const char **lib_path);
