### PR TITLE
Add error message for likely macOS build failure

### DIFF
--- a/build/probe.pm
+++ b/build/probe.pm
@@ -90,7 +90,9 @@ EOT
 
     print ::dots('    probing whether your compiler thinks that it is gcc');
     compile($config, 'try')
-        or die "Can't compile simple gcc probe, so something is badly wrong (if on linux, maybe you need something like 'sudo apt-get install build-essential')";
+        or die "Can't compile simple gcc probe, so something is badly wrong ("
+            . "if on linux, maybe you need something like 'sudo apt-get install build-essential'; "
+            . "if on macOS, maybe you need to install XCode and accept the XCode EULA)";
     my $gcc = !system './try';
     print $gcc ? "YES\n": "NO\n";
 


### PR DESCRIPTION
On a recent Rakudo install, I encountered a build failure that is due to this happening after an Xcode upgrade:

```shell
brent@ragnar ~/c/rakudo (nom)> gcc


Agreeing to the Xcode/iOS license requires admin privileges, please re-run as root via sudo.


brent@ragnar ~/c/rakudo (nom)>
```

So, in the pursuit of awesome error messages, this.
