### PR TITLE
Correctly calculate the work_size when the inlining is enabled.

### DIFF
--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -4,8 +4,18 @@
  * lexicals. */
 static void calculate_work_env_sizes(MVMThreadContext *tc, MVMStaticFrame *sf,
                                      MVMSpeshCandidate *c) {
-    c->work_size = (c->num_locals + sf->body.cu->body.max_callsite_size)
-        * sizeof(MVMRegister);
+    MVMuint32 max_callsite_size;
+    MVMint32 i;
+
+    max_callsite_size = sf->body.cu->body.max_callsite_size;
+
+    for (i = 0; i < c->num_inlines; i++) {
+        MVMuint32 cs = c->inlines[i].code->body.sf->body.cu->body.max_callsite_size;
+        if (cs > max_callsite_size)
+            max_callsite_size = cs;
+    }
+
+    c->work_size = (c->num_locals + max_callsite_size) * sizeof(MVMRegister);
     c->env_size = c->num_lexicals * sizeof(MVMRegister);
 }
 


### PR DESCRIPTION
Thanks to @jnthn for pinpointing the problem.

[RT#128705](https://rt.perl.org/Public/Bug/Display.html?id=128705)