### PR TITLE
Align bytecode sections to 8 bytes

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -764,91 +764,91 @@ static MVMString * concatenate_outputs(MVMThreadContext *tc, MVMSerializationWri
     MVMString *result;
 
     /* Calculate total size. */
-    output_size += HEADER_SIZE;
-    output_size += writer->root.num_dependencies * DEP_TABLE_ENTRY_SIZE;
-    output_size += writer->root.num_stables * STABLES_TABLE_ENTRY_SIZE;
-    output_size += writer->stables_data_offset;
-    output_size += writer->root.num_objects * OBJECTS_TABLE_ENTRY_SIZE;
-    output_size += writer->objects_data_offset;
-    output_size += writer->root.num_closures * CLOSURES_TABLE_ENTRY_SIZE;
-    output_size += writer->root.num_contexts * CONTEXTS_TABLE_ENTRY_SIZE;
-    output_size += writer->contexts_data_offset;
-    output_size += writer->root.num_repos * REPOS_TABLE_ENTRY_SIZE;
-    output_size += writer->param_interns_data_offset;
+    output_size += MVM_ALIGN_SECTION(HEADER_SIZE);
+    output_size += MVM_ALIGN_SECTION(writer->root.num_dependencies * DEP_TABLE_ENTRY_SIZE);
+    output_size += MVM_ALIGN_SECTION(writer->root.num_stables * STABLES_TABLE_ENTRY_SIZE);
+    output_size += MVM_ALIGN_SECTION(writer->stables_data_offset);
+    output_size += MVM_ALIGN_SECTION(writer->root.num_objects * OBJECTS_TABLE_ENTRY_SIZE);
+    output_size += MVM_ALIGN_SECTION(writer->objects_data_offset);
+    output_size += MVM_ALIGN_SECTION(writer->root.num_closures * CLOSURES_TABLE_ENTRY_SIZE);
+    output_size += MVM_ALIGN_SECTION(writer->root.num_contexts * CONTEXTS_TABLE_ENTRY_SIZE);
+    output_size += MVM_ALIGN_SECTION(writer->contexts_data_offset);
+    output_size += MVM_ALIGN_SECTION(writer->root.num_repos * REPOS_TABLE_ENTRY_SIZE);
+    output_size += MVM_ALIGN_SECTION(writer->param_interns_data_offset);
 
     /* Allocate a buffer that size. */
     output = (char *)MVM_malloc(output_size);
 
     /* Write version into header. */
     write_int32(output, 0, CURRENT_VERSION);
-    offset += HEADER_SIZE;
+    offset += MVM_ALIGN_SECTION(HEADER_SIZE);
 
     /* Put dependencies table in place and set location/rows in header. */
     write_int32(output, 4, offset);
     write_int32(output, 8, writer->root.num_dependencies);
     memcpy(output + offset, writer->root.dependencies_table,
         writer->root.num_dependencies * DEP_TABLE_ENTRY_SIZE);
-    offset += writer->root.num_dependencies * DEP_TABLE_ENTRY_SIZE;
+    offset += MVM_ALIGN_SECTION(writer->root.num_dependencies * DEP_TABLE_ENTRY_SIZE);
 
     /* Put STables table in place, and set location/rows in header. */
     write_int32(output, 12, offset);
     write_int32(output, 16, writer->root.num_stables);
     memcpy(output + offset, writer->root.stables_table,
         writer->root.num_stables * STABLES_TABLE_ENTRY_SIZE);
-    offset += writer->root.num_stables * STABLES_TABLE_ENTRY_SIZE;
+    offset += MVM_ALIGN_SECTION(writer->root.num_stables * STABLES_TABLE_ENTRY_SIZE);
 
     /* Put STables data in place. */
     write_int32(output, 20, offset);
     memcpy(output + offset, writer->root.stables_data,
         writer->stables_data_offset);
-    offset += writer->stables_data_offset;
+    offset += MVM_ALIGN_SECTION(writer->stables_data_offset);
 
     /* Put objects table in place, and set location/rows in header. */
     write_int32(output, 24, offset);
     write_int32(output, 28, writer->root.num_objects);
     memcpy(output + offset, writer->root.objects_table,
         writer->root.num_objects * OBJECTS_TABLE_ENTRY_SIZE);
-    offset += writer->root.num_objects * OBJECTS_TABLE_ENTRY_SIZE;
+    offset += MVM_ALIGN_SECTION(writer->root.num_objects * OBJECTS_TABLE_ENTRY_SIZE);
 
     /* Put objects data in place. */
     write_int32(output, 32, offset);
     memcpy(output + offset, writer->root.objects_data,
         writer->objects_data_offset);
-    offset += writer->objects_data_offset;
+    offset += MVM_ALIGN_SECTION(writer->objects_data_offset);
 
     /* Put closures table in place, and set location/rows in header. */
     write_int32(output, 36, offset);
     write_int32(output, 40, writer->root.num_closures);
     memcpy(output + offset, writer->root.closures_table,
         writer->root.num_closures * CLOSURES_TABLE_ENTRY_SIZE);
-    offset += writer->root.num_closures * CLOSURES_TABLE_ENTRY_SIZE;
+    offset += MVM_ALIGN_SECTION(writer->root.num_closures * CLOSURES_TABLE_ENTRY_SIZE);
 
     /* Put contexts table in place, and set location/rows in header. */
     write_int32(output, 44, offset);
     write_int32(output, 48, writer->root.num_contexts);
     memcpy(output + offset, writer->root.contexts_table,
         writer->root.num_contexts * CONTEXTS_TABLE_ENTRY_SIZE);
-    offset += writer->root.num_contexts * CONTEXTS_TABLE_ENTRY_SIZE;
+    offset += MVM_ALIGN_SECTION(writer->root.num_contexts * CONTEXTS_TABLE_ENTRY_SIZE);
 
     /* Put contexts data in place. */
     write_int32(output, 52, offset);
     memcpy(output + offset, writer->root.contexts_data,
         writer->contexts_data_offset);
-    offset += writer->contexts_data_offset;
+    offset += MVM_ALIGN_SECTION(writer->contexts_data_offset);
 
     /* Put repossessions table in place, and set location/rows in header. */
     write_int32(output, 56, offset);
     write_int32(output, 60, writer->root.num_repos);
     memcpy(output + offset, writer->root.repos_table,
         writer->root.num_repos * REPOS_TABLE_ENTRY_SIZE);
-    offset += writer->root.num_repos * REPOS_TABLE_ENTRY_SIZE;
+    offset += MVM_ALIGN_SECTION(writer->root.num_repos * REPOS_TABLE_ENTRY_SIZE);
 
     /* Put parameterized type intern data in place. */
     write_int32(output, 64, offset);
     write_int32(output, 68, writer->root.num_param_interns);
     memcpy(output + offset, writer->root.param_interns_data,
         writer->param_interns_data_offset);
-    offset += writer->param_interns_data_offset;
+    offset += MVM_ALIGN_SECTION(writer->param_interns_data_offset);
 
     /* Sanity check. */
     if (offset != output_size)

--- a/src/moar.h
+++ b/src/moar.h
@@ -63,6 +63,8 @@ typedef double   MVMnum64;
 #define ALIGNOF(t) ((char *)(&((struct { char c; t _h; } *)0)->_h) - (char *)0)
 #endif
 
+#define MVM_ALIGN_SECTION(offset) ((offset) + (offset) % ALIGNOF(MVMint64))
+
 #if defined MVM_BUILD_SHARED
 #  define MVM_PUBLIC  MVM_DLL_EXPORT
 #  define MVM_PRIVATE MVM_DLL_LOCAL


### PR DESCRIPTION
The bytecode file gets mmapped, and pointers to larger types inside
these sections dereferenced directly, so make sure each section starts
on a maximum alignment boundary.  The internal aligment in each section
is the responsibility of that section's (de)serializers.

This only increases the size of the NQP stage0 bytecode files by about
300 bytes out of a total 2.6MB.