### PR TITLE
Fix buffer overflow when replacement length > output buffer size

### DIFF
--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -168,7 +168,7 @@ char * MVM_string_ascii_encode_substr(MVMThreadContext *tc, MVMString *str, MVMu
                 i++;
             }
             else if (replacement) {
-                if (i >= result_alloc - repl_length) {
+                if (repl_length >= result_alloc || i >= result_alloc - repl_length) {
                     result_alloc += repl_length;
                     result = MVM_realloc(result, result_alloc + 1);
                 }

--- a/src/strings/latin1.c
+++ b/src/strings/latin1.c
@@ -157,7 +157,7 @@ char * MVM_string_latin1_encode_substr(MVMThreadContext *tc, MVMString *str, MVM
                 i++;
             }
             else if (replacement) {
-                if (i >= result_alloc - repl_length) {
+                if (repl_length >= result_alloc || i >= result_alloc - repl_length) {
                     result_alloc += repl_length;
                     result = MVM_realloc(result, result_alloc + 1);
                 }

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -424,7 +424,7 @@ char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
         if (bytes)
             result_pos += bytes;
         else if (replacement) {
-            if (result_pos >= result_limit - repl_length) {
+            if (repl_length >= result_limit || result_pos >= result_limit - repl_length) {
                 result_limit += repl_length;
                 result = MVM_realloc(result, result_limit + 4);
             }

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -443,7 +443,7 @@ static void emit_cp(MVMThreadContext *tc, MVMCodepoint cp, MVMuint8 **result,
     if (bytes)
         *result_pos += bytes;
     else if (repl_bytes) {
-        if (*result_pos >= *result_limit - repl_length) {
+        if (repl_length >= *result_limit || *result_pos >= *result_limit - repl_length) {
             *result_limit += repl_length;
             *result = MVM_realloc(*result, *result_limit + 4);
         }

--- a/src/strings/windows1252.c
+++ b/src/strings/windows1252.c
@@ -289,7 +289,7 @@ char * MVM_string_windows1252_encode_substr(MVMThreadContext *tc, MVMString *str
                 i++;
             }
             else if (replacement) {
-                if (i >= result_alloc - repl_length) {
+                if (repl_length >= result_alloc || i >= result_alloc - repl_length) {
                     result_alloc += repl_length;
                     result = MVM_realloc(result, result_alloc + 1);
                 }


### PR DESCRIPTION
This fixes it for all encodings except UTF-16, which doesn't have realloc logic at all. I can fix that separately if nobody beats me to it.