### PR TITLE
Fix temp root stack underflow with exceptions in NC callbacks

### DIFF
--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -315,27 +315,27 @@ static char callback_handler(DCCallback *cb, DCArgs *cb_args, DCValue *cb_result
         MVMCompUnit **backup_interp_cu          = tc->interp_cu;
         MVMFrame *backup_cur_frame              = MVM_frame_force_to_heap(tc, tc->cur_frame);
         MVMFrame *backup_thread_entry_frame     = tc->thread_entry_frame;
-        MVMuint32 backup_mark                   = MVM_gc_root_temp_mark(tc);
-        jmp_buf backup_interp_jump;
-        memcpy(backup_interp_jump, tc->interp_jump, sizeof(jmp_buf));
-
-        tc->cur_frame->return_value = &res;
-        tc->cur_frame->return_type  = MVM_RETURN_OBJ;
         MVMROOT(tc, backup_cur_frame, {
         MVMROOT(tc, backup_thread_entry_frame, {
-            MVM_interp_run(tc, callback_invoke, &cid);
-        });
-        });
+            MVMuint32 backup_mark                   = MVM_gc_root_temp_mark(tc);
+            jmp_buf backup_interp_jump;
+            memcpy(backup_interp_jump, tc->interp_jump, sizeof(jmp_buf));
 
-        tc->interp_cur_op         = backup_interp_cur_op;
-        tc->interp_bytecode_start = backup_interp_bytecode_start;
-        tc->interp_reg_base       = backup_interp_reg_base;
-        tc->interp_cu             = backup_interp_cu;
-        tc->cur_frame             = backup_cur_frame;
-        tc->current_frame_nr      = backup_cur_frame->sequence_nr;
-        tc->thread_entry_frame    = backup_thread_entry_frame;
-        memcpy(tc->interp_jump, backup_interp_jump, sizeof(jmp_buf));
-        MVM_gc_root_temp_mark_reset(tc, backup_mark);
+            tc->cur_frame->return_value = &res;
+            tc->cur_frame->return_type  = MVM_RETURN_OBJ;
+            MVM_interp_run(tc, callback_invoke, &cid);
+
+            tc->interp_cur_op         = backup_interp_cur_op;
+            tc->interp_bytecode_start = backup_interp_bytecode_start;
+            tc->interp_reg_base       = backup_interp_reg_base;
+            tc->interp_cu             = backup_interp_cu;
+            tc->cur_frame             = backup_cur_frame;
+            tc->current_frame_nr      = backup_cur_frame->sequence_nr;
+            tc->thread_entry_frame    = backup_thread_entry_frame;
+            memcpy(tc->interp_jump, backup_interp_jump, sizeof(jmp_buf));
+            MVM_gc_root_temp_mark_reset(tc, backup_mark);
+        });
+        });
     }
 
     /* Handle return value. */

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -307,27 +307,27 @@ static void callback_handler(ffi_cif *cif, void *cb_result, void **cb_args, void
         MVMCompUnit **backup_interp_cu          = tc->interp_cu;
         MVMFrame *backup_cur_frame              = MVM_frame_force_to_heap(tc, tc->cur_frame);
         MVMFrame *backup_thread_entry_frame     = tc->thread_entry_frame;
-        MVMuint32 backup_mark                   = MVM_gc_root_temp_mark(tc);
-        jmp_buf backup_interp_jump;
-        memcpy(backup_interp_jump, tc->interp_jump, sizeof(jmp_buf));
-
-        tc->cur_frame->return_value = &res;
-        tc->cur_frame->return_type  = MVM_RETURN_OBJ;
         MVMROOT(tc, backup_cur_frame, {
         MVMROOT(tc, backup_thread_entry_frame, {
-            MVM_interp_run(tc, callback_invoke, &cid);
-        });
-        });
+            MVMuint32 backup_mark                   = MVM_gc_root_temp_mark(tc);
+            jmp_buf backup_interp_jump;
+            memcpy(backup_interp_jump, tc->interp_jump, sizeof(jmp_buf));
 
-        tc->interp_cur_op         = backup_interp_cur_op;
-        tc->interp_bytecode_start = backup_interp_bytecode_start;
-        tc->interp_reg_base       = backup_interp_reg_base;
-        tc->interp_cu             = backup_interp_cu;
-        tc->cur_frame             = backup_cur_frame;
-        tc->current_frame_nr      = backup_cur_frame->sequence_nr;
-        tc->thread_entry_frame    = backup_thread_entry_frame;
-        memcpy(tc->interp_jump, backup_interp_jump, sizeof(jmp_buf));
-        MVM_gc_root_temp_mark_reset(tc, backup_mark);
+            tc->cur_frame->return_value = &res;
+            tc->cur_frame->return_type  = MVM_RETURN_OBJ;
+            MVM_interp_run(tc, callback_invoke, &cid);
+
+            tc->interp_cur_op         = backup_interp_cur_op;
+            tc->interp_bytecode_start = backup_interp_bytecode_start;
+            tc->interp_reg_base       = backup_interp_reg_base;
+            tc->interp_cu             = backup_interp_cu;
+            tc->cur_frame             = backup_cur_frame;
+            tc->current_frame_nr      = backup_cur_frame->sequence_nr;
+            tc->thread_entry_frame    = backup_thread_entry_frame;
+            memcpy(tc->interp_jump, backup_interp_jump, sizeof(jmp_buf));
+            MVM_gc_root_temp_mark_reset(tc, backup_mark);
+        });
+        });
     }
 
     /* Handle return value. */


### PR DESCRIPTION
MVM_gc_root_temp_mark marks the temporary root stack at its current height as
the limit for removing all roots. At this point all MVMROOTs have to be in
place. Otherwise a MVM_gc_root_temp_pop_all called by
MVM_exception_throw_adhoc_free_va will remove not only the temp roots installed
by the nested run loop, but also frame roots leading to a possible temp root
underflow later on.