### PR TITLE
adjust byte count when UTF-16 BOM marker consumed

### DIFF
--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -34,11 +34,13 @@ MVMString * MVM_string_utf16_decode(MVMThreadContext *tc,
             low = 0;
             high = 1;
             utf16 += 2;
+            bytes -= 2;
         }
         else if (!memcmp(utf16, BOM_UTF16BE, 2)) {
             low = 1;
             high = 0;
             utf16 += 2;
+            bytes -= 2;
         }
     }
     utf16_end = utf16 + bytes;


### PR DESCRIPTION
Something I noticed in Rakudo, when experimenting with
UTF-16 BOM markers. For example:

    % perl6 -e'my $s = Buf.new([255, 254, 72, 0, 101, 0]).decode("utf-16"); say $s.perl'
    "He\0"

The 2-byte "\xFF\FE" BOM marker is consumed, but the byte count hasn't been adjusted, so
it's running past the end of the string.