### PR TITLE
Add missing break statement to callback_handler switch cascade

### DIFF
--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -276,6 +276,7 @@ static char callback_handler(DCCallback *cb, DCArgs *cb_args, DCValue *cb_result
                 args[i - 1].o = type;
                 MVM_gc_root_temp_push(tc, (MVMCollectable **)&(args[i - 1].o));
                 num_roots++;
+                break;
             case MVM_NATIVECALL_ARG_UCHAR:
                 args[i - 1].i64 = dcbArgUChar(cb_args);
                 break;


### PR DESCRIPTION
It seems that a break statement is missing in the MVM_NATIVECALL_ARG_* cascade of case statements.  This adds the missing break.  The NQP tests pass.

Please review carefully in case I've got this completely wrong.
