### PR TITLE
Destroy correct string decodestream

### DIFF
--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -937,7 +937,7 @@ static void spawn_gc_free(MVMThreadContext *tc, MVMObject *t, void *data) {
             si->ds_stdout = NULL;
         }
         if (si->ds_stderr) {
-            MVM_string_decodestream_destory(tc, si->ds_stdout);
+            MVM_string_decodestream_destory(tc, si->ds_stderr);
             si->ds_stderr = NULL;
         }
         MVM_free(si);


### PR DESCRIPTION
In spawn_gc_free() a branch which looks like it is supposed to destroy the
stderr stream was actually destroying the stdout stream (which was happening
in another code path) and thus is possibly a copy-paste error.

Please review.  As usual, comments are most welcome.