### PR TITLE
Add support for parsing Unicode numbers

### DIFF
--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -358,9 +358,19 @@ MVMObject * MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMi
     }
 
     while (offset < chars) {
-        if (ch >= '0' && ch <= '9') ch = ch - '0';
+        // as of Unicode 6.0.0, we can be assured that Nd numerals are within
+        // 0..9
+        MVMint64 gcNd = MVM_unicode_name_to_property_value_code(tc, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "Nd"));
+        if (MVM_unicode_codepoint_has_property_value(tc, ch, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, gcNd)) {
+            // the string returned for NUMERIC_VALUE contains a floating point
+            // value, so atoi will stop on the . in the string. This is fine
+            // though, since we'd have to truncate the float regardless.
+            ch = atoi(MVM_unicode_codepoint_get_property_cstr(tc, ch, MVM_UNICODE_PROPERTY_NUMERIC_VALUE));
+        }
         else if (ch >= 'a' && ch <= 'z') ch = ch - 'a' + 10;
         else if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 10;
+        else if (ch >= 0xFF21 && ch <= 0xFF3A) ch = ch - 0xFF21 + 10; // uppercase fullwidth
+        else if (ch >= 0xFF41 && ch <= 0xFF5A) ch = ch - 0xFF41 + 10; // lowercase fullwidth
         else break;
         if (ch >= radix) break;
         zvalue = zvalue * radix + ch;

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -358,19 +358,22 @@ MVMObject * MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMi
     }
 
     while (offset < chars) {
-        // as of Unicode 6.0.0, we can be assured that Nd numerals are within
-        // 0..9
-        MVMint64 gcNd = MVM_unicode_name_to_property_value_code(tc, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "Nd"));
-        if (MVM_unicode_codepoint_has_property_value(tc, ch, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, gcNd)) {
+        if (ch >= '0' && ch <= '9') ch = ch - '0'; // fast-path for ASCII 0..9
+        else if (ch >= 'a' && ch <= 'z') ch = ch - 'a' + 10;
+        else if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 10;
+        else if (ch >= 0xFF21 && ch <= 0xFF3A) ch = ch - 0xFF21 + 10; // uppercase fullwidth
+        else if (ch >= 0xFF41 && ch <= 0xFF5A) ch = ch - 0xFF41 + 10; // lowercase fullwidth
+        else if (MVM_unicode_codepoint_has_property_value(tc, ch, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY,
+                                                          MVM_unicode_name_to_property_value_code(tc, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY,
+                                                                                                  MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "Nd")))) {
+            // As of Unicode 6.0.0, we know that Nd category numerals are within
+            // the range 0..9
+
             // the string returned for NUMERIC_VALUE contains a floating point
             // value, so atoi will stop on the . in the string. This is fine
             // though, since we'd have to truncate the float regardless.
             ch = atoi(MVM_unicode_codepoint_get_property_cstr(tc, ch, MVM_UNICODE_PROPERTY_NUMERIC_VALUE));
         }
-        else if (ch >= 'a' && ch <= 'z') ch = ch - 'a' + 10;
-        else if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 10;
-        else if (ch >= 0xFF21 && ch <= 0xFF3A) ch = ch - 0xFF21 + 10; // uppercase fullwidth
-        else if (ch >= 0xFF41 && ch <= 0xFF5A) ch = ch - 0xFF41 + 10; // lowercase fullwidth
         else break;
         if (ch >= radix) break;
         zvalue = zvalue * radix + ch;

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -945,17 +945,20 @@ MVMObject * MVM_bigint_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *st
         // as of Unicode 6.0.0, characters with the 'de' Numeric Type (and are
         // thus also of General Category Nd, since 4.0.0) are contiguous
         // sequences of 10 chars whose Numeric Values ascend from 0 through 9.
-        MVMint64 gcNd = MVM_unicode_name_to_property_value_code(tc, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "Nd"));
-        if (MVM_unicode_codepoint_has_property_value(tc, ch, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, gcNd)) {
+
+        if (ch >= '0' && ch <= '9') ch = ch - '0'; // fast-path for ASCII 0..9
+        else if (ch >= 'a' && ch <= 'z') ch = ch - 'a' + 10;
+        else if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 10;
+        else if (ch >= 0xFF21 && ch <= 0xFF3A) ch = ch - 0xFF21 + 10; // uppercase fullwidth
+        else if (ch >= 0xFF41 && ch <= 0xFF5A) ch = ch - 0xFF41 + 10; // lowercase fullwidth
+        else if (MVM_unicode_codepoint_has_property_value(tc, ch, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY,
+                                                          MVM_unicode_name_to_property_value_code(tc, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY,
+                                                                                                  MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "Nd")))) {
             // the string returned for NUMERIC_VALUE contains a floating point
             // value, so atoi will stop on the . in the string. This is fine
             // though, since we'd have to truncate the float regardless.
             ch = atoi(MVM_unicode_codepoint_get_property_cstr(tc, ch, MVM_UNICODE_PROPERTY_NUMERIC_VALUE));
         }
-        else if (ch >= 'a' && ch <= 'z') ch = ch - 'a' + 10;
-        else if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 10;
-        else if (ch >= 0xFF21 && ch <= 0xFF3A) ch = ch - 0xFF21 + 10; // uppercase fullwidth
-        else if (ch >= 0xFF41 && ch <= 0xFF5A) ch = ch - 0xFF41 + 10; // lowercase fullwidth
         else break;
         if (ch >= radix) break;
         mp_mul_d(&zvalue, radix, &zvalue);

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -941,10 +941,21 @@ MVMObject * MVM_bigint_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *st
         ch = (offset < chars) ? MVM_string_get_grapheme_at_nocheck(tc, str, offset) : 0;
     }
 
-   while (offset < chars) {
-        if (ch >= '0' && ch <= '9') ch = ch - '0';
+    while (offset < chars) {
+        // as of Unicode 6.0.0, characters with the 'de' Numeric Type (and are
+        // thus also of General Category Nd, since 4.0.0) are contiguous
+        // sequences of 10 chars whose Numeric Values ascend from 0 through 9.
+        MVMint64 gcNd = MVM_unicode_name_to_property_value_code(tc, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "Nd"));
+        if (MVM_unicode_codepoint_has_property_value(tc, ch, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY, gcNd)) {
+            // the string returned for NUMERIC_VALUE contains a floating point
+            // value, so atoi will stop on the . in the string. This is fine
+            // though, since we'd have to truncate the float regardless.
+            ch = atoi(MVM_unicode_codepoint_get_property_cstr(tc, ch, MVM_UNICODE_PROPERTY_NUMERIC_VALUE));
+        }
         else if (ch >= 'a' && ch <= 'z') ch = ch - 'a' + 10;
         else if (ch >= 'A' && ch <= 'Z') ch = ch - 'A' + 10;
+        else if (ch >= 0xFF21 && ch <= 0xFF3A) ch = ch - 0xFF21 + 10; // uppercase fullwidth
+        else if (ch >= 0xFF41 && ch <= 0xFF5A) ch = ch - 0xFF41 + 10; // lowercase fullwidth
         else break;
         if (ch >= radix) break;
         mp_mul_d(&zvalue, radix, &zvalue);


### PR DESCRIPTION
This change allows MVM_radix and MVM_bigint_radix to parse numbers containing any Nd category characters as well as letters from scripts with characters that can be used as hex digits (according to the Hex_Digit property), which effectively means just adding the upper- and lowercase fullwidth versions of the ASCII alphabet as valid characters.