### PR TITLE
Make MVMMultiCache container aware.

### DIFF
--- a/src/6model/6model.c
+++ b/src/6model/6model.c
@@ -408,7 +408,7 @@ void MVM_6model_stable_gc_free(MVMThreadContext *tc, MVMSTable *st) {
 
 /* Get the next type cache ID for a newly created STable. */
 MVMuint64 MVM_6model_next_type_cache_id(MVMThreadContext *tc) {
-    return (MVMuint64)MVM_add(&tc->instance->cur_type_cache_id, 64) + 64;
+    return (MVMuint64)MVM_add(&tc->instance->cur_type_cache_id, MVM_TYPE_CACHE_ID_INCR) + MVM_TYPE_CACHE_ID_INCR;
 }
 
 void MVM_6model_never_repossess(MVMThreadContext *tc, MVMObject *obj) {

--- a/src/6model/reprs/MVMMultiCache.c
+++ b/src/6model/reprs/MVMMultiCache.c
@@ -163,8 +163,14 @@ MVMObject * MVM_multi_cache_add(MVMThreadContext *tc, MVMObject *cache_obj, MVMO
         if (arg_type == MVM_CALLSITE_ARG_OBJ) {
             MVMObject *arg = MVM_args_get_pos_obj(tc, apc, i, 1).arg.o;
             if (arg) {
+                MVMuint8 rwness = 0;
                 MVMContainerSpec const *contspec = STABLE(arg)->container_spec;
                 if (contspec && IS_CONCRETE(arg)) {
+                    if (MVM_6model_container_iscont_i(tc, arg)
+                    ||  MVM_6model_container_iscont_n(tc, arg)
+                    ||  MVM_6model_container_iscont_s(tc, arg)
+                    || (!MVM_is_null(tc, arg) && contspec && contspec->can_store(tc, arg)))
+                        rwness = 2;
                     if (contspec->fetch_never_invokes) {
                         if (REPR(arg)->ID != MVM_REPR_ID_NativeRef) {
                             MVMRegister r;
@@ -176,14 +182,14 @@ MVMObject * MVM_multi_cache_add(MVMThreadContext *tc, MVMObject *cache_obj, MVMO
                         goto DONE;
                     }
                 }
-                arg_tup[i] = STABLE(arg)->type_cache_id | (IS_CONCRETE(arg) ? 1 : 0);
+                arg_tup[i] = STABLE(arg)->type_cache_id | (IS_CONCRETE(arg) ? 1 : 0) | rwness;
             }
             else {
                 goto DONE;
             }
         }
         else {
-            arg_tup[i] = (arg_type << 1) | 1;
+            arg_tup[i] = (arg_type << 2) | 1;
         }
     }
 
@@ -257,8 +263,14 @@ MVMObject * MVM_multi_cache_find(MVMThreadContext *tc, MVMObject *cache_obj, MVM
         if (arg_type == MVM_CALLSITE_ARG_OBJ) {
             MVMObject *arg = MVM_args_get_pos_obj(tc, apc, i, 1).arg.o;
             if (arg) {
+                MVMuint8 rwness = 0;
                 MVMContainerSpec const *contspec = STABLE(arg)->container_spec;
                 if (contspec && IS_CONCRETE(arg)) {
+                    if (MVM_6model_container_iscont_i(tc, arg)
+                    ||  MVM_6model_container_iscont_n(tc, arg)
+                    ||  MVM_6model_container_iscont_s(tc, arg)
+                    || (!MVM_is_null(tc, arg) && contspec && contspec->can_store(tc, arg)))
+                        rwness = 2;
                     if (contspec->fetch_never_invokes) {
                         if (REPR(arg)->ID != MVM_REPR_ID_NativeRef) {
                             MVMRegister r;
@@ -270,14 +282,14 @@ MVMObject * MVM_multi_cache_find(MVMThreadContext *tc, MVMObject *cache_obj, MVM
                         return NULL;
                     }
                 }
-                arg_tup[i] = STABLE(arg)->type_cache_id | (IS_CONCRETE(arg) ? 1 : 0);
+                arg_tup[i] = STABLE(arg)->type_cache_id | (IS_CONCRETE(arg) ? 1 : 0) | rwness;
             }
             else {
                 return NULL;
             }
         }
         else {
-            arg_tup[i] = (arg_type << 1) | 1;
+            arg_tup[i] = (arg_type << 2) | 1;
         }
     }
 
@@ -337,8 +349,14 @@ MVMObject * MVM_multi_cache_find_callsite_args(MVMThreadContext *tc, MVMObject *
         if (arg_type == MVM_CALLSITE_ARG_OBJ) {
             MVMObject *arg = args[i].o;
             if (arg) {
+                MVMuint8 rwness = 0;
                 MVMContainerSpec const *contspec = STABLE(arg)->container_spec;
                 if (contspec && IS_CONCRETE(arg)) {
+                    if (MVM_6model_container_iscont_i(tc, arg)
+                    ||  MVM_6model_container_iscont_n(tc, arg)
+                    ||  MVM_6model_container_iscont_s(tc, arg)
+                    || (!MVM_is_null(tc, arg) &&contspec && contspec->can_store(tc, arg)))
+                        rwness = 2;
                     if (contspec->fetch_never_invokes) {
                         if (REPR(arg)->ID != MVM_REPR_ID_NativeRef) {
                             MVMRegister r;
@@ -350,14 +368,14 @@ MVMObject * MVM_multi_cache_find_callsite_args(MVMThreadContext *tc, MVMObject *
                         return NULL;
                     }
                 }
-                arg_tup[i] = STABLE(arg)->type_cache_id | (IS_CONCRETE(arg) ? 1 : 0);
+                arg_tup[i] = STABLE(arg)->type_cache_id | (IS_CONCRETE(arg) ? 1 : 0) | rwness;
             }
             else {
                 return NULL;
             }
         }
         else {
-            arg_tup[i] = (arg_type << 1) | 1;
+            arg_tup[i] = (arg_type << 2) | 1;
         }
     }
 
@@ -445,7 +463,7 @@ MVMObject * MVM_multi_cache_find_spesh(MVMThreadContext *tc, MVMObject *cache_ob
             }
         }
         else {
-            arg_tup[i] = (arg_type << 1) | 1;
+            arg_tup[i] = (arg_type << 2) | 1;
         }
     }
 

--- a/src/6model/reprs/MVMMultiCache.c
+++ b/src/6model/reprs/MVMMultiCache.c
@@ -355,7 +355,7 @@ MVMObject * MVM_multi_cache_find_callsite_args(MVMThreadContext *tc, MVMObject *
                     if (MVM_6model_container_iscont_i(tc, arg)
                     ||  MVM_6model_container_iscont_n(tc, arg)
                     ||  MVM_6model_container_iscont_s(tc, arg)
-                    || (!MVM_is_null(tc, arg) &&contspec && contspec->can_store(tc, arg)))
+                    || (!MVM_is_null(tc, arg) && contspec && contspec->can_store(tc, arg)))
                         rwness = 2;
                     if (contspec->fetch_never_invokes) {
                         if (REPR(arg)->ID != MVM_REPR_ID_NativeRef) {

--- a/src/moar.h
+++ b/src/moar.h
@@ -213,3 +213,6 @@ MVM_PUBLIC void MVM_vm_set_lib_path(MVMInstance *instance, int count, const char
  * which the other atomic operation macros are used... */
 #define MVM_store(addr, new) AO_store_full((volatile AO_t *)(addr), (AO_t)(new))
 #define MVM_load(addr) AO_load_full((volatile AO_t *)(addr))
+
+/* Constant for incrementing the type cache ID for new STables */
+#define MVM_TYPE_CACHE_ID_INCR 128


### PR DESCRIPTION
This patch allows caching of Rakudo multi candidates that dispatch differently
with identical types but different rwness.  I'm not completely sure that
nothing has to be done for MVM_multi_cache_find_spesh, but I haven't come
across any breakage without adding something there. Of course that doesn't
necessarily show there isn't any.