### PR TITLE
Check if the *next* outer is null.

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -188,7 +188,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMuint16    outers = GET_UI16(cur_op, 4);
                 MVMRegister  found;
                 while (outers) {
-                    if (!f)
+                    if (!f->outer)
                         MVM_exception_throw_adhoc(tc, "getlex: outer index out of range");
                     f = f->outer;
                     outers--;


### PR DESCRIPTION
Otherwise there's cases where we do go one too far and SEGV after the while.