### PR TITLE
Revert func_ptr free from commit 688eecd

### DIFF
--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -235,8 +235,6 @@ void MVM_spesh_candidate_destroy(MVMThreadContext *tc, MVMSpeshCandidate *candid
     MVM_free(candidate->inlines);
     MVM_free(candidate->local_types);
     MVM_free(candidate->lexical_types);
-    if (candidate->jitcode) {
-        MVM_free(candidate->jitcode->func_ptr);
+    if (candidate->jitcode)
         MVM_jit_destroy_code(tc, candidate->jitcode);
-    }
 }


### PR DESCRIPTION
Unfortunately freeing the func_ptr wasn't the correct thing to do; the
change actually caused a bad free of a variable.  Sorry about that!  This
reverts the commit and thus removes a potentially bad free operation.