### PR TITLE
LHF fix for stray header files

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -263,6 +263,10 @@ if ($args{'jit'}) {
 # fallback
 $config{jit} //= '$(JIT_STUB)';
 
+if ($config{'toolchain'} eq 'msvc') {
+    $config{install}   .= "\t\$(MKPATH) \$(DESTDIR)\$(PREFIX)/include/msinttypes\n"
+                        . "\t\$(CP) 3rdparty/msinttypes/*.h \$(DESTDIR)\$(PREFIX)/include/msinttypes\n";
+}
 
 
 

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -454,9 +454,7 @@ install: all
 	$(CP) src/instrument/*.h $(DESTDIR)$(PREFIX)/include/moar/instrument
 	$(MKPATH) $(DESTDIR)$(PREFIX)/include/libuv
 	$(MKPATH) $(DESTDIR)$(PREFIX)/include/libtommath
-	$(MKPATH) $(DESTDIR)$(PREFIX)/include/msinttypes
 	$(CP) 3rdparty/libuv/include/*.h $(DESTDIR)$(PREFIX)/include/libuv
-	$(CP) 3rdparty/msinttypes/*.h $(DESTDIR)$(PREFIX)/include/msinttypes
 @install@
 
 lib: @moar@

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -455,12 +455,8 @@ install: all
 	$(MKPATH) $(DESTDIR)$(PREFIX)/include/libuv
 	$(MKPATH) $(DESTDIR)$(PREFIX)/include/libtommath
 	$(MKPATH) $(DESTDIR)$(PREFIX)/include/msinttypes
-	$(MKPATH) $(DESTDIR)$(PREFIX)/include/sha1
-	$(MKPATH) $(DESTDIR)$(PREFIX)/include/tinymt
 	$(CP) 3rdparty/libuv/include/*.h $(DESTDIR)$(PREFIX)/include/libuv
 	$(CP) 3rdparty/msinttypes/*.h $(DESTDIR)$(PREFIX)/include/msinttypes
-	$(CP) 3rdparty/sha1/*.h $(DESTDIR)$(PREFIX)/include/sha1
-	$(CP) 3rdparty/tinymt/*.h $(DESTDIR)$(PREFIX)/include/tinymt
 @install@
 
 lib: @moar@


### PR DESCRIPTION
This attempts to partially address issue #323. It doesn't help with the
libtommath, libuv or dyncall headers being installed directly into /usr/include,
but those have --has-foo Configure switches so are somewhat easier to avoid
without hacking the build system directly.