### PR TITLE
Fix a few items found by warnings

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2144,7 +2144,7 @@ static void deserialize_closure(MVMThreadContext *tc, MVMSerializationReader *re
 
 /* Reads in what we need to lazily deserialize ->HOW later. */
 static void deserialize_how_lazy(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
-    MVMSerializationContext *sc = read_locate_sc_and_index(tc, reader, &st->HOW_idx);
+    MVMSerializationContext *sc = read_locate_sc_and_index(tc, reader, (MVMint32*)&st->HOW_idx);
 
     MVM_ASSIGN_REF(tc, &(st->header), st->HOW_sc, sc);
 }

--- a/src/core/fixedsizealloc.c
+++ b/src/core/fixedsizealloc.c
@@ -205,7 +205,6 @@ void MVM_fixed_size_free_at_safepoint(MVMThreadContext *tc, MVMFixedSizeAlloc *a
         /* Came from a bin; put into free list. */
         MVMFixedSizeAllocSizeClass     *bin_ptr = &(al->size_classes[bin]);
         MVMFixedSizeAllocFreeListEntry *to_add  = (MVMFixedSizeAllocFreeListEntry *)to_free;
-        MVMFixedSizeAllocFreeListEntry *orig;
         if (MVM_instance_have_user_threads(tc)) {
             /* Multi-threaded; race to add it to the "free at next safe point"
              * list. */

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -68,7 +68,6 @@ MVMFrame * MVM_frame_dec_ref(MVMThreadContext *tc, MVMFrame *frame) {
     /* MVM_dec returns what the count was before it decremented it
      * to zero, so we look for 1 here. */
     while (MVM_decr(&frame->ref_count) == 1) {
-        MVMuint32 pool_index = frame->static_info->body.pool_index;
         MVMFrame *outer_to_decr = frame->outer;
 
         /* If there's a caller pointer, decrement that. */
@@ -194,7 +193,6 @@ static MVMFrame * autoclose(MVMThreadContext *tc, MVMStaticFrame *needed) {
 static MVMFrame * allocate_frame(MVMThreadContext *tc, MVMStaticFrameBody *static_frame_body,
                                  MVMSpeshCandidate *spesh_cand) {
     MVMFrame *frame = NULL;
-    MVMFrame *node;
     MVMint32  env_size, work_size;
 
     /* Allocate the frame. */

--- a/src/core/validation.c
+++ b/src/core/validation.c
@@ -240,7 +240,7 @@ static void validate_literal_operand(Validator *val, MVMuint32 flags) {
             MVMuint32 index = GET_UI32(val->cur_op, 0);
             MVMuint32 count = val->cu->body.orig_strings;
             if (index >= count)
-                fail(val, MSG(val, "string index %" PRIu16
+                fail(val, MSG(val, "string index %" PRIu32
                         " out of range 0..%" PRIu32), index, count - 1);
             break;
         }
@@ -315,7 +315,7 @@ static void validate_lex_operand(Validator *val, MVMuint32 flags) {
     lex_count = frame->body.num_lexicals;
     if (lex_index >= lex_count)
         fail(val, MSG(val, "lexical operand index %" PRIu16
-                " out of range 0.. %" PRIu16), lex_index, lex_count - 1);
+                " out of range 0.. %" PRIu32), lex_index, lex_count - 1);
 
     val->cur_op += 4;
 }
@@ -447,7 +447,7 @@ static void validate_arg(Validator *val) {
 
         if (index >= count)
             fail (val, MSG(val, "argument index %" PRIu16
-                    " not in range 0..%" PRIu16), index, count - 1);
+                    " not in range 0..%" PRIu32), index, count - 1);
 
         flags = val->cur_call->arg_flags[index];
 

--- a/src/strings/nfg.c
+++ b/src/strings/nfg.c
@@ -153,7 +153,6 @@ static MVMGrapheme32 add_synthetic(MVMThreadContext *tc, MVMCodepoint *codes, MV
     /* Grow the synthetics table if needed. */
     if (nfg->num_synthetics % MVM_SYNTHETIC_GROW_ELEMS == 0) {
         size_t orig_size = nfg->num_synthetics * sizeof(MVMNFGSynthetic);
-        size_t new_size  = nfg->num_synthetics * sizeof(MVMNFGSynthetic);
         MVMNFGSynthetic *new_synthetics = MVM_fixed_size_alloc(tc, tc->instance->fsa,
             (nfg->num_synthetics + MVM_SYNTHETIC_GROW_ELEMS) * sizeof(MVMNFGSynthetic));
         if (orig_size) {

--- a/src/strings/normalize.c
+++ b/src/strings/normalize.c
@@ -72,7 +72,7 @@ void MVM_unicode_normalize_codepoints(MVMThreadContext *tc, MVMObject *in, MVMOb
     MVM_unicode_normalizer_cleanup(tc, &norm);
 
     /* Put result into array body. */
-    ((MVMArray *)out)->body.slots.u32 = result;
+    ((MVMArray *)out)->body.slots.u32 = (MVMuint32 *)result;
     ((MVMArray *)out)->body.start     = 0;
     ((MVMArray *)out)->body.elems     = result_pos;
 }
@@ -178,7 +178,7 @@ void MVM_unicode_string_to_codepoints(MVMThreadContext *tc, MVMString *s, MVMNor
     }
 
     /* Put result into array body. */
-    ((MVMArray *)out)->body.slots.u32 = result;
+    ((MVMArray *)out)->body.slots.u32 = (MVMuint32 *)result;
     ((MVMArray *)out)->body.start     = 0;
     ((MVMArray *)out)->body.elems     = result_pos;
 }

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -23,7 +23,7 @@ static void check_strand_sanity(MVMThreadContext *tc, MVMString *s) {
 #endif
 
 /* Checks a string is not null or non-concrete and throws if so. */
-MVM_STATIC_INLINE MVM_string_check_arg(MVMThreadContext *tc, MVMString *s, const char *operation) {
+MVM_STATIC_INLINE void MVM_string_check_arg(MVMThreadContext *tc, MVMString *s, const char *operation) {
     if (!s || !IS_CONCRETE(s))
         MVM_exception_throw_adhoc(tc, "%s requires a concrete string, but got %s",
             operation, s ? "a type object" : "null");

--- a/src/strings/unicode_db.c
+++ b/src/strings/unicode_db.c
@@ -44230,7 +44230,6 @@ static const char* MVM_unicode_get_property_str(MVMThreadContext *tc, MVMint32 c
 
 static MVMint32 MVM_unicode_get_property_int(MVMThreadContext *tc, MVMint32 codepoint, MVMint64 property_code) {
     MVMuint32 switch_val = (MVMuint32)property_code;
-    MVMint32 result_val = 0; /* we'll never have negatives, but so */
     MVMuint32 codepoint_row = MVM_codepoint_to_row_index(tc, codepoint);
     MVMuint16 bitfield_row;
 

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -36,6 +36,9 @@ MVMString * MVM_unicode_get_name(MVMThreadContext *tc, MVMint64 codepoint) {
                     name = "<reserved>";
             }
         }
+        else {
+            name = "<illegal>";
+        }
     }
 
     return MVM_string_ascii_decode(tc, tc->instance->VMString, name, strlen(name));

--- a/tools/ucd2c.pl
+++ b/tools/ucd2c.pl
@@ -686,7 +686,6 @@ sub emit_property_value_lookup {
     my $out = "
 static MVMint32 MVM_unicode_get_property_int(MVMThreadContext *tc, MVMint32 codepoint, MVMint64 property_code) {
     MVMuint32 switch_val = (MVMuint32)property_code;
-    MVMint32 result_val = 0; /* we'll never have negatives, but so */
     MVMuint32 codepoint_row = MVM_codepoint_to_row_index(tc, codepoint);
     MVMuint16 bitfield_row;
 


### PR DESCRIPTION
  * Make some casts explicit
  * Fixup printf formats
  * Remove unused code
  * In MVM_unicode_get_name ensure name is always initialized before use

Note - we can't just turn on -Werror -Wall because of the following:

In src/core/interp.c clang thinks the label "runloop" is unused.  It is
referenced but only inside of a macro.  This is probably a bug in clang.

In the generated file src/strings/unicode.c both CaseFolding_grows_table
and CaseFolding_simple_table are reported as unused.  Do we need these?

When compiling src/jit/emit_posix_x64.c clang complains that the
function emit_win64_callargs in src/jit/emit_x64.dasc is unused.  Since
I'm compiling on MacOS X that makes sense.