### PR TITLE
Remove unused variables

### DIFF
--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -109,7 +109,6 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
         MVMint32 num_attrs        = MVM_repr_elems(tc, flat_list);
         MVMint32 info_alloc       = num_attrs == 0 ? 1 : num_attrs;
         MVMint32 cur_obj_attr     = 0;
-        MVMint32 cur_str_attr     = 0;
         MVMint32 cur_init_slot    = 0;
         MVMint32 i;
 

--- a/src/6model/reprs/MVMMultiCache.c
+++ b/src/6model/reprs/MVMMultiCache.c
@@ -153,7 +153,7 @@ MVMObject * MVM_multi_cache_add(MVMThreadContext *tc, MVMObject *cache_obj, MVMO
                        have_callsite, matched_args, unmatched_arg,
                        tweak_node, insert_node;
     size_t             new_size;
-    MVMMultiCacheNode *new_head, *old_head;
+    MVMMultiCacheNode *new_head;
     MVMObject        **new_results;
 
     /* Allocate a cache if needed. */

--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -345,7 +345,6 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
     MVMMultiDimArrayREPRData *repr_data = (MVMMultiDimArrayREPRData *)st->REPR_data;
     MVMMultiDimArrayBody     *body      = (MVMMultiDimArrayBody *)data;
     MVMint64 i, flat_elems;
-    size_t size;
 
     /* Read in dimensions. */
     for (i = 0; i < repr_data->num_dimensions; i++)

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2474,7 +2474,6 @@ static void deserialize_stable(MVMThreadContext *tc, MVMSerializationReader *rea
 
     /* Calculate location of STable's table row. */
     char *st_table_row = reader->root.stables_table + i * STABLES_TABLE_ENTRY_SIZE;
-    MVMString *hll_name;
     MVMuint8 flags;
     MVMuint8 mode;
 

--- a/src/core/fixedsizealloc.c
+++ b/src/core/fixedsizealloc.c
@@ -241,7 +241,6 @@ void MVM_fixed_size_free_at_safepoint(MVMThreadContext *tc, MVMFixedSizeAlloc *a
     if (bin < MVM_FSA_BINS) {
         /* Came from a bin; put into free list. */
         MVMFixedSizeAllocSizeClass     *bin_ptr = &(al->size_classes[bin]);
-        MVMFixedSizeAllocFreeListEntry *to_add  = (MVMFixedSizeAllocFreeListEntry *)to_free;
         if (MVM_instance_have_user_threads(tc)) {
             /* Multi-threaded; race to add it to the "free at next safe point"
              * list. */

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3165,7 +3165,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(ctxouter): {
-                MVMObject *this_ctx = GET_REG(cur_op, 2).o, *ctx;
+                MVMObject *this_ctx = GET_REG(cur_op, 2).o;
                 MVMFrame *frame;
                 if (!IS_CONCRETE(this_ctx) || REPR(this_ctx)->ID != MVM_REPR_ID_MVMContext) {
                     MVM_exception_throw_adhoc(tc, "ctxouter needs an MVMContext");
@@ -4099,7 +4099,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(ctxouterskipthunks): {
-                MVMObject *this_ctx = GET_REG(cur_op, 2).o, *ctx;
+                MVMObject *this_ctx = GET_REG(cur_op, 2).o;
                 MVMFrame *frame;
                 if (!IS_CONCRETE(this_ctx) || REPR(this_ctx)->ID != MVM_REPR_ID_MVMContext) {
                     MVM_exception_throw_adhoc(tc, "ctxouter needs an MVMContext");

--- a/src/core/validation.c
+++ b/src/core/validation.c
@@ -395,8 +395,6 @@ static void validate_operands(Validator *val) {
             break;
         }
         case MVM_OP_checkarity: {
-            MVMint64 count;
-
             validate_literal_operand(val, operands[0]);
 
             validate_literal_operand(val, operands[1]);

--- a/src/gc/orchestrate.c
+++ b/src/gc/orchestrate.c
@@ -272,7 +272,7 @@ void MVM_gc_mark_thread_unblocked(MVMThreadContext *tc) {
 }
 
 static MVMint32 is_full_collection(MVMThreadContext *tc) {
-    MVMuint64 percent_growth, threshold;
+    MVMuint64 percent_growth;
     size_t rss, promoted;
 
     /* If it's below the absolute minimum, quickly return. */

--- a/src/io/eventloop.c
+++ b/src/io/eventloop.c
@@ -45,9 +45,6 @@ static void async_handler(uv_async_t *handle) {
 /* Enters the event loop. */
 static void enter_loop(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *args) {
     uv_async_t   *async;
-    uv_prepare_t  prep;
-    uv_check_t    check;
-    int           r;
 
     /* Set up async handler so we can be woken up when there's new tasks. */
     async = MVM_malloc(sizeof(uv_async_t));

--- a/src/jit/emit_x64.dasc
+++ b/src/jit/emit_x64.dasc
@@ -1407,7 +1407,6 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitGraph *jg,
         MVMint16 obj = ins->operands[1].reg.orig;
         MVMint32 str_idx = ins->operands[2].lit_str_idx;
         MVMuint16 ss_idx = ins->operands[3].lit_i16;
-        MVMStaticFrame *sf = jg->sg->sf;
         | get_spesh_slot TMP1, ss_idx;
         | mov TMP2, WORK[obj];
         | mov TMP2, OBJECT:TMP2->st;

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -273,7 +273,6 @@ static void process_collectable(MVMThreadContext *tc, MVMHeapSnapshotState *ss,
 }
 static void process_gc_worklist(MVMThreadContext *tc, MVMHeapSnapshotState *ss, char *desc) {
     MVMCollectable **c_ptr;
-    MVMFrame *f;
     MVMuint16 ref_kind = desc
         ? MVM_SNAPSHOT_REF_KIND_STRING
         : MVM_SNAPSHOT_REF_KIND_UNKNOWN;
@@ -582,8 +581,6 @@ void MVM_profile_heap_add_collectable_rel_idx(MVMThreadContext *tc,
 
 /* Drives the overall process of recording a snapshot of the heap. */
 static void record_snapshot(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, MVMHeapSnapshot *hs) {
-    MVMuint64 perm_root_synth;
-
     /* Initialize state for taking a snapshot. */
     MVMHeapSnapshotState ss;
     memset(&ss, 0, sizeof(MVMHeapSnapshotState));

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -584,7 +584,7 @@ void MVM_profile_heap_add_collectable_rel_idx(MVMThreadContext *tc,
 static void record_snapshot(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, MVMHeapSnapshot *hs) {
     MVMuint64 perm_root_synth;
 
-    /* Iinitialize state for taking a snapshot. */
+    /* Initialize state for taking a snapshot. */
     MVMHeapSnapshotState ss;
     memset(&ss, 0, sizeof(MVMHeapSnapshotState));
     ss.col = col;

--- a/src/spesh/deopt.c
+++ b/src/spesh/deopt.c
@@ -74,7 +74,6 @@ static void uninline(MVMThreadContext *tc, MVMFrame *f, MVMSpeshCandidate *cand,
                 if (callee) {
                     /* Tweak the callee's caller to the uninlined frame, not
                      * the frame holding the inlinings. */
-                    MVMFrame *orig_caller = callee->caller;
                     MVM_ASSIGN_REF(tc, &(callee->header), callee->caller, uf);
 
                     /* Copy over the return location. */

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -247,7 +247,9 @@ static void optimize_exception_ops(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSp
         ins->operands[1].lit_i16 = st->size;
         ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot(tc, g, (MVMCollectable *)st);
     } else {
+        /*
         MVMSpeshFacts *target_facts;
+        */
 
         /* XXX This currently still causes problems. */
         return;

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -231,14 +231,11 @@ MVMString * MVM_string_utf8_c8_decode(MVMThreadContext *tc, const MVMObject *res
     MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
     MVMint32 count = 0;
     MVMCodepoint codepoint;
-    MVMint32 line_ending = 0;
     MVMint32 state = 0;
     MVMint32 bufsize = bytes;
     MVMGrapheme32 *buffer = MVM_malloc(sizeof(MVMGrapheme32) * bufsize);
     size_t orig_bytes;
     const char *orig_utf8, *last_accept_utf8;
-    MVMint32 line;
-    MVMint32 col;
     MVMint32 ready;
 
     /* Need to normalize to NFG as we decode. */


### PR DESCRIPTION
Remove as many unused variables as found by the `-Wunused-variable` GCC compiler flag as possible.  This doesn't remove all such warnings since the `copy_to()` function in `CUnion.c` is currently NYI, and the automatically generated output in `unicode.c` contains in one place an unused `size` variable.

I've tried to slice the commits as thinly as possible so that they can be cherry-picked if so desired.

If I can improve upon the patches please let me know and I'll resubmit the PR.