### PR TITLE
fix for ARMv5

### DIFF
--- a/src/moar.h
+++ b/src/moar.h
@@ -21,6 +21,7 @@
 #include <uv.h>
 
 /* libatomic_ops */
+#define AO_REQUIRE_CAS
 #include <atomic_ops.h>
 
 /* dynload/dyncall/dyncallback */


### PR DESCRIPTION
When cross compiling for ARMv6, all works fine with `libatomic_ops`.

For ARMv5, the linking fails with :
```
linking moar
arm-none-linux-gnueabi-gcc -o moar -O2 -DNDEBUG -Wl,-rpath,/usr/lib src/main.o -L. -lmoar
./libmoar.so: undefined reference to `AO_compare_and_swap_full'
./libmoar.so: undefined reference to `AO_fetch_compare_and_swap_full'
./libmoar.so: undefined reference to `AO_fetch_and_sub1_full'
./libmoar.so: undefined reference to `AO_fetch_and_add1_full'
./libmoar.so: undefined reference to `AO_fetch_and_add_full'
collect2: error: ld returned 1 exit status
```

With the architecture ARMv5, the Compare-And-Swap has not a hardware support, it must be emulated.
The `#define AO_REQUIRE_CAS` allows to use the emulation as fallback (see [README.txt](https://github.com/MoarVM/MoarVM/blob/master/3rdparty/libatomic_ops/doc/README.txt)).