### PR TITLE
Reduce big ints only when both operands are >1023 used size

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -865,13 +865,13 @@ MVMnum64 MVM_bigint_div_num(MVMThreadContext *tc, MVMObject *a, MVMObject *b) {
         mp_int *ia = force_bigint(ba, tmp);
         mp_int *ib = force_bigint(bb, tmp);
 
-        int max_size = DIGIT_BIT * MAX(USED(ia), USED(ib));
-        if (max_size > 1023) {
+        int min_size = DIGIT_BIT * MIN(USED(ia), USED(ib));
+        if (min_size > 1023) {
             mp_int reduced_a, reduced_b;
             mp_init(&reduced_a);
             mp_init(&reduced_b);
-            mp_div_2d(ia, max_size - 1023, &reduced_a, NULL);
-            mp_div_2d(ib, max_size - 1023, &reduced_b, NULL);
+            mp_div_2d(ia, min_size - 1023, &reduced_a, NULL);
+            mp_div_2d(ib, min_size - 1023, &reduced_b, NULL);
             c = mp_get_double(&reduced_a) / mp_get_double(&reduced_b);
             mp_clear(&reduced_a);
             mp_clear(&reduced_b);


### PR DESCRIPTION
The current implementation risks making one of the operands zero,
if it's small enough that when divided by `2**(max_size - 1023)` its
whole part is zero. This causes operations like `nqp::div_In(2**1020, 1)`
to produce `Inf` and `nqp::div_In(1, 2**1020)` to produce zero, despite
both being perfectly representable in normalized double.

Fix by using the minimum size rather than the maximum size as a condition
for reduction.

Note: this still doesn't fix nqp::div_In() enterly, as (at least in
the docs[^1]) it's described as allowing scale of 309.

Fixes RT#130154: https://rt.perl.org/Ticket/Display.html?id=130154
Fixes RT#130153: https://rt.perl.org/Ticket/Display.html?id=130153
Fixes RT#130155: https://rt.perl.org/Ticket/Display.html?id=130155

[1] https://github.com/perl6/nqp/blob/master/docs/ops.markdown#div