### PR TITLE
Fix memory leak in MVM_bigint_mod.

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -496,8 +496,9 @@ MVMObject * MVM_bigint_mod(MVMThreadContext *tc, MVMObject *result_type, MVMObje
         mp_init(ic);
 
         mp_result = mp_mod(ia, ib, ic);
+        clear_temp_bigints(tmp, 2);
+
         if (mp_result == MP_VAL) {
-            clear_temp_bigints(tmp, 2);
             MVM_exception_throw_adhoc(tc, "Division by zero");
         }
         store_bigint_result(bc, ic);


### PR DESCRIPTION
Thanks to jnthn for interpreting valgrind output and identifying the cause :)

This error manifests in current MVM with Perl6 code like this:

```perl6
my $count = 1;
loop {
    $count %% 1;
}
```
On OSX 10.10 and a nqp/Rakudo built on MVM e5753cc0b6647091f223137a62053b14554728c1

