### PR TITLE
work around clock_gettime issue on OSX

### DIFF
--- a/src/platform/posix/time.c
+++ b/src/platform/posix/time.c
@@ -4,6 +4,11 @@
 #include <errno.h>
 #include <sys/time.h>
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 #define E9 1000000000
 #define E9F 1000000000.0f
 

--- a/src/platform/posix/time.c
+++ b/src/platform/posix/time.c
@@ -9,18 +9,27 @@
 
 MVMuint64 MVM_platform_now(void)
 {
-#ifdef CLOCK_REALTIME
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+    clock_serv_t    cclock;
+    mach_timespec_t ts;
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &ts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    return (MVMuint64)ts.tv_sec * E9 + ts.tv_nsec;
+#else
+#  ifdef CLOCK_REALTIME
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
         return 0;
 
     return (MVMuint64)ts.tv_sec * E9 + ts.tv_nsec;
-#else
+#  else
     struct timeval tv;
     if (gettimeofday(&tv, NULL) != 0)
         return 0;
 
     return (MVMuint64)tv.tv_sec * E9 + tv.tv_usec * 1000;
+#  endif
 #endif
 }
 


### PR DESCRIPTION
This hopefully resolves issue #437. Needs testing on pre- and post
OSX 10.12 / Xcode 8.