### PR TITLE
Avoid leak of C strings in MVM_exception_throw_adhoc

### DIFF
--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -708,13 +708,30 @@ MVM_NO_RETURN
 void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) {
     va_list args;
     va_start(args, messageFormat);
-    MVM_exception_throw_adhoc_va(tc, messageFormat, args);
+    MVM_exception_throw_adhoc_free_va(tc, NULL, messageFormat, args);
     va_end(args);
 }
 
 /* Throws an ad-hoc (untyped) exception. */
 MVM_NO_RETURN
 void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) {
+    MVM_exception_throw_adhoc_free_va(tc, NULL, messageFormat, args);
+}
+
+/* Throws an ad-hoc (untyped) exception, taking a NULL-terminated array of
+ * char pointers to deallocate after message construction. */
+MVM_NO_RETURN
+void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) {
+    va_list args;
+    va_start(args, messageFormat);
+    MVM_exception_throw_adhoc_free_va(tc, waste, messageFormat, args);
+    va_end(args);
+}
+
+/* Throws an ad-hoc (untyped) exception, taking a NULL-terminated array of
+ * char pointers to deallocate after message construction. */
+MVM_NO_RETURN
+void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) {
     LocatedHandler lh;
 
     /* Create and set up an exception object. */
@@ -724,6 +741,13 @@ void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageForma
         int        bytes     = vsnprintf(c_message, 1024, messageFormat, args);
         MVMString *message   = MVM_string_utf8_decode(tc, tc->instance->VMString, c_message, bytes);
         MVM_free(c_message);
+
+        /* Clean up after ourselves to avoid leaking C strings. */
+        if (waste) {
+            while(*waste)
+                MVM_free(*waste++);
+        }
+
         MVM_ASSIGN_REF(tc, &(ex->common.header), ex->body.message, message);
         if (tc->cur_frame) {
             ex->body.origin = MVM_frame_inc_ref(tc, tc->cur_frame);

--- a/src/core/exceptions.h
+++ b/src/core/exceptions.h
@@ -81,6 +81,8 @@ MVM_PUBLIC MVM_NO_RETURN void MVM_panic(MVMint32 exitCode, const char *messageFo
 MVM_PUBLIC MVM_NO_RETURN void MVM_oops(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_GCC MVM_FORMAT(printf, 2, 3);
 MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_GCC MVM_FORMAT(printf, 2, 3);
 MVM_NO_RETURN void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) MVM_NO_RETURN_GCC;
+MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) MVM_NO_RETURN_GCC MVM_FORMAT(printf, 3, 4);
+MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) MVM_NO_RETURN_GCC;
 MVM_PUBLIC void MVM_crash_on_error(void);
 char * MVM_exception_backtrace_line(MVMThreadContext *tc, MVMFrame *cur_frame, MVMuint16 not_top);
 


### PR DESCRIPTION
Adds functions

    void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...);
    void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args);

that take a null-terminated list of `char` pointers to deallocate after message construction.

Feel free to come up with a better name. Also note that this means there are now 886 occurrences of the term `throw_adhoc` in `src/` pending review...