### PR TITLE
Fix copy-and-paste error

### DIFF
--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -924,7 +924,7 @@ static void spawn_gc_free(MVMThreadContext *tc, MVMObject *t, void *data) {
             si->ds_stdout = NULL;
         }
         if (si->ds_stderr) {
-            MVM_string_decodestream_destory(tc, si->ds_stdout);
+            MVM_string_decodestream_destory(tc, si->ds_stderr);
             si->ds_stderr = NULL;
         }
         MVM_free(si);


### PR DESCRIPTION
The attribute si->ds_stderr is actually being destroyed in this part of the
code (similarly to si->ds_stdout in th block above this change), thus the
call to `MVM_string_decodestream_destory` should really use si->ds_stderr
instead of si->ds_stdout.