### PR TITLE
[readme] declare the supported Unicode version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,7 @@ Some key features provided by MoarVM include:
 
 * Meta-object programming, using the 6model design
 * Precise, generational, and parallel GC
-* Unicode support (Unicode database lookup, encodings, normalization)
+* Unicode 8.0 support (Unicode Character Database, encodings, normalization)
 * First-class code objects, lexical variables and closures
 * Exceptions
 * Continuations


### PR DESCRIPTION
This is important to clearly display to users and I had a hard time finding it.

I found it in commit 7575ca4b and docs/ChangeLog for 2015.07.