### PR TITLE
Gracefully handle a 0 RSS reported by the Linux kernel

### DIFF
--- a/src/gc/orchestrate.c
+++ b/src/gc/orchestrate.c
@@ -281,7 +281,7 @@ static MVMint32 is_full_collection(MVMThreadContext *tc) {
         return 0;
 
     /* Otherwise, consider percentage of resident set size. */
-    if (uv_resident_set_memory(&rss) < 0)
+    if (uv_resident_set_memory(&rss) < 0 || rss == 0)
         rss = 50 * 1024 * 1024;
     percent_growth = (100 * promoted) / rss;
     return percent_growth >= MVM_GC_GEN2_THRESHOLD_PERCENT;


### PR DESCRIPTION
May fix a Floating point exception on armhf in case the reason is that
the Linux kernel just reports a 0 for RSS there.