### PR TITLE
fix sha1 op to work with null bytes

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -3088,17 +3088,18 @@ Computes the SHA-1 hash of string.
 
 */
 MVMString * MVM_sha1(MVMThreadContext *tc, MVMString *str) {
-    /* Grab the string as a C string. */
-    char *cstr = MVM_string_utf8_encode_C_string(tc, str);
+    /* Grab the string as UTF8 bytes. */
+    MVMuint64 output_size;
+    char *utf8_string = MVM_string_utf8_encode(tc, str, &output_size, 0);
 
     /* Compute its SHA-1 and encode it. */
     SHA1Context      context;
     char          output[80];
     SHA1Init(&context);
-    SHA1Update(&context, (unsigned char*)cstr, strlen(cstr));
+    SHA1Update(&context, (unsigned char*) utf8_string, (size_t) output_size);
     SHA1Final(&context, output);
 
     /* Free the C-MVMString and put result into a new MVMString. */
-    MVM_free(cstr);
+    MVM_free(utf8_string);
     return MVM_string_ascii_decode(tc, tc->instance->VMString, output, 40);
 }


### PR DESCRIPTION
Fixes MoarVM terminating on null bytes, as in:
```
david@X346:~/git/rakudo-bleed$ ./perl6-m -e'use nqp; say nqp::sha1("ab\x[0]c"); say nqp::sha1("ab\x[0]d"); '
DA23614E02469A0D7C7BD1BDAB5C9C474B1904DC
DA23614E02469A0D7C7BD1BDAB5C9C474B1904DC
david@X346:~/git/rakudo-bleed$ ./perl6-j -e'use nqp; say nqp::sha1("ab\x[0]c"); say nqp::sha1("ab\x[0]d"); '
DBDD4F85D8A56500AA5C9C8A0D456F96280C92E5
2876366FE4F4BC6D0B9D7FEC1D6F757B94AFD827
```
This fixes MoarVM to act like the JVM

This is a prerequisite for this PR https://github.com/rakudo/rakudo/pull/811