### PR TITLE
Fix parens warning on OSX

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -109,7 +109,7 @@ static MVMint16 get_calling_convention(MVMThreadContext *tc, MVMString *name) {
 
 /* Map argument type ID to dyncall character ID. */
 static char get_signature_char(MVMint16 type_id) {
-    if (type_id & MVM_NATIVECALL_ARG_RW_MASK == MVM_NATIVECALL_ARG_RW)
+    if ( (type_id & MVM_NATIVECALL_ARG_RW_MASK) == MVM_NATIVECALL_ARG_RW)
         return 'p';
 
     switch (type_id & MVM_NATIVECALL_ARG_TYPE_MASK) {


### PR DESCRIPTION
Get a warning on OSX the == will be evaluated before the &

src/core/nativecall.c:112:17: warning: & has lower precedence than ==; == will be evaluated first [-Wparentheses]
    if (type_id & MVM_NATIVECALL_ARG_RW_MASK == MVM_NATIVECALL_ARG_RW)
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/nativecall.c:112:17: note: place parentheses around the '==' expression to silence this warning
    if (type_id & MVM_NATIVECALL_ARG_RW_MASK == MVM_NATIVECALL_ARG_RW)
                ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/nativecall.c:112:17: note: place parentheses around the & expression to evaluate it first
    if (type_id & MVM_NATIVECALL_ARG_RW_MASK == MVM_NATIVECALL_ARG_RW)
        ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.