### PR TITLE
Initialise variables which could be used without first being set

### DIFF
--- a/src/6model/reprs/MVMArray.c
+++ b/src/6model/reprs/MVMArray.c
@@ -879,6 +879,14 @@ static void asplice(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *
 static MVMStorageSpec get_elem_storage_spec(MVMThreadContext *tc, MVMSTable *st) {
     MVMArrayREPRData *repr_data = (MVMArrayREPRData *)st->REPR_data;
     MVMStorageSpec spec;
+    /* initialise storage spec to default values */
+    spec.inlineable      = MVM_STORAGE_SPEC_REFERENCE;
+    spec.bits            = 0;
+    spec.align           = 0;
+    spec.boxed_primitive = MVM_STORAGE_SPEC_BP_NONE;
+    spec.can_box         = 0;
+    spec.is_unsigned     = 0;
+
     switch (repr_data->slot_type) {
         case MVM_ARRAY_STR:
             spec.inlineable      = MVM_STORAGE_SPEC_INLINED;

--- a/src/core/bytecodedump.c
+++ b/src/core/bytecodedump.c
@@ -176,7 +176,7 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
     MVMuint32 lineloc;
     MVMuint16 op_num;
     const MVMOpInfo *op_info;
-    MVMuint32 operand_size;
+    MVMuint32 operand_size = 0;
     unsigned char op_rw;
     unsigned char op_type;
     unsigned char op_flags;

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -27,7 +27,7 @@ static void boolify_return(MVMThreadContext *tc, void *sr_data);
 static void flip_return(MVMThreadContext *tc, void *sr_data);
 void MVM_coerce_istrue(MVMThreadContext *tc, MVMObject *obj, MVMRegister *res_reg,
         MVMuint8 *true_addr, MVMuint8 *false_addr, MVMuint8 flip) {
-    MVMint64 result;
+    MVMint64 result = 0;
     if (MVM_is_null(tc, obj)) {
         result = 0;
     }


### PR DESCRIPTION
These changes initialise variables which could theoretically be used without first being set.  Please review in order to check that the initialised values used are appropriate and correct.  Comments are most welcome.