### PR TITLE
Replace use of comma op inside an init of an array of pointers as thi…

### DIFF
--- a/src/mast/driver.c
+++ b/src/mast/driver.c
@@ -97,9 +97,9 @@ void MVM_mast_to_file(MVMThreadContext *tc, MVMObject *mast, MVMObject *types, M
             MVM_free(c_filename);
         }
         else {
-            /* we have to use parentheses here, otherwise MVMROOT thinks the
-             * comma introduces a new argument */
-            char *waste[2] = { (c_filename, NULL) };
+            char *waste[2];
+            waste[0] = c_filename;
+            waste[1] = NULL;
             MVM_exception_throw_adhoc_free(tc, waste, "Unable to write bytecode to '%s'", c_filename);
         }
     });


### PR DESCRIPTION
…s wasn't doing what was intended. Also gets rid of the last warning in this codebase (as of now).