### PR TITLE
Free up spesh log slots after specialization.

### DIFF
--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -222,6 +222,10 @@ void MVM_spesh_candidate_specialize(MVMThreadContext *tc, MVMStaticFrame *static
             candidate->jitcode = MVM_jit_compile_graph(tc, jg);
     }
 
+    /* No longer need log slots. */
+    MVM_free(candidate->log_slots);
+    candidate->log_slots = NULL;
+
     /* Update spesh slots. */
     candidate->num_spesh_slots = sg->num_spesh_slots;
     candidate->spesh_slots     = sg->spesh_slots;


### PR DESCRIPTION
Spesh logging keeps values alive, preventing the GC from collecting
them. It logs values to sample what types show up, which is fine, but
we should not hang on to them beyond the point the specializer has
used them in its analysis. This reduces memory overhead, perhaps
quite notably in some applications that have large objects (for
example, RT #130494 leaked many objects in this way). On CORE.setting
compilation it saves ~3MB - not much in the scheme of things, but nice
to win.