### PR TITLE
Remove pointless arguments in encoding convenience functions

### DIFF
--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -194,12 +194,10 @@ char * MVM_string_ascii_encode_substr(MVMThreadContext *tc, MVMString *str, MVMu
 
 /* Encodes the specified string to ASCII.  */
 char * MVM_string_ascii_encode(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size) {
-    return MVM_string_ascii_encode_substr(tc, str, output_size, 0,
-        MVM_string_graphs(tc, str), NULL);
+    return MVM_string_ascii_encode_substr(tc, str, output_size, 0, -1, NULL);
 }
 
 /* Encodes the specified string to ASCII not returning length.  */
 char * MVM_string_ascii_encode_any(MVMThreadContext *tc, MVMString *str) {
-    MVMuint64 output_size;
-    return MVM_string_ascii_encode(tc, str, &output_size);
+    return MVM_string_ascii_encode(tc, str, NULL);
 }

--- a/src/strings/latin1.c
+++ b/src/strings/latin1.c
@@ -184,6 +184,5 @@ char * MVM_string_latin1_encode_substr(MVMThreadContext *tc, MVMString *str, MVM
  * will become a ?. The result string is NULL terminated, but the specified
  * size is the non-null part. */
 char * MVM_string_latin1_encode(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size) {
-    return MVM_string_latin1_encode_substr(tc, str, output_size, 0,
-        MVM_string_graphs(tc, str), NULL);
+    return MVM_string_latin1_encode_substr(tc, str, output_size, 0, -1, NULL);
 }

--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -154,5 +154,5 @@ char * MVM_string_utf16_encode_substr(MVMThreadContext *tc, MVMString *str, MVMu
 
 /* Encodes the whole string, double-NULL terminated. */
 char * MVM_string_utf16_encode(MVMThreadContext *tc, MVMString *str) {
-    return MVM_string_utf16_encode_substr(tc, str, NULL, 0, MVM_string_graphs(tc, str), NULL);
+    return MVM_string_utf16_encode_substr(tc, str, NULL, 0, -1, NULL);
 }

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -448,8 +448,7 @@ char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
 
 /* Encodes the specified string to UTF-8. */
 char * MVM_string_utf8_encode(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size) {
-    return MVM_string_utf8_encode_substr(tc, str, output_size, 0,
-        MVM_string_graphs(tc, str), NULL);
+    return MVM_string_utf8_encode_substr(tc, str, output_size, 0, -1, NULL);
 }
 
 /* Encodes the specified string to a UTF-8 C string. */


### PR DESCRIPTION
Passing -1/NULL achieves the same result more efficiently and clearly.