### PR TITLE
Fix 32 bit issue with rw args in NativeCall callbacks

### DIFF
--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -423,7 +423,7 @@ static char callback_handler(DCCallback *cb, DCArgs *cb_args, DCValue *cb_result
     MVMRegister r; \
     if ((arg_types[i] & MVM_NATIVECALL_ARG_RW_MASK) == MVM_NATIVECALL_ARG_RW) { \
         if (MVM_6model_container_is ## cont_X(tc, value)) { \
-            dc_type *rw = (dc_type *)MVM_malloc(sizeof(dc_type *)); \
+            dc_type *rw = (dc_type *)MVM_malloc(sizeof(dc_type)); \
             MVM_6model_container_de ## cont_X(tc, value, &r); \
             *rw = (dc_type)r. reg_slot ; \
             if (!free_rws) \


### PR DESCRIPTION
We allocated the size of a pointer for storing a 64 bit integer.
Reported by valgrind as Invalid write of size 4 in MVM_nativecall_invoke
(nativecall_dyncall.c:491)