### PR TITLE
Check if the next outer is null in bindlex.

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -209,7 +209,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMFrame *f = tc->cur_frame;
                 MVMuint16 outers = GET_UI16(cur_op, 2);
                 while (outers) {
-                    if (!f)
+                    if (!f->outer)
                         MVM_exception_throw_adhoc(tc, "bindlex: outer index out of range");
                     f = f->outer;
                     outers--;


### PR DESCRIPTION
Analogous to commit b370dd9. I don't think we hit this, but the semantics are
equivalent and we could hit it when trying to bind further out than outers are
actually available.

Add.: "it" here means "dereferencing a null pointer". 