### PR TITLE
Remove unread stored values

### DIFF
--- a/src/6model/bootstrap.c
+++ b/src/6model/bootstrap.c
@@ -74,7 +74,7 @@ static void new_type(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *a
 
 /* Adds a method. */
 static void add_method(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *args) {
-    MVMObject *self, *type_obj, *method, *method_table;
+    MVMObject *self, *method, *method_table;
     MVMString *name;
 
     /* Get arguments. */
@@ -82,7 +82,6 @@ static void add_method(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister 
     MVM_args_proc_init(tc, &arg_ctx, callsite, args);
     MVM_args_checkarity(tc, &arg_ctx, 4, 4);
     self     = MVM_args_get_pos_obj(tc, &arg_ctx, 0, MVM_ARG_REQUIRED).arg.o;
-    type_obj = MVM_args_get_pos_obj(tc, &arg_ctx, 1, MVM_ARG_REQUIRED).arg.o;
     name     = MVM_args_get_pos_str(tc, &arg_ctx, 2, MVM_ARG_REQUIRED).arg.s;
     method   = MVM_args_get_pos_obj(tc, &arg_ctx, 3, MVM_ARG_REQUIRED).arg.o;
     MVM_args_proc_cleanup(tc, &arg_ctx);
@@ -99,14 +98,13 @@ static void add_method(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister 
 
 /* Adds an method. */
 static void add_attribute(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *args) {
-    MVMObject *self, *type_obj, *attr, *attributes;
+    MVMObject *self, *attr, *attributes;
 
     /* Get arguments. */
     MVMArgProcContext arg_ctx; arg_ctx.named_used = NULL;
     MVM_args_proc_init(tc, &arg_ctx, callsite, args);
     MVM_args_checkarity(tc, &arg_ctx, 3, 3);
     self     = MVM_args_get_pos_obj(tc, &arg_ctx, 0, MVM_ARG_REQUIRED).arg.o;
-    type_obj = MVM_args_get_pos_obj(tc, &arg_ctx, 1, MVM_ARG_REQUIRED).arg.o;
     attr     = MVM_args_get_pos_obj(tc, &arg_ctx, 2, MVM_ARG_REQUIRED).arg.o;
     MVM_args_proc_cleanup(tc, &arg_ctx);
 

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -145,7 +145,6 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
             MVMObject *inlined_val = MVM_repr_at_key_o(tc, attr, tc->instance->str_consts.inlined);
             MVMint64 inlined = !MVM_is_null(tc, inlined_val) && MVM_repr_get_int(tc, inlined_val);
             MVMint32   bits  = sizeof(void *) * 8;
-            MVMint32   align = ALIGNOF(void *);
             if (!MVM_is_null(tc, type)) {
                 /* See if it's a type that we know how to handle in a C struct. */
                 const MVMStorageSpec *spec = REPR(type)->get_storage_spec(tc, STABLE(type));
@@ -159,7 +158,6 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                      * repurpose it to store the bit-width of the type, so
                      * that get_attribute_ref can find it later. */
                     bits = spec->bits;
-                    align = spec->align;
 
                     repr_data->attribute_locations[i] = (bits << MVM_CUNION_ATTR_SHIFT) | MVM_CUNION_ATTR_IN_STRUCT;
                     repr_data->flattened_stables[i] = STABLE(type);

--- a/src/6model/reprs/MVMArray.c
+++ b/src/6model/reprs/MVMArray.c
@@ -335,7 +335,7 @@ static void set_size_internal(MVMThreadContext *tc, MVMArrayBody *body, MVMint64
 
     /* fill out any unused slots with NULL pointers or zero values */
     body->slots.any = slots;
-    elems = zero_slots(tc, body, elems, ssize, repr_data->slot_type);
+    zero_slots(tc, body, elems, ssize, repr_data->slot_type);
 
     body->ssize = ssize;
 }

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -580,7 +580,6 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
      * attributes. */
     mro_count   = REPR(info)->elems(tc, STABLE(info), info, OBJECT_BODY(info));
     mro_pos     = mro_count;
-    num_attrs   = 0;
     total_attrs = 0;
     while (mro_pos--) {
         /* Get info for the class at the current position. */

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -2857,7 +2857,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     ((MVMCode *)obj)->body.outer = context;
                     MVM_frame_inc_ref(tc, context);
                     if (orig) {
-                        orig = MVM_frame_dec_ref(tc, orig);
+                        MVM_frame_dec_ref(tc, orig);
                     }
                 }
                 cur_op += 4;

--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -152,7 +152,6 @@ void MVM_file_copy(MVMThreadContext *tc, MVMString *src, MVMString * dest) {
     if (uv_fs_close(tc->loop, &req, out_fd, NULL) < 0) {
         goto failure;
     }
-    out_fd = -1;
 
     MVM_free(b);
     MVM_free(a);

--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -131,7 +131,6 @@ static MVMString * take_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint3
             ds->chars_head_pos = 0;
             if (ds->chars_head == NULL)
                 ds->chars_tail = NULL;
-            cur_chars = next_chars;
         }
         else {
             /* There's enough in this buffer to satisfy us, and we'll leave

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -268,7 +268,6 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, MVMObject *result_type,
      * memory */
     if (bufsize - count > 4) {
         buffer = MVM_realloc(buffer, count * sizeof(MVMGrapheme32));
-        bufsize = count;
     }
     result->body.storage.blob_32 = buffer;
     result->body.storage_type    = MVM_STRING_GRAPHEME_32;


### PR DESCRIPTION
clang's `scan-build` program found several "unread stored value" problems.  This PR fixes as many of these issues as currently possible (some are caused by not yet implemented features, others by automatically generated code).  The NQP test suite passes after incorporating these changes.