### PR TITLE
Take into account actual allocated of I/O buffers.

### DIFF
--- a/src/io/asyncsocket.c
+++ b/src/io/asyncsocket.c
@@ -60,7 +60,7 @@ static void on_read(uv_stream_t *handle, ssize_t nread, const uv_buf_t *buf) {
                 MVMArray *res_buf      = (MVMArray *)MVM_repr_alloc_init(tc, ri->buf_type);
                 res_buf->body.slots.i8 = (MVMint8 *)buf->base;
                 res_buf->body.start    = 0;
-                res_buf->body.ssize    = nread;
+                res_buf->body.ssize    = buf->len;
                 res_buf->body.elems    = nread;
                 MVM_repr_push_o(tc, arr, (MVMObject *)res_buf);
             }

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -63,7 +63,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
                 MVMArray *res_buf      = (MVMArray *)MVM_repr_alloc_init(tc, ri->buf_type);
                 res_buf->body.slots.i8 = (MVMint8 *)buf->base;
                 res_buf->body.start    = 0;
-                res_buf->body.ssize    = nread;
+                res_buf->body.ssize    = buf->len;
                 res_buf->body.elems    = nread;
                 MVM_repr_push_o(tc, arr, (MVMObject *)res_buf);
             }

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -768,7 +768,7 @@ static void async_read(uv_stream_t *handle, ssize_t nread, const uv_buf_t *buf, 
                 MVMArray  *res_buf     = (MVMArray *)MVM_repr_alloc_init(tc, buf_type);
                 res_buf->body.slots.i8 = (MVMint8 *)buf->base;
                 res_buf->body.start    = 0;
-                res_buf->body.ssize    = nread;
+                res_buf->body.ssize    = buf->len;
                 res_buf->body.elems    = nread;
                 MVM_repr_push_o(tc, arr, (MVMObject *)res_buf);
             }


### PR DESCRIPTION
It seems libuv suggest we allocate 64KB sometimes, even when the
input we get is tiny. While I'm not sure second-guessing it is wise,
we should at least be honest internally about what's allocated. By
storing the actual allocated size, the GC can track it as part of
the gen2 promotion statistics, and be smarter about triggering full
collections. This reduces memory overhead.