### PR TITLE
Fix write to null handle on async socket.

### DIFF
--- a/src/io/asyncsocket.c
+++ b/src/io/asyncsocket.c
@@ -468,7 +468,6 @@ static MVMint64 close_socket(MVMThreadContext *tc, MVMOSHandle *h) {
         task->body.ops  = &close_op_table;
         task->body.data = data->handle;
         MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
-        data->handle = NULL;
     }
     return 0;
 }


### PR DESCRIPTION
Related to this blurb: https://gist.github.com/kanatohodets/6642786a927c2616f6f2

I think this is safe because the handle is caught by MVM_free in close_cb when the close_socket task is processed by the event loop.

Feedback welcome!