### PR TITLE
Indicate encoding in HTML

### DIFF
--- a/tools/parse_coverage_report.p6
+++ b/tools/parse_coverage_report.p6
@@ -115,7 +115,7 @@ sub MAIN(Str $file where *.IO.e, Str $source where *.IO.e, Str $filename? = $sou
 
     sub make_html($sourcefile) {
         qq:to/TMPL/;
-            <html><head><title>coverage report for $source </title></head>
+            <html><head><meta charset="utf-8"><title>coverage report for $source </title></head>
             <style>
                 li   \{ white-space: pre }
                 li.c \{ background: #cfc }


### PR DESCRIPTION
So we don't get mojibake:
![m](https://cloud.githubusercontent.com/assets/5747918/18848221/6e5dd682-83fb-11e6-99a5-26b042129828.png)
