### PR TITLE
VS 2013 and later provide stdint.h and inttypes.h

### DIFF
--- a/src/platform/inttypes.h
+++ b/src/platform/inttypes.h
@@ -1,4 +1,4 @@
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 #include <msinttypes/inttypes.h>
 /* Print size_t values. */
 #define MVM_PRSz "Iu"

--- a/src/platform/stdint.h
+++ b/src/platform/stdint.h
@@ -1,4 +1,4 @@
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 #include <msinttypes/stdint.h>
 #else
 #include <stdint.h>


### PR DESCRIPTION
Therefore, there is no need to use third party substitutes for those header files if build is on VS 2013 and later.

See [What's New for Visual C++ in Visual Studio 2013][1] and [C99 library support in Visual Studio 2013][2].

[1]: https://msdn.microsoft.com/library/hh409293%28v=vs.120%29.aspx
[2]: http://blogs.msdn.com/b/vcblog/archive/2013/07/19/c99-library-support-in-visual-studio-2013.aspx