### PR TITLE
Remove keep_caller from MVMFrame

### DIFF
--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -605,7 +605,6 @@ void MVM_exception_throwobj(MVMThreadContext *tc, MVMuint8 mode, MVMObject *ex_o
     if (!ex->body.origin) {
         MVM_ASSIGN_REF(tc, &(ex->common.header), ex->body.origin, tc->cur_frame);
         tc->cur_frame->throw_address = *(tc->interp_cur_op);
-        tc->cur_frame->keep_caller   = 1;
     }
 
     run_handler(tc, lh, ex_obj, 0, NULL);
@@ -863,7 +862,6 @@ void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const
         if (tc->cur_frame) {
             ex->body.origin = tc->cur_frame;
             tc->cur_frame->throw_address = *(tc->interp_cur_op);
-            tc->cur_frame->keep_caller   = 1;
         }
         else {
             ex->body.origin = NULL;

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -802,14 +802,6 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
 
         /* Signal to the GC to ignore ->work */
         returner->tc = NULL;
-
-        /* Unless we need to keep the caller chain in place, clear it up. */
-        if (caller) {
-            if (!returner->keep_caller)
-                returner->caller = NULL;
-            else if (unwind)
-                caller->keep_caller = 1;
-        }
     }
 
     /* If it's a call stack frame, remove it from the stack. */
@@ -1760,7 +1752,6 @@ MVMObject * MVM_frame_context_wrapper(MVMThreadContext *tc, MVMFrame *f) {
         ctx = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTContext);
         MVM_ASSIGN_REF(tc, &(ctx->header), ((MVMContext *)ctx)->body.context, f);
     });
-    f->keep_caller = 1;
     return ctx;
 }
 

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -139,10 +139,6 @@ struct MVMFrame {
     MVMuint16 allocd_work;
     MVMuint16 allocd_env;
 
-    /* Flags that the caller chain should be kept in place after return or
-     * unwind; used to make sure we can get a backtrace after an exception. */
-    MVMuint8 keep_caller;
-
     /* Flags that the frame has been captured in a continuation, and as
      * such we should keep everything in place for multiple invocations. */
     MVMuint8 in_continuation;


### PR DESCRIPTION
Fixes some cases (RT #128803) where the backtraces would be abruptly
truncated due to an optimization introduced in cecf5729.
As suggested by @jnthn [1] the best solution is to simply revert the
optimization as it's not worth it anymore.

Please keep in mind that at the moment this change makes the spectest suite fail when doing the `t/spec/integration/error-reporting.rakudo.moar` file as it contains a test for the [RT #12745](https://rt.perl.org/Public/Bug/Display.html?id=127425).
This change obsoletes the [https://github.com/rakudo/rakudo/commit/67b6544e48](commit referenced in the ticket) and renders the test useless as @zoffixznet pointed out.

[1] http://irclog.perlgeek.de/moarvm/2016-08-17#i_13040630