### PR TITLE
Cast unsigned short to MVMunit64 to avoid integer overflow

### DIFF
--- a/src/gc/orchestrate.c
+++ b/src/gc/orchestrate.c
@@ -271,7 +271,7 @@ void MVM_gc_mark_thread_unblocked(MVMThreadContext *tc) {
 
 static MVMint32 is_full_collection(MVMThreadContext *tc) {
     MVMuint64 threshold = MVM_GC_GEN2_THRESHOLD_BASE +
-        (tc->instance->num_user_threads * MVM_GC_GEN2_THRESHOLD_THREAD);
+        ((MVMuint64)tc->instance->num_user_threads * MVM_GC_GEN2_THRESHOLD_THREAD);
     return MVM_load(&tc->instance->gc_promoted_bytes_since_last_full) > threshold;
 }
 


### PR DESCRIPTION
Coverity noticed that in the expression changed here, the variable
`tc->instance->num_user_threads` was an unsigned short, which was then being
implicitly promoted to int and then promoted again to unsigned long.
However, if the result of the expression is sufficiently large, this won't
calculate the correct value anymore since the value overflows.  By casting
`num_user_threads` to MVMunit64 we ensure that the overflow is avoided.