### PR TITLE
Use CPPFLAGS is @cflags instead of @ldflags

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -306,6 +306,7 @@ push @cflags, $config{ccdefflags};
 push @cflags, $config{ccshared}     unless $args{static};
 push @cflags, '-fno-omit-frame-pointer -fsanitize=address' if $args{asan};
 push @cflags, $ENV{CFLAGS} if $ENV{CFLAGS};
+push @cflags, $ENV{CPPFLAGS} if $ENV{CPPFLAGS};
 $config{cflags} = join ' ', @cflags;
 
 # generate LDFLAGS
@@ -316,7 +317,6 @@ push @ldflags, $config{ldinstflags}       if $args{instrument};
 push @ldflags, $config{ldrpath}           unless $args{static};
 push @ldflags, $^O eq 'darwin' ? '-faddress-sanitizer' : '-fsanitize=address' if $args{asan};
 push @ldflags, $ENV{LDFLAGS}  if $ENV{LDFLAGS};
-push @ldflags, $ENV{CPPFLAGS} if $ENV{CPPFLAGS};
 $config{ldflags} = join ' ', @ldflags;
 
 # setup library names


### PR DESCRIPTION
The `CPPFLAGS` is for the C pre-processor, not for the linker.