### PR TITLE
Unlock mutex before returning

### DIFF
--- a/src/core/dll.c
+++ b/src/core/dll.c
@@ -65,6 +65,7 @@ int MVM_dll_free(MVMThreadContext *tc, MVMString *name) {
 
     /* already freed */
     if (!entry->lib)
+        uv_mutex_unlock(&tc->instance->mutex_dll_registry);
         return 0;
 
     if (entry->refcount > 0) {


### PR DESCRIPTION
The locked mutex could return without being unlocked beforehand.  This
change adds the missing unlock and avoids a potential thread blockage.