### PR TITLE
Change Travis matrix option to --no-jit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ notifications:
 
 env:
   matrix:
-    - MVM_OPTIONS="--enable-jit"  CC="gcc"
-    - MVM_OPTIONS=""              CC="gcc"
-    - MVM_OPTIONS="--enable-jit"  CC="clang"
-    - MVM_OPTIONS=""              CC="clang"
+    - MVM_OPTIONS="--no-jit"  CC="gcc"
+    - MVM_OPTIONS=""          CC="gcc"
+    - MVM_OPTIONS="--no-jit"  CC="clang"
+    - MVM_OPTIONS=""          CC="clang"


### PR DESCRIPTION
This is because JIT is on by default, thus only the JIT was being tested in
all configurations.  It was also throwing the warning that --enable-jit was
obsolete and mentioning the --no-jit option, which would make sense so as to
test with and without JIT.