### PR TITLE
The function MVMNFGTrieNode incorrectly tries to free a memory block of

### DIFF
--- a/src/strings/nfg.c
+++ b/src/strings/nfg.c
@@ -130,7 +130,7 @@ static MVMNFGTrieNode * twiddle_trie_node(MVMThreadContext *tc, MVMNFGTrieNode *
     /* Free any existing node at next safe point, return the new one. */
     if (current)
         MVM_fixed_size_free_at_safepoint(tc, tc->instance->fsa,
-            sizeof(MVMNGFTrieNodeEntry), current);
+            sizeof(MVMNFGTrieNode), current);
     return new_node;
 }
 static void add_synthetic_to_trie(MVMThreadContext *tc, MVMCodepoint *codes, MVMint32 num_codes, MVMGrapheme32 synthetic) {


### PR DESCRIPTION
sizeof(MVMNGFTrieNodeEntry) when the memory chunk to be freed contains
an MVMNFGTrieNode. This works on 64-bit systems since both structs
happens to be of the same size, something which is not the case on 32
bit systems. This resolves RT #130191 and is spectest clean.

cygx++ for helping track this down.