### PR TITLE
Free allocated variable before returning

### DIFF
--- a/src/6model/reprs/MVMCode.c
+++ b/src/6model/reprs/MVMCode.c
@@ -157,6 +157,7 @@ MVM_PUBLIC MVMObject * MVM_code_location(MVMThreadContext *tc, MVMObject *code) 
         } else {
             filename = cu->body.filename;
         }
+        MVM_free(ann);
 
         filename_boxed = MVM_repr_box_str(tc, tc->instance->boot_types.BOOTStr, filename);
 


### PR DESCRIPTION
Coverity scan pointed out that the variable `ann` wasn't being freed before
the function MVM_code_location() returned.  This should fix this issue.  The
NQP tests all pass after having made this change (there aren't any MoarVM
tests), so it seems that everything still works as expected.

The full output from Coverity is as follows:

    *** CID 56061:  Resource leaks  (RESOURCE_LEAK)
    /src/6model/reprs/MVMCode.c: 170 in MVM_code_location()
    164     
    165             linenumber_boxed = MVM_repr_box_int(tc, tc->instance->boot_types.BOOTInt, line_nr);
    166             MVM_repr_bind_key_o(tc, result, linenumber_key, linenumber_boxed);
    167     
    168             MVM_gc_root_temp_pop_n(tc, 3);
    169     
    
                CID 56061: Resource leaks (RESOURCE_LEAK) Variable "ann" going out of scope leaks the storage it points to. 
    
    170             return result;
    171         }
    172     
    173         return NULL;