### PR TITLE
Windows 1252 support

### DIFF
--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -83,6 +83,9 @@ static void run_decode(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint32 *stop
     case MVM_encoding_type_latin1:
         MVM_string_latin1_decodestream(tc, ds, stopper_chars, stopper_sep);
         break;
+    case MVM_encoding_type_windows1252:
+        MVM_string_windows1252_decodestream(tc, ds, stopper_chars, stopper_sep);
+        break;
     default:
         MVM_exception_throw_adhoc(tc, "Streaming decode NYI for encoding %d",
             (int)ds->encoding);

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1517,6 +1517,9 @@ MVMuint8 MVM_string_find_encoding(MVMThreadContext *tc, MVMString *name) {
     else if (MVM_string_equal(tc, name, encoding_latin1_name)) {
         return MVM_encoding_type_latin1;
     }
+    else if (MVM_string_equal(tc, name, encoding_windows1252_name)) {
+        return MVM_encoding_type_windows1252;
+    }
     else if (MVM_string_equal(tc, name, encoding_utf16_name)) {
         return MVM_encoding_type_utf16;
     }

--- a/src/strings/windows1252.c
+++ b/src/strings/windows1252.c
@@ -127,6 +127,65 @@ static MVMuint8 windows1252_cp_to_char(MVMint32 codepoint) {
 
 }
 
+/* Decodes using a decodestream. Decodes as far as it can with the input
+ * buffers, or until a stopper is reached. */
+void MVM_string_windows1252_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds,
+                                    MVMint32 *stopper_chars, MVMint32 *stopper_sep) {
+    MVMint32 count = 0, total = 0;
+    MVMint32 bufsize;
+    MVMGrapheme32 *buffer;
+    MVMDecodeStreamBytes *cur_bytes;
+    MVMDecodeStreamBytes *last_accept_bytes = ds->bytes_head;
+    MVMint32 last_accept_pos;
+
+    /* If there's no buffers, we're done. */
+    if (!ds->bytes_head)
+        return;
+    last_accept_pos = ds->bytes_head_pos;
+
+    /* If we're asked for zero chars, also done. */
+    if (stopper_chars && *stopper_chars == 0)
+        return;
+
+    /* Take length of head buffer as initial guess. */
+    bufsize = ds->bytes_head->length;
+    buffer = MVM_malloc(bufsize * sizeof(MVMGrapheme32));
+
+    /* Decode each of the buffers. */
+    cur_bytes = ds->bytes_head;
+    while (cur_bytes) {
+        /* Process this buffer. */
+        MVMint32  pos = cur_bytes == ds->bytes_head ? ds->bytes_head_pos : 0;
+        unsigned char *bytes = (unsigned char *)cur_bytes->bytes;
+        while (pos < cur_bytes->length) {
+            MVMCodepoint codepoint = WINDOWS1252_CHAR_TO_CP(bytes[pos++]);
+            if (count == bufsize) {
+                /* We filled the buffer. Attach this one to the buffers
+                 * linked list, and continue with a new one. */
+                MVM_string_decodestream_add_chars(tc, ds, buffer, bufsize);
+                buffer = MVM_malloc(bufsize * sizeof(MVMGrapheme32));
+                count = 0;
+            }
+            buffer[count++] = codepoint; /* XXX NFG needs this to change. */
+            last_accept_bytes = cur_bytes;
+            last_accept_pos = pos;
+            total++;
+            if (stopper_chars && *stopper_chars == total)
+                goto done;
+            if (stopper_sep && *stopper_sep == codepoint)
+                goto done;
+        }
+        cur_bytes = cur_bytes->next;
+    }
+  done:
+
+    /* Attach what we successfully parsed as a result buffer, and trim away
+     * what we chewed through. */
+    if (count)
+        MVM_string_decodestream_add_chars(tc, ds, buffer, count);
+    MVM_string_decodestream_discard_to(tc, ds, last_accept_bytes, last_accept_pos);
+}
+
 /* Decodes the specified number of bytes of windows1252 into an NFG string,
  * creating a result of the specified type. The type must have the MVMString
  * REPR. */

--- a/src/strings/windows1252.h
+++ b/src/strings/windows1252.h
@@ -1,2 +1,3 @@
 MVMString * MVM_string_windows1252_decode(MVMThreadContext *tc, MVMObject *result_type, char *windows1252, size_t bytes);
+MVM_PUBLIC void MVM_string_windows1252_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint32 *stopper_chars, MVMint32 *stopper_sep);
 char * MVM_string_windows1252_encode_substr(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length);


### PR DESCRIPTION
This updates the windows-1252 code that was left in MoarVM for later use, and hooks it in.

windows-1252 codepage support is important for HTML apps and standardized for HTML5 now.