### PR TITLE
Fix alignment macro definition

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -759,8 +759,8 @@ void MVM_serialization_write_stable_ref(MVMThreadContext *tc, MVMSerializationWr
 static MVMString * concatenate_outputs(MVMThreadContext *tc, MVMSerializationWriter *writer) {
     char      *output      = NULL;
     char      *output_b64  = NULL;
-    MVMint32   output_size = 0;
-    MVMint32   offset      = 0;
+    MVMuint32  output_size = 0;
+    MVMuint32  offset      = 0;
     MVMString *result;
 
     /* Calculate total size. */

--- a/src/mast/compiler.c
+++ b/src/mast/compiler.c
@@ -1386,8 +1386,8 @@ static char * form_string_heap(VM, WriterState *ws, unsigned int *string_heap_si
 
 /* Takes all the pieces and forms the bytecode output. */
 static char * form_bytecode_output(VM, WriterState *ws, unsigned int *bytecode_size) {
-    unsigned int size    = 0;
-    unsigned int pos     = 0;
+    MVMuint32     size    = 0;
+    MVMuint32     pos     = 0;
     char         *output;
     unsigned int  string_heap_size;
     char         *string_heap;

--- a/src/moar.h
+++ b/src/moar.h
@@ -63,7 +63,8 @@ typedef double   MVMnum64;
 #define ALIGNOF(t) ((char *)(&((struct { char c; t _h; } *)0)->_h) - (char *)0)
 #endif
 
-#define MVM_ALIGN_SECTION(offset) ((offset) + (offset) % ALIGNOF(MVMint64))
+#define MVM_ALIGN_SECTION_MASK ((MVMuint32)ALIGNOF(MVMint64) - 1)
+#define MVM_ALIGN_SECTION(offset) (((offset) + (MVM_ALIGN_SECTION_MASK)) & ~(MVM_ALIGN_SECTION_MASK))
 
 #if defined MVM_BUILD_SHARED
 #  define MVM_PUBLIC  MVM_DLL_EXPORT


### PR DESCRIPTION
Also consistently use MVMuint32 for the size and offset values.