### PR TITLE
fix logical-op-parentheses compile warnings...

### DIFF
--- a/src/strings/normalize.c
+++ b/src/strings/normalize.c
@@ -470,7 +470,7 @@ static void canonical_composition(MVMThreadContext *tc, MVMNormalizer *n, MVMint
  * the handling of breaking around controls much earlier, so don't have to
  * consider that case. */
 static MVMint32 maybe_hangul(MVMCodepoint cp) {
-    return cp >= 0x1100 && cp < 0x1200 || cp >= 0xA960 && cp < 0xD7FC;
+    return (cp >= 0x1100 && cp < 0x1200) || (cp >= 0xA960 && cp < 0xD7FC);
 }
 static MVMint32 is_regional_indicator(MVMCodepoint cp) {
     /* U+1F1E6 REGIONAL INDICATOR SYMBOL LETTER A

--- a/src/strings/normalize.h
+++ b/src/strings/normalize.h
@@ -68,7 +68,7 @@ MVM_STATIC_INLINE MVMint32 MVM_unicode_normalizer_process_codepoint(MVMThreadCon
      * far in normalized form without having to consider them into the
      * normalization process. The exception is if we're computing NFG, and
      * we got \r, which can form a grapheme in the case of \r\n. */
-    if (in < 0x20 || in >= 0x7F && in <= 0x9F || in == 0xAD)
+    if (in < 0x20 || (in >= 0x7F && in <= 0x9F) || in == 0xAD)
         if (!(MVM_NORMALIZE_GRAPHEME(n->form) && in == 0x0D))
             return MVM_unicode_normalizer_process_codepoint_norm_terminator(tc, n, in, out);
 


### PR DESCRIPTION
in normalize.h:

    src/strings/normalize.h:71:33: warning: '&&' within '||' [-Wlogical-op-parentheses]
    if (in < 0x20 || in >= 0x7F && in <= 0x9F || in == 0xAD)
                  ~~ ~~~~~~~~~~~^~~~~~~~~~~~~
    src/strings/normalize.h:71:33: note: place parentheses around the '&&' expression to silence this warning
        if (in < 0x20 || in >= 0x7F && in <= 0x9F || in == 0xAD)
                                    ^
                         (                       )
    1 warning generated.
    compiling ....

wrap the >= && <= test in parentheses to fix this warning which is
showing (?) a potential precedence issue in the multiple || clauses
(there can't really *be* an issue here because we only ever test the
same variable, in, on both sides of the && clause, but should that
change in the future then there's the chance a bug could appear)

w/r/t: a4c5058392e7a0d4628f9f2206e943099893e1ad