### PR TITLE
Initialise all spec attributes to default values

### DIFF
--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -703,6 +703,15 @@ static MVMuint64 elems(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
 static MVMStorageSpec get_elem_storage_spec(MVMThreadContext *tc, MVMSTable *st) {
     MVMMultiDimArrayREPRData *repr_data = (MVMMultiDimArrayREPRData *)st->REPR_data;
     MVMStorageSpec spec;
+
+    /* initialise storage spec to default values */
+    spec.bits            = 0;
+    spec.align           = 0;
+    spec.is_unsigned     = 0;
+    spec.inlineable      = 0;
+    spec.boxed_primitive = 0;
+    spec.can_box         = 0;
+
     switch (repr_data->slot_type) {
         case MVM_ARRAY_STR:
             spec.inlineable      = MVM_STORAGE_SPEC_INLINED;


### PR DESCRIPTION
Not all of the `spec` struct attributes are assigned within
`get_elem_storage_spec()`.  This change sets all attributes so that none
will be potentially used uninitialised.