### PR TITLE
better armv6 and v7 detection

### DIFF
--- a/build/probe.pm
+++ b/build/probe.pm
@@ -237,7 +237,7 @@ sub unaligned_access {
             if ($arch =~ /^(?:x86_64|amd64|i[0-9]86)$/) {
                 # Don't know alignment constraints for ARMv8
                 _gen_unaligned_access($config, 'all');
-            } elsif ($arch =~ /^armv(?:6|7)/) {
+            } elsif ($arch =~ /armv(?:6|7)/) {
                 _gen_unaligned_access($config, 'int32');
             } else {
                 # ARMv5 and earlier do "interesting" things on unaligned 32 bit


### PR DESCRIPTION
A Linux kernel reports an $arch of `armv7` when a NetBSD kernel on the same machine reports the appropriate $arch as `earmv7hf`
http://testers.p6c.org/reports/32564.html