### PR TITLE
Serialization int

### DIFF
--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -419,17 +419,17 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMCArrayREPRData *repr_data = (MVMCArrayREPRData *) MVM_malloc(sizeof(MVMCArrayREPRData));
 
     if (reader->root.version >= 19) {
-        repr_data->elem_size = MVM_serialization_read_varint(tc, reader);
-    } else {
         repr_data->elem_size = MVM_serialization_read_int(tc, reader);
+    } else {
+        repr_data->elem_size = MVM_serialization_read_int64(tc, reader);
     }
 
     repr_data->elem_type = MVM_serialization_read_ref(tc, reader);
 
     if (reader->root.version >= 19) {
-        repr_data->elem_kind = MVM_serialization_read_varint(tc, reader);
-    } else {
         repr_data->elem_kind = MVM_serialization_read_int(tc, reader);
+    } else {
+        repr_data->elem_kind = MVM_serialization_read_int64(tc, reader);
     }
 
     st->REPR_data = repr_data;

--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -409,17 +409,29 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 /* Serializes the REPR data. */
 static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationWriter *writer) {
     MVMCArrayREPRData *repr_data = (MVMCArrayREPRData *)st->REPR_data;
-    MVM_serialization_write_int(tc, writer, repr_data->elem_size);
+    MVM_serialization_write_varint(tc, writer, repr_data->elem_size);
     MVM_serialization_write_ref(tc, writer, repr_data->elem_type);
-    MVM_serialization_write_int(tc, writer, repr_data->elem_kind);
+    MVM_serialization_write_varint(tc, writer, repr_data->elem_kind);
 }
 
 /* Deserializes the REPR data. */
 static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
     MVMCArrayREPRData *repr_data = (MVMCArrayREPRData *) MVM_malloc(sizeof(MVMCArrayREPRData));
-    repr_data->elem_size = MVM_serialization_read_int(tc, reader);
+
+    if (reader->root.version >= 19) {
+        repr_data->elem_size = MVM_serialization_read_varint(tc, reader);
+    } else {
+        repr_data->elem_size = MVM_serialization_read_int(tc, reader);
+    }
+
     repr_data->elem_type = MVM_serialization_read_ref(tc, reader);
-    repr_data->elem_kind = MVM_serialization_read_int(tc, reader);
+
+    if (reader->root.version >= 19) {
+        repr_data->elem_kind = MVM_serialization_read_varint(tc, reader);
+    } else {
+        repr_data->elem_kind = MVM_serialization_read_int(tc, reader);
+    }
+
     st->REPR_data = repr_data;
 }
 

--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -409,9 +409,9 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 /* Serializes the REPR data. */
 static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationWriter *writer) {
     MVMCArrayREPRData *repr_data = (MVMCArrayREPRData *)st->REPR_data;
-    MVM_serialization_write_varint(tc, writer, repr_data->elem_size);
+    MVM_serialization_write_int(tc, writer, repr_data->elem_size);
     MVM_serialization_write_ref(tc, writer, repr_data->elem_type);
-    MVM_serialization_write_varint(tc, writer, repr_data->elem_kind);
+    MVM_serialization_write_int(tc, writer, repr_data->elem_kind);
 }
 
 /* Deserializes the REPR data. */

--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -735,12 +735,12 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMCPPStructREPRData *repr_data = (MVMCPPStructREPRData *) MVM_malloc(sizeof(MVMCPPStructREPRData));
     MVMint32 i, num_classes, num_slots;
 
-    repr_data->struct_size    = MVM_serialization_read_varint(tc, reader);
+    repr_data->struct_size    = MVM_serialization_read_int(tc, reader);
     if (reader->root.version >= 17) {
-        repr_data->struct_align = MVM_serialization_read_varint(tc, reader);
+        repr_data->struct_align = MVM_serialization_read_int(tc, reader);
     }
-    repr_data->num_attributes = MVM_serialization_read_varint(tc, reader);
-    repr_data->num_child_objs = MVM_serialization_read_varint(tc, reader);
+    repr_data->num_attributes = MVM_serialization_read_int(tc, reader);
+    repr_data->num_child_objs = MVM_serialization_read_int(tc, reader);
 
     repr_data->attribute_locations = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * repr_data->num_attributes);
     repr_data->struct_offsets      = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * repr_data->num_attributes);
@@ -748,10 +748,10 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->member_types        = (MVMObject **)MVM_malloc(repr_data->num_attributes * sizeof(MVMObject *));
 
     for(i = 0; i < repr_data->num_attributes; i++) {
-        repr_data->attribute_locations[i] = MVM_serialization_read_varint(tc, reader);
-        repr_data->struct_offsets[i] = MVM_serialization_read_varint(tc, reader);
+        repr_data->attribute_locations[i] = MVM_serialization_read_int(tc, reader);
+        repr_data->struct_offsets[i] = MVM_serialization_read_int(tc, reader);
 
-        if(MVM_serialization_read_varint(tc, reader)){
+        if(MVM_serialization_read_int(tc, reader)){
             MVM_ASSIGN_REF(tc, &(st->header), repr_data->flattened_stables[i], MVM_serialization_read_stable_ref(tc, reader));
         }
         else {
@@ -761,7 +761,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
         repr_data->member_types[i] = MVM_serialization_read_ref(tc, reader);
     }
 
-    num_classes = MVM_serialization_read_varint(tc, reader);
+    num_classes = MVM_serialization_read_int(tc, reader);
     repr_data->name_to_index_mapping = (MVMCPPStructNameMap *)MVM_malloc(sizeof(MVMCPPStructNameMap) * (1 + num_classes));
     for(i = 0; i < num_classes; i++){
         repr_data->name_to_index_mapping[i].class_key = MVM_serialization_read_ref(tc, reader);
@@ -770,10 +770,10 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->name_to_index_mapping[i].class_key = NULL;
     repr_data->name_to_index_mapping[i].name_map = NULL;
 
-    num_slots = MVM_serialization_read_varint(tc, reader);
+    num_slots = MVM_serialization_read_int(tc, reader);
     repr_data->initialize_slots = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * (1 + num_slots));
     for(i = 0; i < num_slots; i++){
-        repr_data->initialize_slots[i] = MVM_serialization_read_varint(tc, reader);
+        repr_data->initialize_slots[i] = MVM_serialization_read_int(tc, reader);
     }
     repr_data->initialize_slots[i] = -1;
 

--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -695,15 +695,15 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     MVMCPPStructREPRData *repr_data = (MVMCPPStructREPRData *)st->REPR_data;
     MVMint32 i, num_classes, num_slots;
 
-    MVM_serialization_write_varint(tc, writer, repr_data->struct_size);
-    MVM_serialization_write_varint(tc, writer, repr_data->struct_align);
-    MVM_serialization_write_varint(tc, writer, repr_data->num_attributes);
-    MVM_serialization_write_varint(tc, writer, repr_data->num_child_objs);
+    MVM_serialization_write_int(tc, writer, repr_data->struct_size);
+    MVM_serialization_write_int(tc, writer, repr_data->struct_align);
+    MVM_serialization_write_int(tc, writer, repr_data->num_attributes);
+    MVM_serialization_write_int(tc, writer, repr_data->num_child_objs);
     for(i = 0; i < repr_data->num_attributes; i++){
-        MVM_serialization_write_varint(tc, writer, repr_data->attribute_locations[i]);
-        MVM_serialization_write_varint(tc, writer, repr_data->struct_offsets[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->attribute_locations[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->struct_offsets[i]);
 
-        MVM_serialization_write_varint(tc, writer, repr_data->flattened_stables[i] != NULL);
+        MVM_serialization_write_int(tc, writer, repr_data->flattened_stables[i] != NULL);
         if (repr_data->flattened_stables[i])
             MVM_serialization_write_stable_ref(tc, writer, repr_data->flattened_stables[i]);
 
@@ -714,7 +714,7 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     while (repr_data->name_to_index_mapping[i].class_key)
         i++;
     num_classes = i;
-    MVM_serialization_write_varint(tc, writer, num_classes);
+    MVM_serialization_write_int(tc, writer, num_classes);
     for(i = 0; i < num_classes; i++){
         MVM_serialization_write_ref(tc, writer, repr_data->name_to_index_mapping[i].class_key);
         MVM_serialization_write_ref(tc, writer, repr_data->name_to_index_mapping[i].name_map);
@@ -724,9 +724,9 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     while(repr_data->initialize_slots && repr_data->initialize_slots[i] != -1)
         i++;
     num_slots = i;
-    MVM_serialization_write_varint(tc, writer, num_slots);
+    MVM_serialization_write_int(tc, writer, num_slots);
     for(i = 0; i < num_slots; i++){
-        MVM_serialization_write_varint(tc, writer, repr_data->initialize_slots[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->initialize_slots[i]);
     }
 }
 

--- a/src/6model/reprs/CPointer.c
+++ b/src/6model/reprs/CPointer.c
@@ -103,7 +103,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
 
 static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerializationWriter *writer) {
     MVMCPointerBody *body = (MVMCPointerBody *)data;
-    MVM_serialization_write_varint(tc, writer,
+    MVM_serialization_write_int(tc, writer,
 #if MVM_PTR_SIZE == 4
         (MVMuint64)(MVMuint32)body->ptr
 #else

--- a/src/6model/reprs/CPointer.c
+++ b/src/6model/reprs/CPointer.c
@@ -85,7 +85,14 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 
 static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMSerializationReader *reader) {
     MVMCPointerBody *body = (MVMCPointerBody *)data;
-    MVMint64 value = MVM_serialization_read_int(tc, reader);
+    MVMint64 value;
+
+    if (reader->root.version >= 19) {
+        value = MVM_serialization_read_varint(tc, reader);
+    } else {
+        value = MVM_serialization_read_int(tc, reader);
+    }
+
 #if MVM_PTR_SIZE == 4
     body->ptr = (void *)(MVMuint32)value;
 #else
@@ -96,7 +103,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
 
 static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerializationWriter *writer) {
     MVMCPointerBody *body = (MVMCPointerBody *)data;
-    MVM_serialization_write_int(tc, writer,
+    MVM_serialization_write_varint(tc, writer,
 #if MVM_PTR_SIZE == 4
         (MVMuint64)(MVMuint32)body->ptr
 #else

--- a/src/6model/reprs/CPointer.c
+++ b/src/6model/reprs/CPointer.c
@@ -88,9 +88,9 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
     MVMint64 value;
 
     if (reader->root.version >= 19) {
-        value = MVM_serialization_read_varint(tc, reader);
-    } else {
         value = MVM_serialization_read_int(tc, reader);
+    } else {
+        value = MVM_serialization_read_int64(tc, reader);
     }
 
 #if MVM_PTR_SIZE == 4

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -695,15 +695,15 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     MVMCStructREPRData *repr_data = (MVMCStructREPRData *)st->REPR_data;
     MVMint32 i, num_classes, num_slots;
 
-    MVM_serialization_write_varint(tc, writer, repr_data->struct_size);
-    MVM_serialization_write_varint(tc, writer, repr_data->struct_align);
-    MVM_serialization_write_varint(tc, writer, repr_data->num_attributes);
-    MVM_serialization_write_varint(tc, writer, repr_data->num_child_objs);
+    MVM_serialization_write_int(tc, writer, repr_data->struct_size);
+    MVM_serialization_write_int(tc, writer, repr_data->struct_align);
+    MVM_serialization_write_int(tc, writer, repr_data->num_attributes);
+    MVM_serialization_write_int(tc, writer, repr_data->num_child_objs);
     for(i = 0; i < repr_data->num_attributes; i++){
-        MVM_serialization_write_varint(tc, writer, repr_data->attribute_locations[i]);
-        MVM_serialization_write_varint(tc, writer, repr_data->struct_offsets[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->attribute_locations[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->struct_offsets[i]);
 
-        MVM_serialization_write_varint(tc, writer, repr_data->flattened_stables[i] != NULL);
+        MVM_serialization_write_int(tc, writer, repr_data->flattened_stables[i] != NULL);
         if (repr_data->flattened_stables[i])
             MVM_serialization_write_stable_ref(tc, writer, repr_data->flattened_stables[i]);
 
@@ -714,7 +714,7 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     while (repr_data->name_to_index_mapping[i].class_key)
         i++;
     num_classes = i;
-    MVM_serialization_write_varint(tc, writer, num_classes);
+    MVM_serialization_write_int(tc, writer, num_classes);
     for(i = 0; i < num_classes; i++){
         MVM_serialization_write_ref(tc, writer, repr_data->name_to_index_mapping[i].class_key);
         MVM_serialization_write_ref(tc, writer, repr_data->name_to_index_mapping[i].name_map);
@@ -724,9 +724,9 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     while(repr_data->initialize_slots && repr_data->initialize_slots[i] != -1)
         i++;
     num_slots = i;
-    MVM_serialization_write_varint(tc, writer, num_slots);
+    MVM_serialization_write_int(tc, writer, num_slots);
     for(i = 0; i < num_slots; i++){
-        MVM_serialization_write_varint(tc, writer, repr_data->initialize_slots[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->initialize_slots[i]);
     }
 }
 

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -735,12 +735,12 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMCStructREPRData *repr_data = (MVMCStructREPRData *) MVM_malloc(sizeof(MVMCStructREPRData));
     MVMint32 i, num_classes, num_slots;
 
-    repr_data->struct_size = MVM_serialization_read_varint(tc, reader);
+    repr_data->struct_size = MVM_serialization_read_int(tc, reader);
     if (reader->root.version >= 17) {
-        repr_data->struct_align = MVM_serialization_read_varint(tc, reader);
+        repr_data->struct_align = MVM_serialization_read_int(tc, reader);
     }
-    repr_data->num_attributes = MVM_serialization_read_varint(tc, reader);
-    repr_data->num_child_objs = MVM_serialization_read_varint(tc, reader);
+    repr_data->num_attributes = MVM_serialization_read_int(tc, reader);
+    repr_data->num_child_objs = MVM_serialization_read_int(tc, reader);
 
     repr_data->attribute_locations = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * repr_data->num_attributes);
     repr_data->struct_offsets      = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * repr_data->num_attributes);
@@ -748,10 +748,10 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->member_types        = (MVMObject **)MVM_malloc(repr_data->num_attributes * sizeof(MVMObject *));
 
     for(i = 0; i < repr_data->num_attributes; i++) {
-        repr_data->attribute_locations[i] = MVM_serialization_read_varint(tc, reader);
-        repr_data->struct_offsets[i] = MVM_serialization_read_varint(tc, reader);
+        repr_data->attribute_locations[i] = MVM_serialization_read_int(tc, reader);
+        repr_data->struct_offsets[i] = MVM_serialization_read_int(tc, reader);
 
-        if(MVM_serialization_read_varint(tc, reader)){
+        if(MVM_serialization_read_int(tc, reader)){
             MVM_ASSIGN_REF(tc, &(st->header), repr_data->flattened_stables[i], MVM_serialization_read_stable_ref(tc, reader));
         }
         else {
@@ -761,7 +761,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
         repr_data->member_types[i] = MVM_serialization_read_ref(tc, reader);
     }
 
-    num_classes = MVM_serialization_read_varint(tc, reader);
+    num_classes = MVM_serialization_read_int(tc, reader);
     repr_data->name_to_index_mapping = (MVMCStructNameMap *)MVM_malloc(sizeof(MVMCStructNameMap) * (1 + num_classes));
     for(i = 0; i < num_classes; i++){
         repr_data->name_to_index_mapping[i].class_key = MVM_serialization_read_ref(tc, reader);
@@ -770,10 +770,10 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->name_to_index_mapping[i].class_key = NULL;
     repr_data->name_to_index_mapping[i].name_map = NULL;
 
-    num_slots = MVM_serialization_read_varint(tc, reader);
+    num_slots = MVM_serialization_read_int(tc, reader);
     repr_data->initialize_slots = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * (1 + num_slots));
     for(i = 0; i < num_slots; i++){
-        repr_data->initialize_slots[i] = MVM_serialization_read_varint(tc, reader);
+        repr_data->initialize_slots[i] = MVM_serialization_read_int(tc, reader);
     }
     repr_data->initialize_slots[i] = -1;
 

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -707,12 +707,12 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMCUnionREPRData *repr_data = (MVMCUnionREPRData *) MVM_malloc(sizeof(MVMCUnionREPRData));
     MVMint32 i, num_classes, num_slots;
 
-    repr_data->struct_size = MVM_serialization_read_varint(tc, reader);
+    repr_data->struct_size = MVM_serialization_read_int(tc, reader);
     if (reader->root.version >= 17) {
-        repr_data->struct_align = MVM_serialization_read_varint(tc, reader);
+        repr_data->struct_align = MVM_serialization_read_int(tc, reader);
     }
-    repr_data->num_attributes = MVM_serialization_read_varint(tc, reader);
-    repr_data->num_child_objs = MVM_serialization_read_varint(tc, reader);
+    repr_data->num_attributes = MVM_serialization_read_int(tc, reader);
+    repr_data->num_child_objs = MVM_serialization_read_int(tc, reader);
 
     repr_data->attribute_locations = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * repr_data->num_attributes);
     repr_data->struct_offsets      = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * repr_data->num_attributes);
@@ -720,10 +720,10 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->member_types        = (MVMObject **)MVM_malloc(repr_data->num_attributes * sizeof(MVMObject *));
 
     for(i = 0; i < repr_data->num_attributes; i++) {
-        repr_data->attribute_locations[i] = MVM_serialization_read_varint(tc, reader);
-        repr_data->struct_offsets[i] = MVM_serialization_read_varint(tc, reader);
+        repr_data->attribute_locations[i] = MVM_serialization_read_int(tc, reader);
+        repr_data->struct_offsets[i] = MVM_serialization_read_int(tc, reader);
 
-        if(MVM_serialization_read_varint(tc, reader)){
+        if(MVM_serialization_read_int(tc, reader)){
             MVM_ASSIGN_REF(tc, &(st->header), repr_data->flattened_stables[i], MVM_serialization_read_stable_ref(tc, reader));
         }
         else {
@@ -733,7 +733,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
         repr_data->member_types[i] = MVM_serialization_read_ref(tc, reader);
     }
 
-    num_classes = MVM_serialization_read_varint(tc, reader);
+    num_classes = MVM_serialization_read_int(tc, reader);
     repr_data->name_to_index_mapping = (MVMCUnionNameMap *)MVM_malloc(sizeof(MVMCUnionNameMap) * (1 + num_classes));
     for(i = 0; i < num_classes; i++){
         repr_data->name_to_index_mapping[i].class_key = MVM_serialization_read_ref(tc, reader);
@@ -742,10 +742,10 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->name_to_index_mapping[i].class_key = NULL;
     repr_data->name_to_index_mapping[i].name_map = NULL;
 
-    num_slots = MVM_serialization_read_varint(tc, reader);
+    num_slots = MVM_serialization_read_int(tc, reader);
     repr_data->initialize_slots = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * (1 + num_slots));
     for(i = 0; i < num_slots; i++){
-        repr_data->initialize_slots[i] = MVM_serialization_read_varint(tc, reader);
+        repr_data->initialize_slots[i] = MVM_serialization_read_int(tc, reader);
     }
     repr_data->initialize_slots[i] = -1;
 

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -667,15 +667,15 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     MVMCUnionREPRData *repr_data = (MVMCUnionREPRData *)st->REPR_data;
     MVMint32 i, num_classes, num_slots;
 
-    MVM_serialization_write_varint(tc, writer, repr_data->struct_size);
-    MVM_serialization_write_varint(tc, writer, repr_data->struct_align);
-    MVM_serialization_write_varint(tc, writer, repr_data->num_attributes);
-    MVM_serialization_write_varint(tc, writer, repr_data->num_child_objs);
+    MVM_serialization_write_int(tc, writer, repr_data->struct_size);
+    MVM_serialization_write_int(tc, writer, repr_data->struct_align);
+    MVM_serialization_write_int(tc, writer, repr_data->num_attributes);
+    MVM_serialization_write_int(tc, writer, repr_data->num_child_objs);
     for(i = 0; i < repr_data->num_attributes; i++){
-        MVM_serialization_write_varint(tc, writer, repr_data->attribute_locations[i]);
-        MVM_serialization_write_varint(tc, writer, repr_data->struct_offsets[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->attribute_locations[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->struct_offsets[i]);
 
-        MVM_serialization_write_varint(tc, writer, repr_data->flattened_stables[i] != NULL);
+        MVM_serialization_write_int(tc, writer, repr_data->flattened_stables[i] != NULL);
         if (repr_data->flattened_stables[i])
             MVM_serialization_write_stable_ref(tc, writer, repr_data->flattened_stables[i]);
 
@@ -686,7 +686,7 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     while (repr_data->name_to_index_mapping[i].class_key)
         i++;
     num_classes = i;
-    MVM_serialization_write_varint(tc, writer, num_classes);
+    MVM_serialization_write_int(tc, writer, num_classes);
     for(i = 0; i < num_classes; i++){
         MVM_serialization_write_ref(tc, writer, repr_data->name_to_index_mapping[i].class_key);
         MVM_serialization_write_ref(tc, writer, repr_data->name_to_index_mapping[i].name_map);
@@ -696,9 +696,9 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     while(repr_data->initialize_slots && repr_data->initialize_slots[i] != -1)
         i++;
     num_slots = i;
-    MVM_serialization_write_varint(tc, writer, num_slots);
+    MVM_serialization_write_int(tc, writer, num_slots);
     for(i = 0; i < num_slots; i++){
-        MVM_serialization_write_varint(tc, writer, repr_data->initialize_slots[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->initialize_slots[i]);
     }
 }
 

--- a/src/6model/reprs/MVMArray.c
+++ b/src/6model/reprs/MVMArray.c
@@ -1130,7 +1130,7 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
     MVMArrayBody     *body      = (MVMArrayBody *)data;
     MVMint64 i;
 
-    MVM_serialization_write_varint(tc, writer, body->elems);
+    MVM_serialization_write_int(tc, writer, body->elems);
     for (i = 0; i < body->elems; i++) {
         switch (repr_data->slot_type) {
             case MVM_ARRAY_OBJ:
@@ -1140,28 +1140,28 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
                 MVM_serialization_write_str(tc, writer, body->slots.s[body->start + i]);
                 break;
             case MVM_ARRAY_I64:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i64[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i64[body->start + i]);
                 break;
             case MVM_ARRAY_I32:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i32[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i32[body->start + i]);
                 break;
             case MVM_ARRAY_I16:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i16[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i16[body->start + i]);
                 break;
             case MVM_ARRAY_I8:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i8[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i8[body->start + i]);
                 break;
             case MVM_ARRAY_U64:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u64[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u64[body->start + i]);
                 break;
             case MVM_ARRAY_U32:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u32[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u32[body->start + i]);
                 break;
             case MVM_ARRAY_U16:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u16[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u16[body->start + i]);
                 break;
             case MVM_ARRAY_U8:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u8[body->start + i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u8[body->start + i]);
                 break;
             case MVM_ARRAY_N64:
                 MVM_serialization_write_num(tc, writer, (MVMnum64)body->slots.n64[body->start + i]);

--- a/src/6model/reprs/MVMArray.c
+++ b/src/6model/reprs/MVMArray.c
@@ -1076,7 +1076,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
     MVMArrayBody     *body      = (MVMArrayBody *)data;
     MVMint64 i;
 
-    body->elems = MVM_serialization_read_varint(tc, reader);
+    body->elems = MVM_serialization_read_int(tc, reader);
     body->ssize = body->elems;
     if (body->ssize)
         body->slots.any = MVM_malloc(body->ssize * repr_data->elem_size);
@@ -1090,28 +1090,28 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
                 MVM_ASSIGN_REF(tc, &(root->header), body->slots.s[i], MVM_serialization_read_str(tc, reader));
                 break;
             case MVM_ARRAY_I64:
-                body->slots.i64[i] = MVM_serialization_read_varint(tc, reader);
+                body->slots.i64[i] = MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_I32:
-                body->slots.i32[i] = (MVMint32)MVM_serialization_read_varint(tc, reader);
+                body->slots.i32[i] = (MVMint32)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_I16:
-                body->slots.i16[i] = (MVMint16)MVM_serialization_read_varint(tc, reader);
+                body->slots.i16[i] = (MVMint16)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_I8:
-                body->slots.i8[i] = (MVMint8)MVM_serialization_read_varint(tc, reader);
+                body->slots.i8[i] = (MVMint8)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U64:
-                body->slots.i64[i] = MVM_serialization_read_varint(tc, reader);
+                body->slots.i64[i] = MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U32:
-                body->slots.i32[i] = (MVMuint32)MVM_serialization_read_varint(tc, reader);
+                body->slots.i32[i] = (MVMuint32)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U16:
-                body->slots.i16[i] = (MVMuint16)MVM_serialization_read_varint(tc, reader);
+                body->slots.i16[i] = (MVMuint16)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U8:
-                body->slots.i8[i] = (MVMuint8)MVM_serialization_read_varint(tc, reader);
+                body->slots.i8[i] = (MVMuint8)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_N64:
                 body->slots.n64[i] = MVM_serialization_read_num(tc, reader);

--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -292,7 +292,7 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
 
     /* Write out dimensions. */
     for (i = 0; i < repr_data->num_dimensions; i++)
-        MVM_serialization_write_varint(tc, writer, body->dimensions[i]);
+        MVM_serialization_write_int(tc, writer, body->dimensions[i]);
 
     /* Write out values. */
     flat_elems = flat_elements(repr_data->num_dimensions, body->dimensions);
@@ -305,28 +305,28 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
                 MVM_serialization_write_str(tc, writer, body->slots.s[i]);
                 break;
             case MVM_ARRAY_I64:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i64[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i64[i]);
                 break;
             case MVM_ARRAY_I32:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i32[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i32[i]);
                 break;
             case MVM_ARRAY_I16:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i16[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i16[i]);
                 break;
             case MVM_ARRAY_I8:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.i8[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.i8[i]);
                 break;
             case MVM_ARRAY_U64:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u64[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u64[i]);
                 break;
             case MVM_ARRAY_U32:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u32[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u32[i]);
                 break;
             case MVM_ARRAY_U16:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u16[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u16[i]);
                 break;
             case MVM_ARRAY_U8:
-                MVM_serialization_write_varint(tc, writer, (MVMint64)body->slots.u8[i]);
+                MVM_serialization_write_int(tc, writer, (MVMint64)body->slots.u8[i]);
                 break;
             case MVM_ARRAY_N64:
                 MVM_serialization_write_num(tc, writer, (MVMnum64)body->slots.n64[i]);
@@ -405,11 +405,11 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
 static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationWriter *writer) {
     MVMMultiDimArrayREPRData *repr_data = (MVMMultiDimArrayREPRData *)st->REPR_data;
     if (repr_data) {
-        MVM_serialization_write_varint(tc, writer, repr_data->num_dimensions);
+        MVM_serialization_write_int(tc, writer, repr_data->num_dimensions);
         MVM_serialization_write_ref(tc, writer, repr_data->elem_type);
     }
     else {
-        MVM_serialization_write_varint(tc, writer, 0);
+        MVM_serialization_write_int(tc, writer, 0);
     }
 }
 

--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -349,7 +349,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
 
     /* Read in dimensions. */
     for (i = 0; i < repr_data->num_dimensions; i++)
-        body->dimensions[i] = MVM_serialization_read_varint(tc, reader);
+        body->dimensions[i] = MVM_serialization_read_int(tc, reader);
 
     /* Allocate storage. */
     body->slots.any = MVM_fixed_size_alloc_zeroed(tc, tc->instance->fsa,
@@ -366,28 +366,28 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
                 MVM_ASSIGN_REF(tc, &(root->header), body->slots.s[i], MVM_serialization_read_str(tc, reader));
                 break;
             case MVM_ARRAY_I64:
-                body->slots.i64[i] = MVM_serialization_read_varint(tc, reader);
+                body->slots.i64[i] = MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_I32:
-                body->slots.i32[i] = (MVMint32)MVM_serialization_read_varint(tc, reader);
+                body->slots.i32[i] = (MVMint32)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_I16:
-                body->slots.i16[i] = (MVMint16)MVM_serialization_read_varint(tc, reader);
+                body->slots.i16[i] = (MVMint16)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_I8:
-                body->slots.i8[i] = (MVMint8)MVM_serialization_read_varint(tc, reader);
+                body->slots.i8[i] = (MVMint8)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U64:
-                body->slots.i64[i] = MVM_serialization_read_varint(tc, reader);
+                body->slots.i64[i] = MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U32:
-                body->slots.i32[i] = (MVMuint32)MVM_serialization_read_varint(tc, reader);
+                body->slots.i32[i] = (MVMuint32)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U16:
-                body->slots.i16[i] = (MVMuint16)MVM_serialization_read_varint(tc, reader);
+                body->slots.i16[i] = (MVMuint16)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_U8:
-                body->slots.i8[i] = (MVMuint8)MVM_serialization_read_varint(tc, reader);
+                body->slots.i8[i] = (MVMuint8)MVM_serialization_read_int(tc, reader);
                 break;
             case MVM_ARRAY_N64:
                 body->slots.n64[i] = MVM_serialization_read_num(tc, reader);
@@ -418,9 +418,9 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMint64 num_dims;
 
     if (reader->root.version >= 19) {
-        num_dims = MVM_serialization_read_varint(tc, reader);
-    } else {
         num_dims = MVM_serialization_read_int(tc, reader);
+    } else {
+        num_dims = MVM_serialization_read_int64(tc, reader);
     }
 
     if (num_dims > 0) {

--- a/src/6model/reprs/NFA.c
+++ b/src/6model/reprs/NFA.c
@@ -77,20 +77,20 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
     MVM_serialization_write_ref(tc, writer, body->fates);
 
     /* Write number of states. */
-    MVM_serialization_write_varint(tc, writer, body->num_states);
+    MVM_serialization_write_int(tc, writer, body->num_states);
 
     /* Write state edge list counts. */
     for (i = 0; i < body->num_states; i++)
-        MVM_serialization_write_varint(tc, writer, body->num_state_edges[i]);
+        MVM_serialization_write_int(tc, writer, body->num_state_edges[i]);
 
     /* Write state graph. */
     for (i = 0; i < body->num_states; i++) {
         for (j = 0; j < body->num_state_edges[i]; j++) {
-            MVM_serialization_write_varint(tc, writer, body->states[i][j].act);
-            MVM_serialization_write_varint(tc, writer, body->states[i][j].to);
+            MVM_serialization_write_int(tc, writer, body->states[i][j].act);
+            MVM_serialization_write_int(tc, writer, body->states[i][j].to);
             switch (body->states[i][j].act & 0xff) {
                 case MVM_NFA_EDGE_FATE:
-                    MVM_serialization_write_varint(tc, writer, body->states[i][j].arg.i);
+                    MVM_serialization_write_int(tc, writer, body->states[i][j].arg.i);
                     break;
                 case MVM_NFA_EDGE_CODEPOINT:
                 case MVM_NFA_EDGE_CODEPOINT_LL:
@@ -100,23 +100,23 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
                     MVMGrapheme32 g = body->states[i][j].arg.g;
                     if (g >= 0) {
                         /* Non-synthetic. */
-                        MVM_serialization_write_varint(tc, writer, g);
+                        MVM_serialization_write_int(tc, writer, g);
                     }
                     else {
                         /* Synthetic. Write the number of codepoints negated,
                          * and then each of the codepoints. */
                         MVMNFGSynthetic *si = MVM_nfg_get_synthetic_info(tc, g);
                         MVMint32 k;
-                        MVM_serialization_write_varint(tc, writer, -(si->num_combs + 1));
-                        MVM_serialization_write_varint(tc, writer, si->base);
+                        MVM_serialization_write_int(tc, writer, -(si->num_combs + 1));
+                        MVM_serialization_write_int(tc, writer, si->base);
                         for (k = 0; k < si->num_combs; k++)
-                            MVM_serialization_write_varint(tc, writer, si->combs[k]);
+                            MVM_serialization_write_int(tc, writer, si->combs[k]);
                     }
                     break;
                 }
                 case MVM_NFA_EDGE_CHARCLASS:
                 case MVM_NFA_EDGE_CHARCLASS_NEG:
-                    MVM_serialization_write_varint(tc, writer, body->states[i][j].arg.i);
+                    MVM_serialization_write_int(tc, writer, body->states[i][j].arg.i);
                     break;
                 case MVM_NFA_EDGE_CHARLIST:
                 case MVM_NFA_EDGE_CHARLIST_NEG:
@@ -131,8 +131,8 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
                 case MVM_NFA_EDGE_CHARRANGE_NEG:
                 case MVM_NFA_EDGE_CHARRANGE_M:
                 case MVM_NFA_EDGE_CHARRANGE_M_NEG: {
-                    MVM_serialization_write_varint(tc, writer, body->states[i][j].arg.uclc.lc);
-                    MVM_serialization_write_varint(tc, writer, body->states[i][j].arg.uclc.uc);
+                    MVM_serialization_write_int(tc, writer, body->states[i][j].arg.uclc.lc);
+                    MVM_serialization_write_int(tc, writer, body->states[i][j].arg.uclc.uc);
                     break;
                 }
             }

--- a/src/6model/reprs/NFA.c
+++ b/src/6model/reprs/NFA.c
@@ -149,13 +149,13 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
     body->fates = MVM_serialization_read_ref(tc, reader);
 
     /* Read number of states. */
-    body->num_states = MVM_serialization_read_varint(tc, reader);
+    body->num_states = MVM_serialization_read_int(tc, reader);
 
     if (body->num_states > 0) {
         /* Read state edge list counts. */
         body->num_state_edges = MVM_malloc(body->num_states * sizeof(MVMint64));
         for (i = 0; i < body->num_states; i++)
-            body->num_state_edges[i] = MVM_serialization_read_varint(tc, reader);
+            body->num_state_edges[i] = MVM_serialization_read_int(tc, reader);
 
         /* Read state graph. */
         body->states = MVM_malloc(body->num_states * sizeof(MVMNFAStateInfo *));
@@ -164,18 +164,18 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
             if (edges > 0)
                 body->states[i] = MVM_malloc(edges * sizeof(MVMNFAStateInfo));
             for (j = 0; j < edges; j++) {
-                body->states[i][j].act = MVM_serialization_read_varint(tc, reader);
-                body->states[i][j].to = MVM_serialization_read_varint(tc, reader);
+                body->states[i][j].act = MVM_serialization_read_int(tc, reader);
+                body->states[i][j].to = MVM_serialization_read_int(tc, reader);
                 switch (body->states[i][j].act & 0xff) {
                     case MVM_NFA_EDGE_FATE:
-                        body->states[i][j].arg.i = MVM_serialization_read_varint(tc, reader);
+                        body->states[i][j].arg.i = MVM_serialization_read_int(tc, reader);
                         break;
                     case MVM_NFA_EDGE_CODEPOINT:
                     case MVM_NFA_EDGE_CODEPOINT_LL:
                     case MVM_NFA_EDGE_CODEPOINT_NEG:
                     case MVM_NFA_EDGE_CODEPOINT_M:
                     case MVM_NFA_EDGE_CODEPOINT_M_NEG: {
-                        MVMint64 cp_or_synth_count = MVM_serialization_read_varint(tc, reader);
+                        MVMint64 cp_or_synth_count = MVM_serialization_read_int(tc, reader);
                         if (cp_or_synth_count >= 0) {
                             body->states[i][j].arg.g = (MVMGrapheme32)cp_or_synth_count;
                         }
@@ -184,7 +184,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
                             MVMCodepoint *codes = MVM_malloc(num_codes * sizeof(MVMCodepoint));
                             MVMint32 k;
                             for (k = 0; k < num_codes; k++)
-                                codes[k] = (MVMCodepoint)MVM_serialization_read_varint(tc, reader);
+                                codes[k] = (MVMCodepoint)MVM_serialization_read_int(tc, reader);
                             body->states[i][j].arg.g = MVM_nfg_codes_to_grapheme(tc, codes, num_codes);
                             MVM_free(codes);
                         }
@@ -192,7 +192,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
                     }
                     case MVM_NFA_EDGE_CHARCLASS:
                     case MVM_NFA_EDGE_CHARCLASS_NEG:
-                        body->states[i][j].arg.i = MVM_serialization_read_varint(tc, reader);
+                        body->states[i][j].arg.i = MVM_serialization_read_int(tc, reader);
                         break;
                     case MVM_NFA_EDGE_CHARLIST:
                     case MVM_NFA_EDGE_CHARLIST_NEG:
@@ -207,8 +207,8 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
                     case MVM_NFA_EDGE_CHARRANGE_NEG:
                     case MVM_NFA_EDGE_CHARRANGE_M:
                     case MVM_NFA_EDGE_CHARRANGE_M_NEG: {
-                        body->states[i][j].arg.uclc.lc = MVM_serialization_read_varint(tc, reader);
-                        body->states[i][j].arg.uclc.uc = MVM_serialization_read_varint(tc, reader);
+                        body->states[i][j].arg.uclc.lc = MVM_serialization_read_int(tc, reader);
+                        body->states[i][j].arg.uclc.uc = MVM_serialization_read_int(tc, reader);
                         break;
                     }
                 }

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -43,8 +43,8 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
 /* Deserializes REPR data. */
 static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
     MVMNativeRefREPRData *repr_data = MVM_malloc(sizeof(MVMNativeRefREPRData));
-    repr_data->primitive_type = MVM_serialization_read_varint(tc, reader);
-    repr_data->ref_kind       = MVM_serialization_read_varint(tc, reader);
+    repr_data->primitive_type = MVM_serialization_read_int(tc, reader);
+    repr_data->ref_kind       = MVM_serialization_read_int(tc, reader);
     st->REPR_data = repr_data;
 }
 

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -31,12 +31,12 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationWriter *writer) {
     MVMNativeRefREPRData *repr_data = (MVMNativeRefREPRData *)st->REPR_data;
     if (repr_data) {
-        MVM_serialization_write_varint(tc, writer, repr_data->primitive_type);
-        MVM_serialization_write_varint(tc, writer, repr_data->ref_kind);
+        MVM_serialization_write_int(tc, writer, repr_data->primitive_type);
+        MVM_serialization_write_int(tc, writer, repr_data->ref_kind);
     }
     else {
-        MVM_serialization_write_varint(tc, writer, 0);
-        MVM_serialization_write_varint(tc, writer, 0);
+        MVM_serialization_write_int(tc, writer, 0);
+        MVM_serialization_write_int(tc, writer, 0);
     }
 }
 

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -215,9 +215,9 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMSerializationReader *reader) {
     MVMP6bigintBody *body = (MVMP6bigintBody *)data;
 
-    if (MVM_serialization_read_varint(tc, reader) == 1) { /* Is it small int? */
+    if (MVM_serialization_read_int(tc, reader) == 1) { /* Is it small int? */
         body->u.smallint.flag = MVM_BIGINT_32_FLAG;
-        body->u.smallint.value = MVM_serialization_read_varint(tc, reader);
+        body->u.smallint.value = MVM_serialization_read_int(tc, reader);
     } else {  /* big int */
         char *buf = MVM_string_ascii_encode(tc, MVM_serialization_read_str(tc, reader), NULL, 0);
         body->u.bigint = MVM_malloc(sizeof(mp_int));

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -195,14 +195,14 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
         str = MVM_string_ascii_decode(tc, tc->instance->VMString, buf, len - 1);
 
         /* write the "is small" flag */
-        MVM_serialization_write_varint(tc, writer, 0);
+        MVM_serialization_write_int(tc, writer, 0);
         MVM_serialization_write_str(tc, writer, str);
         MVM_free(buf);
     }
     else {
         /* write the "is small" flag */
-        MVM_serialization_write_varint(tc, writer, 1);
-        MVM_serialization_write_varint(tc, writer, body->u.smallint.value);
+        MVM_serialization_write_int(tc, writer, 1);
+        MVM_serialization_write_int(tc, writer, body->u.smallint.value);
     }
 }
 

--- a/src/6model/reprs/P6int.c
+++ b/src/6model/reprs/P6int.c
@@ -167,8 +167,8 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 /* Serializes the REPR data. */
 static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationWriter *writer) {
     MVMP6intREPRData *repr_data = (MVMP6intREPRData *)st->REPR_data;
-    MVM_serialization_write_varint(tc, writer, repr_data->bits);
-    MVM_serialization_write_varint(tc, writer, repr_data->is_unsigned);
+    MVM_serialization_write_int(tc, writer, repr_data->bits);
+    MVM_serialization_write_int(tc, writer, repr_data->is_unsigned);
 }
 
 /* Deserializes representation data. */
@@ -193,7 +193,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
 }
 
 static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerializationWriter *writer) {
-    MVM_serialization_write_varint(tc, writer, get_int(tc, st, NULL, data));
+    MVM_serialization_write_int(tc, writer, get_int(tc, st, NULL, data));
 }
 
 /* Initializes the representation. */

--- a/src/6model/reprs/P6int.c
+++ b/src/6model/reprs/P6int.c
@@ -176,8 +176,8 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMP6intREPRData *repr_data = (MVMP6intREPRData *)MVM_malloc(sizeof(MVMP6intREPRData));
 
 
-    repr_data->bits        = MVM_serialization_read_varint(tc, reader);
-    repr_data->is_unsigned = MVM_serialization_read_varint(tc, reader);
+    repr_data->bits        = MVM_serialization_read_int(tc, reader);
+    repr_data->is_unsigned = MVM_serialization_read_int(tc, reader);
 
     if (repr_data->bits !=  1 && repr_data->bits !=  2 && repr_data->bits !=  4 && repr_data->bits != 8
      && repr_data->bits != 16 && repr_data->bits != 32 && repr_data->bits != 64)
@@ -189,7 +189,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
 }
 
 static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMSerializationReader *reader) {
-    set_int(tc, st, root, data, MVM_serialization_read_varint(tc, reader));
+    set_int(tc, st, root, data, MVM_serialization_read_int(tc, reader));
 }
 
 static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerializationWriter *writer) {

--- a/src/6model/reprs/P6num.c
+++ b/src/6model/reprs/P6num.c
@@ -118,7 +118,7 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 /* Serializes the REPR data. */
 static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationWriter *writer) {
     MVMP6numREPRData *repr_data = (MVMP6numREPRData *)st->REPR_data;
-    MVM_serialization_write_varint(tc, writer, repr_data->bits);
+    MVM_serialization_write_int(tc, writer, repr_data->bits);
 }
 
 /* Deserializes representation data. */

--- a/src/6model/reprs/P6num.c
+++ b/src/6model/reprs/P6num.c
@@ -126,7 +126,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMP6numREPRData *repr_data = (MVMP6numREPRData *)MVM_malloc(sizeof(MVMP6numREPRData));
 
 
-    repr_data->bits        = MVM_serialization_read_varint(tc, reader);
+    repr_data->bits        = MVM_serialization_read_int(tc, reader);
 
     if (repr_data->bits !=  1 && repr_data->bits !=  2 && repr_data->bits !=  4 && repr_data->bits != 8
      && repr_data->bits != 16 && repr_data->bits != 32 && repr_data->bits != 64)

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -890,58 +890,58 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
         MVM_exception_throw_adhoc(tc,
             "Representation must be composed before it can be serialized");
 
-    MVM_serialization_write_varint(tc, writer, repr_data->num_attributes);
+    MVM_serialization_write_int(tc, writer, repr_data->num_attributes);
 
     for (i = 0; i < repr_data->num_attributes; i++) {
-        MVM_serialization_write_varint(tc, writer, repr_data->flattened_stables[i] != NULL);
+        MVM_serialization_write_int(tc, writer, repr_data->flattened_stables[i] != NULL);
         if (repr_data->flattened_stables[i])
             MVM_serialization_write_stable_ref(tc, writer, repr_data->flattened_stables[i]);
     }
 
-    MVM_serialization_write_varint(tc, writer, repr_data->mi);
+    MVM_serialization_write_int(tc, writer, repr_data->mi);
 
     if (repr_data->auto_viv_values) {
-        MVM_serialization_write_varint(tc, writer, 1);
+        MVM_serialization_write_int(tc, writer, 1);
         for (i = 0; i < repr_data->num_attributes; i++)
             MVM_serialization_write_ref(tc, writer, repr_data->auto_viv_values[i]);
     }
     else {
-        MVM_serialization_write_varint(tc, writer, 0);
+        MVM_serialization_write_int(tc, writer, 0);
     }
 
-    MVM_serialization_write_varint(tc, writer, repr_data->unbox_int_slot);
-    MVM_serialization_write_varint(tc, writer, repr_data->unbox_num_slot);
-    MVM_serialization_write_varint(tc, writer, repr_data->unbox_str_slot);
+    MVM_serialization_write_int(tc, writer, repr_data->unbox_int_slot);
+    MVM_serialization_write_int(tc, writer, repr_data->unbox_num_slot);
+    MVM_serialization_write_int(tc, writer, repr_data->unbox_str_slot);
 
     if (repr_data->unbox_slots) {
-        MVM_serialization_write_varint(tc, writer, 1);
+        MVM_serialization_write_int(tc, writer, 1);
         for (i = 0; i < repr_data->num_attributes; i++) {
-            MVM_serialization_write_varint(tc, writer, repr_data->unbox_slots[i].repr_id);
-            MVM_serialization_write_varint(tc, writer, repr_data->unbox_slots[i].slot);
+            MVM_serialization_write_int(tc, writer, repr_data->unbox_slots[i].repr_id);
+            MVM_serialization_write_int(tc, writer, repr_data->unbox_slots[i].slot);
         }
     }
     else {
-        MVM_serialization_write_varint(tc, writer, 0);
+        MVM_serialization_write_int(tc, writer, 0);
     }
 
     i = 0;
     while (repr_data->name_to_index_mapping[i].class_key)
         i++;
     num_classes = i;
-    MVM_serialization_write_varint(tc, writer, num_classes);
+    MVM_serialization_write_int(tc, writer, num_classes);
     for (i = 0; i < num_classes; i++) {
         const MVMuint32 num_attrs = repr_data->name_to_index_mapping[i].num_attrs;
         MVMuint32 j;
         MVM_serialization_write_ref(tc, writer, repr_data->name_to_index_mapping[i].class_key);
-        MVM_serialization_write_varint(tc, writer, num_attrs);
+        MVM_serialization_write_int(tc, writer, num_attrs);
         for (j = 0; j < num_attrs; j++) {
             MVM_serialization_write_str(tc, writer, repr_data->name_to_index_mapping[i].names[j]);
-            MVM_serialization_write_varint(tc, writer, repr_data->name_to_index_mapping[i].slots[j]);
+            MVM_serialization_write_int(tc, writer, repr_data->name_to_index_mapping[i].slots[j]);
         }
     }
 
-    MVM_serialization_write_varint(tc, writer, repr_data->pos_del_slot);
-    MVM_serialization_write_varint(tc, writer, repr_data->ass_del_slot);
+    MVM_serialization_write_int(tc, writer, repr_data->pos_del_slot);
+    MVM_serialization_write_int(tc, writer, repr_data->ass_del_slot);
 }
 
 /* Deserializes representation data. */

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -856,11 +856,11 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
 static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
     /* To calculate size, we need number of attributes and to know about
      * anything flattend in. */
-    MVMint64  num_attributes = MVM_serialization_read_varint(tc, reader);
+    MVMint64  num_attributes = MVM_serialization_read_int(tc, reader);
     MVMuint32 cur_offset = sizeof(MVMP6opaque);
     MVMint64  i;
     for (i = 0; i < num_attributes; i++) {
-        if (MVM_serialization_read_varint(tc, reader)) {
+        if (MVM_serialization_read_int(tc, reader)) {
             MVMSTable *st = MVM_serialization_read_stable_ref(tc, reader);
             const MVMStorageSpec *ss = st->REPR->get_storage_spec(tc, st);
             if (ss->inlineable) {
@@ -951,20 +951,20 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
 
     MVMP6opaqueREPRData *repr_data = MVM_malloc(sizeof(MVMP6opaqueREPRData));
 
-    repr_data->num_attributes = (MVMuint16)MVM_serialization_read_varint(tc, reader);
+    repr_data->num_attributes = (MVMuint16)MVM_serialization_read_int(tc, reader);
 
     repr_data->flattened_stables = (MVMSTable **)MVM_malloc(P6OMAX(repr_data->num_attributes, 1) * sizeof(MVMSTable *));
     for (i = 0; i < repr_data->num_attributes; i++)
-        if (MVM_serialization_read_varint(tc, reader)) {
+        if (MVM_serialization_read_int(tc, reader)) {
             MVM_ASSIGN_REF(tc, &(st->header), repr_data->flattened_stables[i], MVM_serialization_read_stable_ref(tc, reader));
         }
         else {
             repr_data->flattened_stables[i] = NULL;
         }
 
-    repr_data->mi = MVM_serialization_read_varint(tc, reader);
+    repr_data->mi = MVM_serialization_read_int(tc, reader);
 
-    if (MVM_serialization_read_varint(tc, reader)) {
+    if (MVM_serialization_read_int(tc, reader)) {
         repr_data->auto_viv_values = (MVMObject **)MVM_malloc(P6OMAX(repr_data->num_attributes, 1) * sizeof(MVMObject *));
         for (i = 0; i < repr_data->num_attributes; i++)
             MVM_ASSIGN_REF(tc, &(st->header), repr_data->auto_viv_values[i], MVM_serialization_read_ref(tc, reader));
@@ -972,21 +972,21 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
         repr_data->auto_viv_values = NULL;
     }
 
-    repr_data->unbox_int_slot = MVM_serialization_read_varint(tc, reader);
-    repr_data->unbox_num_slot = MVM_serialization_read_varint(tc, reader);
-    repr_data->unbox_str_slot = MVM_serialization_read_varint(tc, reader);
+    repr_data->unbox_int_slot = MVM_serialization_read_int(tc, reader);
+    repr_data->unbox_num_slot = MVM_serialization_read_int(tc, reader);
+    repr_data->unbox_str_slot = MVM_serialization_read_int(tc, reader);
 
-    if (MVM_serialization_read_varint(tc, reader)) {
+    if (MVM_serialization_read_int(tc, reader)) {
         repr_data->unbox_slots = (MVMP6opaqueBoxedTypeMap *)MVM_malloc(P6OMAX(repr_data->num_attributes, 1) * sizeof(MVMP6opaqueBoxedTypeMap));
         for (i = 0; i < repr_data->num_attributes; i++) {
-            repr_data->unbox_slots[i].repr_id = MVM_serialization_read_varint(tc, reader);
-            repr_data->unbox_slots[i].slot = MVM_serialization_read_varint(tc, reader);
+            repr_data->unbox_slots[i].repr_id = MVM_serialization_read_int(tc, reader);
+            repr_data->unbox_slots[i].slot = MVM_serialization_read_int(tc, reader);
         }
     } else {
         repr_data->unbox_slots = NULL;
     }
 
-    num_classes = (MVMuint16)MVM_serialization_read_varint(tc, reader);
+    num_classes = (MVMuint16)MVM_serialization_read_int(tc, reader);
     repr_data->name_to_index_mapping = (MVMP6opaqueNameMap *)MVM_malloc((num_classes + 1) * sizeof(MVMP6opaqueNameMap));
     for (i = 0; i < num_classes; i++) {
         MVMint32 num_attrs = 0;
@@ -994,14 +994,14 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
         MVM_ASSIGN_REF(tc, &(st->header), repr_data->name_to_index_mapping[i].class_key,
             MVM_serialization_read_ref(tc, reader));
 
-        num_attrs = MVM_serialization_read_varint(tc, reader);
+        num_attrs = MVM_serialization_read_int(tc, reader);
         repr_data->name_to_index_mapping[i].names = (MVMString **)MVM_malloc(P6OMAX(num_attrs, 1) * sizeof(MVMString *));
         repr_data->name_to_index_mapping[i].slots = (MVMuint16 *)MVM_malloc(P6OMAX(num_attrs, 1) * sizeof(MVMuint16));
         for (j = 0; j < num_attrs; j++) {
             MVM_ASSIGN_REF(tc, &(st->header), repr_data->name_to_index_mapping[i].names[j],
                 MVM_serialization_read_str(tc, reader));
 
-            repr_data->name_to_index_mapping[i].slots[j] = (MVMuint16)MVM_serialization_read_varint(tc, reader);
+            repr_data->name_to_index_mapping[i].slots[j] = (MVMuint16)MVM_serialization_read_int(tc, reader);
         }
 
         repr_data->name_to_index_mapping[i].num_attrs = num_attrs;
@@ -1010,8 +1010,8 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     /* set the last one to be NULL */
     repr_data->name_to_index_mapping[i].class_key = NULL;
 
-    repr_data->pos_del_slot = (MVMint16)MVM_serialization_read_varint(tc, reader);
-    repr_data->ass_del_slot = (MVMint16)MVM_serialization_read_varint(tc, reader);
+    repr_data->pos_del_slot = (MVMint16)MVM_serialization_read_int(tc, reader);
+    repr_data->ass_del_slot = (MVMint16)MVM_serialization_read_int(tc, reader);
 
     /* Re-calculate the remaining info, which is platform specific or
      * derived information. */

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -332,18 +332,18 @@ void MVM_serialization_write_cstr(MVMThreadContext *tc, MVMSerializationWriter *
     else
         len = 0;
     if (len) {
-        MVM_serialization_write_varint(tc, writer, len);
+        MVM_serialization_write_int(tc, writer, len);
         expand_storage_if_needed(tc, writer, len);
         memcpy(*(writer->cur_write_buffer) + *(writer->cur_write_offset), string, len);
         *(writer->cur_write_offset) += len;
     } else {
-        MVM_serialization_write_varint(tc, writer, 0);
+        MVM_serialization_write_int(tc, writer, 0);
     }
 }
 
 /* Writing function for variable sized integers. Writes out a 64 bit value
    using between 1 and 9 bytes. */
-void MVM_serialization_write_varint(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value) {
+void MVM_serialization_write_int(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value) {
     MVMuint8 storage_needed;
     char *buffer;
     size_t offset;
@@ -480,7 +480,7 @@ static void write_array_var(MVMThreadContext *tc, MVMSerializationWriter *writer
     MVMint32 i;
 
     /* Write out element count. */
-    MVM_serialization_write_varint(tc, writer, elems);
+    MVM_serialization_write_int(tc, writer, elems);
 
     /* Write elements. */
     for (i = 0; i < elems; i++)
@@ -493,11 +493,11 @@ static void write_array_int(MVMThreadContext *tc, MVMSerializationWriter *writer
     MVMint32 i;
 
     /* Write out element count. */
-    MVM_serialization_write_varint(tc, writer, elems);
+    MVM_serialization_write_int(tc, writer, elems);
 
     /* Write elements. */
     for (i = 0; i < elems; i++)
-        MVM_serialization_write_varint(tc, writer, MVM_repr_at_pos_i(tc, arr, i));
+        MVM_serialization_write_int(tc, writer, MVM_repr_at_pos_i(tc, arr, i));
 }
 
 /* Writes an array where each item is a MVMString. */
@@ -727,7 +727,7 @@ void MVM_serialization_write_ref(MVMThreadContext *tc, MVMSerializationWriter *w
             /* Nothing to do for these. */
             break;
         case REFVAR_VM_INT:
-            MVM_serialization_write_varint(tc, writer, MVM_repr_get_int(tc, ref));
+            MVM_serialization_write_int(tc, writer, MVM_repr_get_int(tc, ref));
             break;
         case REFVAR_VM_NUM:
             MVM_serialization_write_num(tc, writer, MVM_repr_get_num(tc, ref));
@@ -988,7 +988,7 @@ static void serialize_stable(MVMThreadContext *tc, MVMSerializationWriter *write
     MVM_serialization_write_ref(tc, writer, st->method_cache);
 
     /* Type check cache. */
-    MVM_serialization_write_varint(tc, writer, st->type_check_cache_length);
+    MVM_serialization_write_int(tc, writer, st->type_check_cache_length);
     for (i = 0; i < st->type_check_cache_length; i++)
         MVM_serialization_write_ref(tc, writer, st->type_check_cache[i]);
 
@@ -1052,13 +1052,13 @@ static void serialize_stable(MVMThreadContext *tc, MVMSerializationWriter *write
     if (st->invocation_spec) {
         MVM_serialization_write_ref(tc, writer, st->invocation_spec->class_handle);
         MVM_serialization_write_str(tc, writer, st->invocation_spec->attr_name);
-        MVM_serialization_write_varint(tc, writer, st->invocation_spec->hint);
+        MVM_serialization_write_int(tc, writer, st->invocation_spec->hint);
         MVM_serialization_write_ref(tc, writer, st->invocation_spec->invocation_handler);
         MVM_serialization_write_ref(tc, writer, st->invocation_spec->md_class_handle);
         MVM_serialization_write_str(tc, writer, st->invocation_spec->md_cache_attr_name);
-        MVM_serialization_write_varint(tc, writer, st->invocation_spec->md_cache_hint);
+        MVM_serialization_write_int(tc, writer, st->invocation_spec->md_cache_hint);
         MVM_serialization_write_str(tc, writer, st->invocation_spec->md_valid_attr_name);
-        MVM_serialization_write_varint(tc, writer, st->invocation_spec->md_valid_hint);
+        MVM_serialization_write_int(tc, writer, st->invocation_spec->md_valid_hint);
     }
 
     /* HLL owner. */
@@ -1096,7 +1096,7 @@ static void serialize_stable(MVMThreadContext *tc, MVMSerializationWriter *write
          * time so we can check if an intern table entry is needed. */
         num_params = MVM_repr_elems(tc, params);
         /* This typically seems to have values between 1 and 3: */
-        MVM_serialization_write_varint(tc, writer, num_params);
+        MVM_serialization_write_int(tc, writer, num_params);
         for (i = 0; i < num_params; i++) {
             /* Save where we were before writing this parameter. */
             size_t pre_write_mark = *(writer->cur_write_offset);
@@ -1230,7 +1230,7 @@ static void serialize_context(MVMThreadContext *tc, MVMSerializationWriter *writ
     writer->cur_write_limit  = &(writer->contexts_data_alloc);
 
     /* Serialize lexicals. */
-    MVM_serialization_write_varint(tc, writer, sf->body.num_lexicals);
+    MVM_serialization_write_int(tc, writer, sf->body.num_lexicals);
     for (i = 0; i < sf->body.num_lexicals; i++) {
         MVM_serialization_write_str(tc, writer, lexnames[i]->key);
         switch (sf->body.lexical_types[i]) {
@@ -1239,7 +1239,7 @@ static void serialize_context(MVMThreadContext *tc, MVMSerializationWriter *writ
             case MVM_reg_int32:
                 MVM_exception_throw_adhoc(tc, "unsupported lexical type");
             case MVM_reg_int64:
-                MVM_serialization_write_varint(tc, writer, frame->env[i].i64);
+                MVM_serialization_write_int(tc, writer, frame->env[i].i64);
                 break;
             case MVM_reg_num32:
                 MVM_exception_throw_adhoc(tc, "unsupported lexical type");

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -211,14 +211,6 @@ static void * base64_decode(const char *s, size_t *data_len)
  * Serialization (writing related)
  * ***************************************************************************/
 
-/* Writes an int64 into a buffer. */
-static void write_int64(char *buffer, size_t offset, MVMint64 value) {
-    memcpy(buffer + offset, &value, 8);
-#ifdef MVM_BIGENDIAN
-    switch_endian(buffer + offset, 8);
-#endif
-}
-
 /* Writes an int32 into a buffer. */
 static void write_int32(char *buffer, size_t offset, MVMint32 value) {
     memcpy(buffer + offset, &value, 4);

--- a/src/6model/serialization.h
+++ b/src/6model/serialization.h
@@ -181,8 +181,8 @@ MVMObject * MVM_serialization_demand_code(MVMThreadContext *tc, MVMSerialization
 void MVM_serialization_finish_deserialize_method_cache(MVMThreadContext *tc, MVMSTable *st);
 
 /* Reader/writer functions. */
+MVMint64 MVM_serialization_read_int64(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMint64 MVM_serialization_read_int(MVMThreadContext *tc, MVMSerializationReader *reader);
-MVMint64 MVM_serialization_read_varint(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMnum64 MVM_serialization_read_num(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMString * MVM_serialization_read_str(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMObject * MVM_serialization_read_ref(MVMThreadContext *tc, MVMSerializationReader *reader);

--- a/src/6model/serialization.h
+++ b/src/6model/serialization.h
@@ -188,7 +188,7 @@ MVMString * MVM_serialization_read_str(MVMThreadContext *tc, MVMSerializationRea
 MVMObject * MVM_serialization_read_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMSTable * MVM_serialization_read_stable_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 void MVM_serialization_force_stable(MVMThreadContext *tc, MVMSerializationReader *reader, MVMSTable *st);
-void MVM_serialization_write_varint(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value);
+void MVM_serialization_write_int(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value);
 void MVM_serialization_write_num(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMnum64 value);
 void MVM_serialization_write_str(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMString *value);
 void MVM_serialization_write_ref(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMObject *ref);

--- a/src/6model/serialization.h
+++ b/src/6model/serialization.h
@@ -188,7 +188,6 @@ MVMString * MVM_serialization_read_str(MVMThreadContext *tc, MVMSerializationRea
 MVMObject * MVM_serialization_read_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMSTable * MVM_serialization_read_stable_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 void MVM_serialization_force_stable(MVMThreadContext *tc, MVMSerializationReader *reader, MVMSTable *st);
-void MVM_serialization_write_int(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value);
 void MVM_serialization_write_varint(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value);
 void MVM_serialization_write_num(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMnum64 value);
 void MVM_serialization_write_str(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMString *value);


### PR DESCRIPTION
1.  Change the remaining serialization of int to varint.
     This reduces rakudo core setting size about 11kb.
2.  Rename MVM_serialization_read_varint back to MVM_serialization_read_int.
     The old MVM_serialization_read_int function will be removed after next nqp bootstrap.