### PR TITLE
Remove more config and generated files in distclean target

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -586,8 +586,9 @@ distclean: realclean
 	$(MSG) remove executable and libraries
 	-$(CMD)$(RM) moar@exe@ @moarlib@ @moardll@ $(NOOUT) $(NOERR)
 	$(MSG) remove configuration and generated files
-	-$(CMD)$(RM) Makefile src/gen/config.h src/strings/unicode.c tools/check.mk $(NOOUT) $(NOERR)
-	-$(CMD)$(RM_RF) build/mk-moar-pc.pl pkgconfig/ $(NOOUT) $(NOERR)
+	-$(CMD)$(RM) Makefile src/gen/config.h src/gen/config.c src/strings/unicode.c \
+	    tools/check.mk 3rdparty/libatomic_ops/config.log 3rdparty/libatomic_ops/config.status $(NOOUT) $(NOERR)
+	-$(CMD)$(RM_RF) src/jit/emit_posix_x64.c build/mk-moar-pc.pl pkgconfig/ $(NOOUT) $(NOERR)
 
 release:
 	[ -n "$(VERSION)" ] || ( echo "\nTry 'make release VERSION=yyyy.mm'\n\n"; exit 1 )


### PR DESCRIPTION
As mentioned in GH #139, the `realclean` target doesn't clean everything up.
Actually, it seems that the `distclean` target is the one which is supposed
to clean up the configuration and generated files (at least in MoarVM).
This wasn't happening completely and the current commit removes all files
still needing to be cleaned.

The file `src/jit/emit_posix_x64.c` is force-removed since it might not
exist on non-POSIX systems.  The `config.log` and `config.status` files
within the atomic ops library are also removed, although they really should
be removed as part of the upstream library's `distclean` Makefile target.