### PR TITLE
Fix memory leaks in nqp_nfa_run.

### DIFF
--- a/src/6model/reprs/NFA.c
+++ b/src/6model/reprs/NFA.c
@@ -661,7 +661,7 @@ static MVMint64 * nqp_nfa_run(MVMThreadContext *tc, MVMNFABody *nfa, MVMString *
                             if (((act == MVM_NFA_EDGE_CODEPOINT_M)     && (ga == gb))
                              || ((act == MVM_NFA_EDGE_CODEPOINT_M_NEG) && (ga != gb)))
                                 nextst[numnext++] = to;
-
+                            MVM_unicode_normalizer_cleanup(tc, &norm);
                             continue;
                         }
                         case MVM_NFA_EDGE_CODEPOINT_IM:
@@ -677,6 +677,7 @@ static MVMint64 * nqp_nfa_run(MVMThreadContext *tc, MVMNFABody *nfa, MVMString *
                             MVM_unicode_normalizer_eof(tc, &norm);
                             if (!ready)
                                 uc_arg = MVM_unicode_normalizer_get_grapheme(tc, &norm);
+                            MVM_unicode_normalizer_cleanup(tc, &norm);
 
                             MVM_unicode_normalizer_init(tc, &norm, MVM_NORMALIZE_NFD);
                             ready = MVM_unicode_normalizer_process_codepoint_to_grapheme(tc, &norm, lc_arg, &lc_arg);
@@ -687,6 +688,7 @@ static MVMint64 * nqp_nfa_run(MVMThreadContext *tc, MVMNFABody *nfa, MVMString *
                             if (((act == MVM_NFA_EDGE_CODEPOINT_IM)     && (ord == lc_arg || ord == uc_arg))
                              || ((act == MVM_NFA_EDGE_CODEPOINT_IM_NEG) && (ord != lc_arg && ord != uc_arg)))
                                 nextst[numnext++] = to;
+                            MVM_unicode_normalizer_cleanup(tc, &norm);
                             continue;
                         }
                         case MVM_NFA_EDGE_CHARRANGE_M: {


### PR DESCRIPTION
MVM_unicode_normalizer_init allocates a buffer which, after use, should be
deallocated by a call to MVM_unicode_normalizer_cleanup. If this is not
done a memory leak occurs. There were three places in the file where the
call to MVM_unicode_normalizer_cleanup had been forgotten. Have run
valgrind and the memory leaks in t/spec/S05-metasyntax/charset.t are now
gone. Have also spectested, no failed tests.