### PR TITLE
Test “--no-jit” instead of “--enable-jit”

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ notifications:
 
 env:
   matrix:
-    - MVM_OPTIONS="--enable-jit"  CC="gcc"
     - MVM_OPTIONS=""              CC="gcc"
-    - MVM_OPTIONS="--enable-jit"  CC="clang"
+    - MVM_OPTIONS="--no-jit"      CC="gcc"
     - MVM_OPTIONS=""              CC="clang"
+    - MVM_OPTIONS="--no-jit"      CC="clang"


### PR DESCRIPTION
From Configure.pl:

    The --enable-jit flag is obsolete, as jit is enabled by default.
    You can use --no-jit to build without jit