### PR TITLE
Avoid passing NULL pointers to memcpy() and memcmp()

### DIFF
--- a/src/core/callsite.c
+++ b/src/core/callsite.c
@@ -5,7 +5,7 @@ static MVMint32 callsites_equal(MVMThreadContext *tc, MVMCallsite *cs1, MVMCalls
                                 MVMint32 num_flags, MVMint32 num_nameds) {
     MVMint32 i;
 
-    if (memcmp(cs1->arg_flags, cs2->arg_flags, num_flags))
+    if (num_flags && memcmp(cs1->arg_flags, cs2->arg_flags, num_flags))
         return 0;
 
     for (i = 0; i < num_nameds; i++)

--- a/src/spesh/deopt.c
+++ b/src/spesh/deopt.c
@@ -27,10 +27,12 @@ static void uninline(MVMThreadContext *tc, MVMFrame *f, MVMSpeshCandidate *cand,
                 MVM_string_utf8_encode_C_string(tc, usf->body.cuuid));*/
 
             /* Copy the locals and lexicals into place. */
-            memcpy(uf->work, f->work + cand->inlines[i].locals_start,
-                usf->body.num_locals * sizeof(MVMRegister));
-            memcpy(uf->env, f->env + cand->inlines[i].lexicals_start,
-                usf->body.num_lexicals * sizeof(MVMRegister));
+            if (usf->body.num_locals)
+                memcpy(uf->work, f->work + cand->inlines[i].locals_start,
+                    usf->body.num_locals * sizeof(MVMRegister));
+            if (usf->body.num_lexicals)
+                memcpy(uf->env, f->env + cand->inlines[i].lexicals_start,
+                    usf->body.num_lexicals * sizeof(MVMRegister));
 
             /* Did we already uninline a frame? */
             if (last_uninlined) {

--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -592,7 +592,8 @@ static void add_predecessors(MVMThreadContext *tc, MVMSpeshGraph *g) {
             MVMSpeshBB  *tgt = cur_bb->succ[i];
             MVMSpeshBB **new_pred = MVM_spesh_alloc(tc, g,
                 (tgt->num_pred + 1) * sizeof(MVMSpeshBB *));
-            memcpy(new_pred, tgt->pred, tgt->num_pred * sizeof(MVMSpeshBB *));
+            if (tgt->num_pred)
+                memcpy(new_pred, tgt->pred, tgt->num_pred * sizeof(MVMSpeshBB *));
             new_pred[tgt->num_pred] = cur_bb;
             tgt->pred = new_pred;
             tgt->num_pred++;
@@ -731,7 +732,8 @@ static void add_child(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *target
 
     /* Nope, so insert. */
     new_children = MVM_spesh_alloc(tc, g, (target->num_children + 1) * sizeof(MVMSpeshBB *));
-    memcpy(new_children, target->children, target->num_children * sizeof(MVMSpeshBB *));
+    if (target->num_children)
+        memcpy(new_children, target->children, target->num_children * sizeof(MVMSpeshBB *));
     new_children[target->num_children] = to_add;
     target->children = new_children;
     target->num_children++;
@@ -758,7 +760,8 @@ static void add_to_frontier_set(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpesh
 
     /* Nope, so insert. */
     new_df = MVM_spesh_alloc(tc, g, (target->num_df + 1) * sizeof(MVMSpeshBB *));
-    memcpy(new_df, target->df, target->num_df * sizeof(MVMSpeshBB *));
+    if (target->num_df)
+        memcpy(new_df, target->df, target->num_df * sizeof(MVMSpeshBB *));
     new_df[target->num_df] = to_add;
     target->df = new_df;
     target->num_df++;


### PR DESCRIPTION
This is undefined behaviour, even with zero counts.

There are still some cases left in 6model which I haven't fixed, because UBSAN only caught some of the similar cases, and I wasn't sure if they should all be conditional or not.