### PR TITLE
Add MIN MAX macros from libtommath

### DIFF
--- a/src/6model/reprs/P6bigint.h
+++ b/src/6model/reprs/P6bigint.h
@@ -1,5 +1,13 @@
 #include "tommath.h"
 
+#ifndef MIN
+#define MIN(x,y) (((x) < (y)) ? (x) : (y))
+#endif
+
+#ifndef MAX
+#define MAX(x,y) (((x) > (y)) ? (x) : (y))
+#endif
+
 #define MVM_BIGINT_32_FLAG      0xFFFFFFFF
 #define MVM_BIGINT_IS_BIG(body) ((body)->u.smallint.flag != 0xFFFFFFFF)
 #define MVM_IS_32BIT_INT(i)     (i >= -2147483648LL && i <= 2147483647LL)


### PR DESCRIPTION
In libtommath 1.0, MIN and MAX macros were moved from tommath.h to
tommath_private.h. See https://github.com/libtom/libtommath/pull/41

This break moar link because MIN and MAX symbols are not
found (I expected compilation to fail. Oh well...)

This commit fixes this issue. This was tested on Debian unstable with
libtommath 1.0 , moar 2016.02 and nqp 2016.02 (to test moar)

Hope this helps