### PR TITLE
mk-moar-pc.in: replace autodie with a plain die

### DIFF
--- a/build/mk-moar-pc.in
+++ b/build/mk-moar-pc.in
@@ -5,10 +5,9 @@
 ##  Copyright © 2014 Daniel Dehennin <daniel.dehennin@baby-gnu.org>
 ##
 ##
-use 5.010_001;
+use 5.010;
 use strict;
 use warnings;
-use autodie;
 
 use File::Basename;
 use File::Path qw{make_path};
@@ -51,7 +50,8 @@ if ( ! -d $dirname ) {
     make_path($dirname);
 }
 
-open my $pcfile, '>', "$args[0]";
+open my $pcfile, '>', "$args[0]"
+  or die "Can not open > $pcfile: $!";
 
 print $pcfile <<EOF;
 # pkg-config information for MoarVM ${version}


### PR DESCRIPTION
There is only one open in the file, no need to enforce different perl
version dependency than Configure.pl.

RT #125771