### PR TITLE
Fix the nativecall attribute error messages

### DIFF
--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -65,7 +65,7 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
         else {
             MVM_exception_throw_adhoc(tc,
                 "CArray representation only handles attributes of type:\n"
-                "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, (s)size_t, bool, Str\n"
+                "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, num64, (s)size_t, bool, Str\n"
                 "  and types with representation: CArray, CPointer, CStruct, CPPStruct and CUnion");
         }
     }

--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -238,7 +238,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                 else {
                     MVM_exception_throw_adhoc(tc,
                         "CPPStruct representation only handles attributes of type:\n"
-                        "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, (s)size_t, bool, Str\n"
+                        "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, num64, (s)size_t, bool, Str\n"
                         "  and types with representation: CArray, CPointer, CStruct, CPPStruct and CUnion");
                 }
             }

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -241,7 +241,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                 else {
                     MVM_exception_throw_adhoc(tc,
                         "CStruct representation only handles attributes of type:\n"
-                        "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, (s)size_t, bool, Str\n"
+                        "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, num64, (s)size_t, bool, Str\n"
                         "  and types with representation: CArray, CPointer, CStruct, CPPStruct and CUnion");
                 }
             }

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -217,7 +217,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                 else {
                     MVM_exception_throw_adhoc(tc,
                         "CUnion representation only handles attributes of type:\n"
-                        "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, (s)size_t, bool, Str\n"
+                        "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num16, num32, num64, (s)size_t, bool, Str\n"
                         "  and types with representation: CArray, CPointer, CStruct, CPPStruct and CUnion");
                 }
             }


### PR DESCRIPTION
The nativecall attribute error messages are missing `num64` in their list.