### PR TITLE
support opening files in modes besides r, w, wa

### DIFF
--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -16,6 +16,7 @@
 #define O_WRONLY _O_WRONLY
 #define O_TRUNC  _O_TRUNC
 #define O_EXCL   _O_EXCL
+#define O_RDWR   _O_RDWR
 #define DEFAULT_MODE _S_IWRITE /* work around sucky libuv defaults */
 #endif
 


### PR DESCRIPTION
Mode strings now take the form

    [rw+-][ctax]*

where

    r O_RDONLY
    - O_WRONLY
    + O_RDWR 
    c O_CREAT
    t O_TRUNC
    a O_APPEND
    x O_EXCL

`w` is a special value to stay backwards compatible: By itself, it is an alias for `-ct`. As part of a string (like `wa`), it's an alias for `-c`.