### PR TITLE
Add missing curlies to if statement

### DIFF
--- a/src/core/dll.c
+++ b/src/core/dll.c
@@ -64,9 +64,10 @@ int MVM_dll_free(MVMThreadContext *tc, MVMString *name) {
     }
 
     /* already freed */
-    if (!entry->lib)
+    if (!entry->lib) {
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
         return 0;
+    }
 
     if (entry->refcount > 0) {
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);


### PR DESCRIPTION
In my previous fix of the mutex unlock issue, the code flow had changed.  To
maintain the old behaviour curlies are needed in the if statement.