### PR TITLE
Initialise unset fields in MVMStorageSpec

### DIFF
--- a/src/6model/reprs/MVMContext.c
+++ b/src/6model/reprs/MVMContext.c
@@ -115,6 +115,10 @@ static MVMStorageSpec get_value_storage_spec(MVMThreadContext *tc, MVMSTable *st
     spec.inlineable      = MVM_STORAGE_SPEC_REFERENCE;
     spec.boxed_primitive = MVM_STORAGE_SPEC_BP_NONE;
     spec.can_box         = 0;
+    spec.bits            = 0;
+    spec.align           = 0;
+    spec.is_unsigned     = 0;
+
     return spec;
 }
 

--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -135,6 +135,9 @@ static MVMStorageSpec get_value_storage_spec(MVMThreadContext *tc, MVMSTable *st
     spec.inlineable      = MVM_STORAGE_SPEC_REFERENCE;
     spec.boxed_primitive = MVM_STORAGE_SPEC_BP_NONE;
     spec.can_box         = 0;
+    spec.bits            = 0;
+    spec.align           = 0;
+    spec.is_unsigned     = 0;
     return spec;
 }
 

--- a/src/6model/reprs/MVMIter.c
+++ b/src/6model/reprs/MVMIter.c
@@ -135,6 +135,9 @@ static MVMStorageSpec get_elem_storage_spec(MVMThreadContext *tc, MVMSTable *st)
     spec.inlineable      = MVM_STORAGE_SPEC_REFERENCE;
     spec.boxed_primitive = MVM_STORAGE_SPEC_BP_NONE;
     spec.can_box         = 0;
+    spec.bits            = 0;
+    spec.align           = 0;
+    spec.is_unsigned     = 0;
     return spec;
 }
 


### PR DESCRIPTION
These fields were uninitialised and thus flagged as a potential problem by
Coverity Scan.  The nqp tests pass and these changes seem correct in this situation,
however a code review would be a good idea to be on the safe side.