### PR TITLE
Remove parentheses warnings in gcc

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -266,7 +266,7 @@ our %COMPILERS = (
         ld => undef,
 
         ccmiscflags  => '-Wdeclaration-after-statement -Werror=declaration-after-statement',
-        ccwarnflags  => '',
+        ccwarnflags  => '-Wparentheses',
         ccoptiflags  => '-O%s -DNDEBUG',
         ccdebugflags => '-g%s',
         ccinstflags  => '-pg',

--- a/docs/japhb-todo.txt
+++ b/docs/japhb-todo.txt
@@ -2,7 +2,6 @@
   + Add a make realclean to cross compiler Makefile to nuke debug files
 * WIP: gcc warnings cleanup
   + WIP: -Wall
-    - DONE: -Wparentheses
     - DONE: -Wreturn-type
       . All are in src/6model/reprs.c, because of exception-throwing stubs; may
         have to explicitly ignore this using the second (granular) method of:

--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -361,7 +361,8 @@ static void describe_refs(MVMThreadContext *tc, MVMHeapSnapshotState *ss, MVMSTa
             if (body->spesh_candidates[i].sg) {
                 MVMCollectable **c_ptr;
                 MVM_spesh_graph_mark(tc, body->spesh_candidates[i].sg, ss->gcwl);
-                while (c_ptr = MVM_gc_worklist_get(tc, ss->gcwl)) {
+                c_ptr = MVM_gc_worklist_get(tc, ss->gcwl);
+                while (c_ptr) {
                     MVMCollectable *c = *c_ptr;
                     MVM_profile_heap_add_collectable_rel_const_cstr(tc, ss, c,
                         "Object held by spesh graph");

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -280,7 +280,8 @@ static void process_gc_worklist(MVMThreadContext *tc, MVMHeapSnapshotState *ss, 
     MVMuint16 ref_index = desc
         ? get_string_index(tc, ss, desc, STR_MODE_CONST)
         : 0;
-    while (c_ptr = MVM_gc_worklist_get(tc, ss->gcwl)) {
+    c_ptr = MVM_gc_worklist_get(tc, ss->gcwl);
+    while (c_ptr) {
         MVMCollectable *c = *c_ptr;
         if (c)
             add_reference(tc, ss, ref_kind, ref_index,

--- a/src/strings/normalize.c
+++ b/src/strings/normalize.c
@@ -479,7 +479,7 @@ static void canonical_composition(MVMThreadContext *tc, MVMNormalizer *n, MVMint
  * the handling of breaking around controls much earlier, so don't have to
  * consider that case. */
 static MVMint32 maybe_hangul(MVMCodepoint cp) {
-    return cp >= 0x1100 && cp < 0x1200 || cp >= 0xA960 && cp < 0xD7FC;
+    return (cp >= 0x1100 && cp < 0x1200) || (cp >= 0xA960 && cp < 0xD7FC);
 }
 static MVMint32 is_regional_indicator(MVMCodepoint cp) {
     /* U+1F1E6 REGIONAL INDICATOR SYMBOL LETTER A


### PR DESCRIPTION
This pull request removes the parentheses issues highlighted by the `-Wparentheses` gcc warning option (on by default in `-Wall`).  It adds the `-Wparentheses` option to the list of gcc warnings flags so that such issues don't repeat themselves in the future.

If I can improve upon the PR please let me know and I'll update it and resubmit.