### PR TITLE
Add $(LDFLAGS) to minilua build command

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -521,7 +521,7 @@ src/strings/unicode.c: src/strings/unicode_db.c src/strings/unicode_ops.c
 	$(CMD)$(CAT) src/strings/unicode_db.c src/strings/unicode_ops.c > $@ $(NOERR)
 
 3rdparty/dynasm/minilua@exe@: 3rdparty/dynasm/minilua.c
-	$(CC) $(CFLAGS) 3rdparty/dynasm/minilua.c -o $@ $(LDLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) 3rdparty/dynasm/minilua.c -o $@ $(LDLIBS)
 
 src/jit/emit_posix_x64.c: $(LUA) src/jit/emit_x64.dasc
 	$(DYNASM) $(DASM_FLAGS_POSIX) -o $@ src/jit/emit_x64.dasc


### PR DESCRIPTION
The minilua is only used during build time but the Debian blhc reports
the hardening flags as missing.

* build/Makefile.in (3rdparty/dynasm/minilua@exe@): Add $(LDFLAGS) to
  silent Debian blhc.