### PR TITLE
Remove potential double-free in MVM_spesh_candidate_setup

### DIFF
--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -111,18 +111,14 @@ MVMSpeshCandidate * MVM_spesh_candidate_setup(MVMThreadContext *tc,
                 fprintf(tc->instance->spesh_log_fh,
                     "Before:\n%s\nAfter:\n%s\n\n========\n\n", before, after);
                 fflush(tc->instance->spesh_log_fh);
-                MVM_free(before);
-                MVM_free(after);
                 MVM_free(c_name);
                 MVM_free(c_cuid);
             }
             used = 1;
         }
     }
-    if (after)
-        MVM_free(after);
-    if (before)
-        MVM_free(before);
+    MVM_free(after);
+    MVM_free(before);
     if (result && !used) {
         MVM_free(sc->bytecode);
         if (sc->handlers)


### PR DESCRIPTION
The `before` and `after` variables were being potentially freed twice.  By
only freeing them in the outer scope of their usage means that the resources
are still freed before exiting the function and the code doesn't try to free
already-freed variables.