### PR TITLE
Move stat_time ops to the right place in dispatch loop

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -79,6 +79,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
         }
 #endif
 
+        /* The ops should be in the same order here as in the oplist file, so
+         * the compiler can can optimise the switch properly */
         DISPATCH(NEXT_OP) {
             OP(no_op):
                 goto NEXT;
@@ -3289,10 +3291,6 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 GET_REG(cur_op, 0).i64 = MVM_file_stat(tc, GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).i64, 0);
                 cur_op += 6;
                 goto NEXT;
-            OP(stat_time):
-                GET_REG(cur_op, 0).n64 = MVM_file_time(tc, GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).i64, 0);
-                cur_op += 6;
-                goto NEXT;
             OP(readline_fh):
                 GET_REG(cur_op, 0).s = MVM_io_readline(tc, GET_REG(cur_op, 2).o, 0);
                 cur_op += 4;
@@ -4371,10 +4369,6 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 GET_REG(cur_op, 0).i64 = MVM_file_stat(tc, GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).i64, 1);
                 cur_op += 6;
                 goto NEXT;
-            OP(lstat_time):
-                GET_REG(cur_op, 0).n64 = MVM_file_time(tc, GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).i64, 1);
-                cur_op += 6;
-                goto NEXT;
             OP(iscont_i):
                 GET_REG(cur_op, 0).i64 = MVM_6model_container_iscont_i(tc,
                     GET_REG(cur_op, 2).o);
@@ -4962,6 +4956,14 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 }
                 goto NEXT;
             }
+            OP(stat_time):
+                GET_REG(cur_op, 0).n64 = MVM_file_time(tc, GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).i64, 0);
+                cur_op += 6;
+                goto NEXT;
+            OP(lstat_time):
+                GET_REG(cur_op, 0).n64 = MVM_file_time(tc, GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).i64, 1);
+                cur_op += 6;
+                goto NEXT;
             OP(sp_log):
                 if (tc->cur_frame->spesh_log_idx >= 0) {
                     MVM_ASSIGN_REF(tc, &(tc->cur_frame->static_info->common.header),


### PR DESCRIPTION
They should be in in the same order as in the oplist file, so that the
compiler can optimese the switch properly.