### PR TITLE
Add a script to download the latest version of all of the Unicode data

### DIFF
--- a/tools/UCD-download.p6
+++ b/tools/UCD-download.p6
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl6
+# Gets the latest Unicode Data files and extracts them.
+use v6;
+my $UCD-zip-lnk = "ftp://ftp.unicode.org/Public/UCD/latest/ucd/UCD.zip";
+my $UCA-all-keys = "ftp://ftp.unicode.org/Public/UCA/latest/allkeys.txt";
+sub download-file ( Str:D $url, Str:D $filename ) {
+    qqx{curl "$url" -o "$filename"};
+}
+sub unzip-file ( Str:D $zip ) {
+    qqx{unzip "$zip"};
+}
+if ! so './UNIDATA'.IO.d {
+    say "Creating UNIDATA directory";
+    mkdir "UNIDATA";
+}
+chdir "UNIDATA";
+if ! so "./UCD.zip".IO.f {
+    say "Downloading the latest UCD from $UCD-zip-lnk";
+    download-file($UCD-zip-lnk,"UCD.zip");
+    say "Unzipping UCD.zip";
+    unzip-file("UCD.zip");
+}
+else {
+if ! so "UCA".IO.d {
+    say "Creating the UCA directory";
+    mkdir "UCA";
+}
+if ! so "./UCA/allkeys.txt".IO.f {
+    say "Downloading allkeys.txt from $UCA-all-keys";
+    chdir "UCA".IO;
+    download-file($UCA-all-keys, "allkeys.txt");
+    chdir '..';
+}
+my $emoji-dir = "ftp://ftp.unicode.org/Public/emoji/";
+my @emoji-vers;
+say "Getting a listing of the Emoji versions";
+for qqx{curl -s "$emoji-dir"}.lines {
+    push @emoji-vers, .split(/' '+/)[8];
+}
+for @emoji-vers.sort.reverse -> $version {
+    say "See version $version of Emoji, checking to see if it's a draft";
+    my $readme = qqx{curl -s "ftp://ftp.unicode.org/Public/emoji/$version/ReadMe.txt"}.chomp;
+    if $readme.match(/draft|PRELIMINARY/, :i) {
+        say "Looks like $version is a draft. ReadMe.txt text: <<$readme>>";
+        next;
+    }
+    else {
+        say "Found version $version. Don't see /:i draft|PRELIMINARY/ in the text.";
+        my $emoji-data = "ftp://ftp.unicode.org/Public/emoji/$version/emoji-data.txt";
+        say $emoji-data;
+        mkdir "emoji";
+        chdir "emoji";
+        download-file($emoji-data, "emoji-data.txt");
+        chdir "..";
+        last;
+    }
+}


### PR DESCRIPTION
Downloads UCD.zip, collation data (allkeys.txt) and emoji-data.txt using this script.

Since there is no 'latest' folder on the ftp for Emoji, we check if the ReadMe.txt has draft or preliminary in the file. All the other draft specs on the Unicode ftp server use one or more of those words in the draft, while do not use them at all in the final verision.