### PR TITLE
refactor pthread_yield detection

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -362,6 +362,7 @@ else {
 }
 
 build::probe::computed_goto(\%config, \%defaults);
+build::probe::pthread_yield(\%config, \%defaults);
 
 my $order = $config{be} ? 'big endian' : 'little endian';
 

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -33,6 +33,11 @@
 #define MVM_HAS_READLINE @hasreadline@
 #endif
 
+/* pthread_yield() detection */
+#if @has_pthread_yield@
+#define MVM_HAS_PTHREAD_YIELD @has_pthread_yield@
+#endif
+
 /* How this compiler does static inline functions. */
 #define MVM_STATIC_INLINE @static_inline@
 

--- a/build/probe.pm
+++ b/build/probe.pm
@@ -57,7 +57,7 @@ sub compile {
         push @objs, $obj;
     }
 
-    my $command = "$config->{ld} $config->{ldout}$leaf @objs  >$devnull 2>&1";
+    my $command = "$config->{ld} $config->{ldout}$leaf @objs $config->{ldlibs} >$devnull 2>&1";
     system $command
         and return;
     return 1;
@@ -317,6 +317,25 @@ EOT
     }
     print $can_cgoto ? "YES\n": "NO\n";
     $config->{cancgoto} = $can_cgoto || 0
+}
+
+sub pthread_yield {
+    my ($config) = @_;
+    my $restore = _to_probe_dir();
+    _spew('try.c', <<'EOT');
+#include <stdlib.h>
+#include <pthread.h>
+
+int main(int argc, char **argv) {
+    pthread_yield();
+    return EXIT_SUCCESS;
+}
+EOT
+
+    print ::dots('    probing pthread_yield support');
+    my $has_pthread_yield = compile($config, 'try');
+    print $has_pthread_yield ? "YES\n": "NO\n";
+    $config->{has_pthread_yield} = $has_pthread_yield || 0
 }
 
 '00';

--- a/src/platform/threads.h
+++ b/src/platform/threads.h
@@ -1,10 +1,11 @@
 #if defined _WIN32
 #define MVM_platform_thread_yield SwitchToThread
-#elif defined(__APPLE__) || defined(__sun) || defined(__NetBSD__) || defined(_POSIX_PRIORITY_SCHEDULING)
+#elif defined MVM_HAS_PTHREAD_YIELD
+#include <pthread.h>
+#define MVM_platform_thread_yield pthread_yield
+#else
 #include <sched.h>
 #define MVM_platform_thread_yield sched_yield
-#else
-#define MVM_platform_thread_yield pthread_yield
 #endif
 
 #if defined _WIN32


### PR DESCRIPTION
the current detection is fragile.
for example, with the musl libc on linux, it fails.

the detection must be done during the configure step.