### PR TITLE
Use /usr/bin/env perl for ./Configure.pl

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;
@@ -756,7 +756,7 @@ sub write_backend_config {
     for my $k (sort keys %config) {
         next if $k eq 'backendconfig';
         my $v = $config{$k};
-        
+
         if (ref($v) eq 'ARRAY') {
             my $i = 0;
             for (@$v) {


### PR DESCRIPTION
We already do this for NQP and Rakudo now, and will make it be more
compatible on Unixish systems. Windows systems are unaffected by this
change.

Some trailing whitespace was also removed.