### PR TITLE
Free jitcode->func_ptr before destroying jitcode

### DIFF
--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -235,6 +235,8 @@ void MVM_spesh_candidate_destroy(MVMThreadContext *tc, MVMSpeshCandidate *candid
     MVM_free(candidate->inlines);
     MVM_free(candidate->local_types);
     MVM_free(candidate->lexical_types);
-    if (candidate->jitcode)
+    if (candidate->jitcode) {
+        MVM_free(candidate->jitcode->func_ptr);
         MVM_jit_destroy_code(tc, candidate->jitcode);
+    }
 }


### PR DESCRIPTION
Coverity showed the issue that the `func_ptr` field was still pointing to memory when the `jitcode` variable was destroyed.  This change frees the field before the enclosing variable is destroyed.  The NQP tests pass.
