### PR TITLE
Extract spesh allocation from spesh

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -90,6 +90,7 @@ OBJECTS = src/core/callsite@obj@ \
           src/core/continuation@obj@ \
           src/core/intcache@obj@ \
           src/core/fixedsizealloc@obj@ \
+          src/core/regionalloc@obj@ \
           src/gen/config@obj@ \
           src/gc/orchestrate@obj@ \
           src/gc/allocation@obj@ \
@@ -235,6 +236,7 @@ HEADERS = src/moar.h \
           src/core/continuation.h \
           src/core/intcache.h \
           src/core/fixedsizealloc.h \
+          src/core/regionalloc.h \
           src/io/io.h \
           src/io/eventloop.h \
           src/io/syncfile.h \

--- a/src/core/regionalloc.c
+++ b/src/core/regionalloc.c
@@ -1,0 +1,45 @@
+#include "moar.h"
+
+void * MVM_region_alloc(MVMThreadContext *tc, MVMRegionAlloc *al, size_t bytes) {
+    char *result = NULL;
+
+#if !defined(MVM_CAN_UNALIGNED_INT64) || !defined(MVM_CAN_UNALIGNED_NUM64)
+    /* Round up size to next multiple of 8, to ensure alignment. */
+    bytes = (bytes + 7) & ~7;
+#endif
+
+    if (al->block != NULL && (al->block->alloc + bytes) < al->block->limit) {
+        result = al->block->alloc;
+        al->block->alloc += bytes;
+    } else {
+        /* No block, or block was full. Add another. */
+        MVMRegionBlock *block = MVM_malloc(sizeof(MVMRegionBlock));
+        size_t buffer_size = al->block == NULL
+            ? MVM_REGIONALLOC_FIRST_MEMBLOCK_SIZE
+            : MVM_REGIONALLOC_MEMBLOCK_SIZE;
+        if (buffer_size < bytes)
+            buffer_size = bytes;
+        block->buffer = MVM_calloc(buffer_size, 1);
+        block->alloc  = block->buffer;
+        block->limit  = block->buffer + buffer_size;
+        block->prev   = al->block;
+        al->block     = block;
+
+        /* Now allocate out of it. */
+        result = block->alloc;
+        block->alloc += bytes;
+    }
+    return result;
+}
+
+void MVM_region_destroy(MVMThreadContext *tc, MVMRegionAlloc *alloc) {
+    MVMRegionBlock *block = alloc->block;
+    /* Free all of the allocated memory. */
+    while (block) {
+        MVMRegionBlock *prev = block->prev;
+        MVM_free(block->buffer);
+        MVM_free(block);
+        block = prev;
+    }
+    alloc->block = NULL;
+}

--- a/src/core/regionalloc.h
+++ b/src/core/regionalloc.h
@@ -1,0 +1,26 @@
+/* A block of bump-pointer allocated memory. For single-threaded use only. */
+struct MVMRegionBlock {
+    /* The memory buffer itself. */
+    char *buffer;
+
+    /* Current allocation position. */
+    char *alloc;
+
+    /* Allocation limit. */
+    char *limit;
+
+    /* Previous, now full, memory block. */
+    MVMRegionBlock *prev;
+};
+
+struct MVMRegionAlloc {
+    MVMRegionBlock *block;
+};
+
+/* The default allocation chunk size for memory blocks used to store spesh
+ * graph nodes. Power of two is best; we start small also. */
+#define MVM_REGIONALLOC_FIRST_MEMBLOCK_SIZE 32768
+#define MVM_REGIONALLOC_MEMBLOCK_SIZE       8192
+
+void * MVM_region_alloc(MVMThreadContext *tc, MVMRegionAlloc *alloc, size_t s);
+void MVM_region_destroy(MVMThreadContext *tc, MVMRegionAlloc *alloc);

--- a/src/moar.h
+++ b/src/moar.h
@@ -136,6 +136,7 @@ MVM_PUBLIC const MVMint32 MVM_jit_support(void);
 #include "gc/roots.h"
 #include "gc/objectid.h"
 #include "gc/finalize.h"
+#include "core/regionalloc.h"
 #include "spesh/dump.h"
 #include "spesh/graph.h"
 #include "spesh/codegen.h"

--- a/src/spesh/graph.h
+++ b/src/spesh/graph.h
@@ -44,9 +44,8 @@ struct MVMSpeshGraph {
     /* Number of log-based guards we have. */
     MVMint32 num_log_guards;
 
-    /* Memory blocks we allocate to store spesh nodes, and which we free along
-     * with the graph. Contains a link to previous blocks. */
-    MVMSpeshMemBlock *mem_block;
+    /* Region allocator for spesh nodes */
+    MVMRegionAlloc region_alloc;
 
     /* Values placed in spesh slots. */
     MVMCollectable **spesh_slots;
@@ -106,26 +105,6 @@ struct MVMSpeshGraph {
     /* If this graph was formed from a spesh candidate rather than an
      * original static frame, the candidate will be stored here. */
     MVMSpeshCandidate *cand;
-};
-
-/* The default allocation chunk size for memory blocks used to store spesh
- * graph nodes. Power of two is best; we start small also. */
-#define MVM_SPESH_FIRST_MEMBLOCK_SIZE 32768
-#define MVM_SPESH_MEMBLOCK_SIZE       8192
-
-/* A block of bump-pointer allocated memory. */
-struct MVMSpeshMemBlock {
-    /* The memory buffer itself. */
-    char *buffer;
-
-    /* Current allocation position. */
-    char *alloc;
-
-    /* Allocation limit. */
-    char *limit;
-
-    /* Previous, now full, memory block. */
-    MVMSpeshMemBlock *prev;
 };
 
 /* A temporary register, added to support transformations. */

--- a/src/types.h
+++ b/src/types.h
@@ -42,6 +42,8 @@ typedef struct MVMExceptionBody MVMExceptionBody;
 typedef struct MVMExtOpRecord MVMExtOpRecord;
 typedef struct MVMExtOpRegistry MVMExtOpRegistry;
 typedef struct MVMExtRegistry MVMExtRegistry;
+typedef struct MVMRegionAlloc MVMRegionAlloc;
+typedef struct MVMRegionBlock MVMRegionBlock;
 typedef struct MVMFixedSizeAlloc MVMFixedSizeAlloc;
 typedef struct MVMFixedSizeAllocFreeListEntry MVMFixedSizeAllocFreeListEntry;
 typedef struct MVMFixedSizeAllocSafepointFreeListEntry MVMFixedSizeAllocSafepointFreeListEntry;


### PR DESCRIPTION
The `spesh` allocator uses a strategy known as memory-region
allocation and is suitable for more contexts than just `spesh`.

Not a strictly necessary step, but may be useful enough to merge.
