### PR TITLE
Fix build without libtommath source

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -239,12 +239,8 @@ else {
 }
 
 if ($args{'has-libtommath'}) {
+    $defaults{-thirdparty}->{tom} = undef;
     unshift @{$config{usrlibs}}, 'tommath';
-
-    # only this objects are needed to build, if moar is linked together with
-    #  the libtommath library from the system
-    $defaults{-thirdparty}->{tom}->{objects} =
-        '3rdparty/libtommath/bn_mp_get_long.o 3rdparty/libtommath/bn_mp_set_long.o';
 }
 else {
     $config{cincludes} .= ' ' . $defaults{ccinc} . '3rdparty/libtommath';


### PR DESCRIPTION
Debian policy requires (as far as possible) to remove convenience copy of source code before build.

`libtommath` is available on Debian as [libtommath package](https://tracker.debian.org/pkg/libtommath), so `libtommath` source is removed from `moar/3rdparty` directory before build.

Unfortunately, `Configure.pl --has-libtommath` wants to create a `libtommath` archive:

```
Configuring 3rdparty libs .............................. OK

  3rdparty: 3rdparty/dyncall/dyncall/libdyncall_s.a
            3rdparty/dyncall/dyncallback/libdyncallback_s.a
            3rdparty/dyncall/dynload/libdynload_s.a
            3rdparty/libtommath/libtommath.a
            3rdparty/sha1/libsha1.a
            3rdparty/tinymt/libtinymt.a
```

And build fails with this message:

```
  make[2]: *** No rule to make target '3rdparty/libtommath/bn_mp_get_long.o', needed by '3rdparty/libtommath/libtommath.a'.  Stop.
  make[2]: Leaving directory '/home/domi/debian-dev/build-area/moarvm-2016.06+dfsg'
```

With this patch, the `libtommath` archive is no longer required and the build succeeds.

All the best

Dod
