### PR TITLE
Fix bugs in interaction between inlining, GC, and threads

### DIFF
--- a/src/6model/reprs/MVMCompUnit.c
+++ b/src/6model/reprs/MVMCompUnit.c
@@ -86,7 +86,10 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     uv_mutex_destroy(body->inline_tweak_mutex);
     MVM_free(body->inline_tweak_mutex);
     MVM_free(body->coderefs);
-    MVM_free(body->callsites);
+    if (body->callsites)
+        MVM_fixed_size_free(tc, tc->instance->fsa,
+            body->num_callsites * sizeof(MVMCallsite *),
+            body->callsites);
     if (body->extops)
         MVM_fixed_size_free(tc, tc->instance->fsa,
             body->num_extops * sizeof(MVMExtOpRecord),

--- a/src/6model/reprs/MVMCompUnit.c
+++ b/src/6model/reprs/MVMCompUnit.c
@@ -87,7 +87,10 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVM_free(body->inline_tweak_mutex);
     MVM_free(body->coderefs);
     MVM_free(body->callsites);
-    MVM_free(body->extops);
+    if (body->extops)
+        MVM_fixed_size_free(tc, tc->instance->fsa,
+            body->num_extops * sizeof(MVMExtOpRecord),
+            body->extops);
     MVM_free(body->strings);
     MVM_free(body->scs);
     MVM_free(body->scs_to_resolve);

--- a/src/6model/reprs/MVMCompUnit.c
+++ b/src/6model/reprs/MVMCompUnit.c
@@ -94,7 +94,10 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
         MVM_fixed_size_free(tc, tc->instance->fsa,
             body->num_extops * sizeof(MVMExtOpRecord),
             body->extops);
-    MVM_free(body->strings);
+    if (body->strings)
+        MVM_fixed_size_free(tc, tc->instance->fsa,
+            body->num_strings * sizeof(MVMString *),
+            body->strings);
     MVM_free(body->scs);
     MVM_free(body->scs_to_resolve);
     MVM_free(body->sc_handle_idxs);

--- a/src/6model/reprs/MVMCompUnit.c
+++ b/src/6model/reprs/MVMCompUnit.c
@@ -26,9 +26,12 @@ static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
 
 /* Initializes a new instance. */
 static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data) {
-    MVMROOT(tc, root, {
+    MVMCompUnit *cu = (MVMCompUnit *)root;
+    MVMROOT(tc, cu, {
         MVMObject *rm = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTReentrantMutex);
-        MVM_ASSIGN_REF(tc, &(root->header), ((MVMCompUnit *)root)->body.update_mutex, rm);
+        MVM_ASSIGN_REF(tc, &(root->header), cu->body.deserialize_frame_mutex, rm);
+        cu->body.inline_tweak_mutex = MVM_malloc(sizeof(uv_mutex_t));
+        uv_mutex_init(cu->body.inline_tweak_mutex);
     });
 }
 
@@ -62,7 +65,7 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
         /* Unresolved sc bodies' handles are marked by the GC instance root marking. */
     }
 
-    MVM_gc_worklist_add(tc, worklist, &body->update_mutex);
+    MVM_gc_worklist_add(tc, worklist, &body->deserialize_frame_mutex);
 
     /* Add various other referenced strings, etc. */
     MVM_gc_worklist_add(tc, worklist, &body->hll_name);
@@ -72,18 +75,16 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 /* Called by the VM in order to free memory associated with this object. */
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMCompUnitBody *body = &((MVMCompUnit *)obj)->body;
-    int i;
 
+    int i;
     for (i = 0; i < body->num_callsites; i++) {
         MVMCallsite *cs = body->callsites[i];
-
-        if (cs->is_interned) {
-            continue;
-        }
-
-        MVM_callsite_destroy(cs);
+        if (!cs->is_interned)
+            MVM_callsite_destroy(cs);
     }
 
+    uv_mutex_destroy(body->inline_tweak_mutex);
+    MVM_free(body->inline_tweak_mutex);
     MVM_free(body->coderefs);
     MVM_free(body->callsites);
     MVM_free(body->extops);
@@ -194,7 +195,7 @@ static void describe_refs(MVMThreadContext *tc, MVMHeapSnapshotState *ss, MVMSTa
             (MVMCollectable *)body->scs[i], "Serialization context dependency");
 
     MVM_profile_heap_add_collectable_rel_const_cstr(tc, ss,
-        (MVMCollectable *)body->update_mutex, "Update_mutex");
+        (MVMCollectable *)body->deserialize_frame_mutex, "Update_mutex");
 
     /* Add various other referenced strings, etc. */
     MVM_profile_heap_add_collectable_rel_const_cstr(tc, ss,

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -854,7 +854,8 @@ void MVM_bytecode_unpack(MVMThreadContext *tc, MVMCompUnit *cu) {
     rs = dissect_bytecode(tc, cu);
 
     /* Allocate space for the strings heap; we deserialize it lazily. */
-    cu_body->strings = MVM_calloc(rs->expected_strings, sizeof(MVMString *));
+    cu_body->strings = MVM_fixed_size_alloc_zeroed(tc, tc->instance->fsa,
+        rs->expected_strings * sizeof(MVMString *));
     cu_body->num_strings = rs->expected_strings;
     cu_body->orig_strings = rs->expected_strings;
     cu_body->string_heap_fast_table = MVM_calloc(

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -726,7 +726,8 @@ static MVMCallsite ** deserialize_callsites(MVMThreadContext *tc, MVMCompUnit *c
     /* Allocate space for callsites. */
     if (rs->expected_callsites == 0)
         return NULL;
-    callsites = MVM_malloc(sizeof(MVMCallsite *) * rs->expected_callsites);
+    callsites = MVM_fixed_size_alloc(tc, tc->instance->fsa,
+        sizeof(MVMCallsite *) * rs->expected_callsites);
 
     /* Load callsites. */
     pos = rs->callsite_seg;

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -582,11 +582,11 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
         return;
 
     /* Acquire the update mutex on the CompUnit. */
-    MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
 
     /* Ensure no other thread has done this for us in the mean time. */
     if (sf->body.fully_deserialized) {
-        MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+        MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
         return;
     }
 
@@ -667,7 +667,7 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
         MVMuint16 flags   = read_int16(pos, 2);
 
         if (lex_idx >= sf->body.num_lexicals) {
-            MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+            MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
             MVM_exception_throw_adhoc(tc, "Lexical index out of bounds: %d > %d", lex_idx, sf->body.num_lexicals);
         }
 
@@ -677,7 +677,7 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
              * can wait. */
             MVMSerializationContext *sc = MVM_sc_get_sc(tc, cu, read_int32(pos, 4));
             if (sc == NULL) {
-                MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+                MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
                 MVM_exception_throw_adhoc(tc, "SC not yet resolved; lookup failed");
             }
             MVM_ASSIGN_REF(tc, &(sf->common.header), sf->body.static_env[lex_idx].o,
@@ -690,7 +690,7 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
     sf->body.fully_deserialized = 1;
 
     /* Release the update mutex again */
-    MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
 }
 
 /* Gets the SC reference for a given static lexical var for

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -313,7 +313,8 @@ static MVMExtOpRecord * deserialize_extop_records(MVMThreadContext *tc, MVMCompU
     if (num == 0)
         return NULL;
 
-    extops = MVM_calloc(num, sizeof *extops);
+    extops = MVM_fixed_size_alloc_zeroed(tc, tc->instance->fsa,
+        num * sizeof(MVMExtOpRecord));
 
     pos = rs->extop_seg;
     for (i = 0; i < num; i++) {

--- a/src/core/compunit.c
+++ b/src/core/compunit.c
@@ -101,7 +101,7 @@ MVMuint16 MVM_cu_callsite_add(MVMThreadContext *tc, MVMCompUnit *cu, MVMCallsite
     MVMuint16 found = 0;
     MVMuint16 idx;
 
-    MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    uv_mutex_lock(cu->body.inline_tweak_mutex);
 
     /* See if we already know this callsite. */
     for (idx = 0; idx < cu->body.num_callsites; idx++)
@@ -118,7 +118,7 @@ MVMuint16 MVM_cu_callsite_add(MVMThreadContext *tc, MVMCompUnit *cu, MVMCallsite
         cu->body.num_callsites++;
     }
 
-    MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    uv_mutex_unlock(cu->body.inline_tweak_mutex);
 
     return idx;
 }
@@ -128,7 +128,7 @@ MVMuint32 MVM_cu_string_add(MVMThreadContext *tc, MVMCompUnit *cu, MVMString *st
     MVMuint32 found = 0;
     MVMuint32 idx;
 
-    MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    uv_mutex_lock(cu->body.inline_tweak_mutex);
 
     /* See if we already know this string; only consider those added already by
      * inline, since we don't intern and don't want this to be costly to hunt. */
@@ -146,7 +146,7 @@ MVMuint32 MVM_cu_string_add(MVMThreadContext *tc, MVMCompUnit *cu, MVMString *st
         cu->body.num_strings++;
     }
 
-    MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    uv_mutex_unlock(cu->body.inline_tweak_mutex);
 
     return idx;
 }

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -27,7 +27,7 @@ static void prepare_and_verify_static_frame(MVMThreadContext *tc, MVMStaticFrame
 
     /* Take compilation unit lock, to make sure we don't race to do the
      * frame preparation/verification work. */
-    MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
     if (static_frame->body.instrumentation_level == 0) {
         /* Work size is number of locals/registers plus size of the maximum
         * call site argument list. */
@@ -64,7 +64,7 @@ static void prepare_and_verify_static_frame(MVMThreadContext *tc, MVMStaticFrame
     }
 
     /* Unlock, now we're finished. */
-    MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.update_mutex);
+    MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
 }
 
 /* When we don't match the current instrumentation level, we hit this. It may

--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -22,12 +22,16 @@ static void demand_extop(MVMThreadContext *tc, MVMCompUnit *target_cu, MVMCompUn
     num_extops = source_cu->body.num_extops;
     for (i = 0; i < num_extops; i++) {
         if (extops[i].info == info) {
-            MVMuint32 size = (target_cu->body.num_extops + 1) * sizeof(MVMExtOpRecord);
-            target_cu->body.extops = target_cu->body.extops
-                ? MVM_realloc(target_cu->body.extops, size)
-                : MVM_malloc(size);
-            memcpy(&target_cu->body.extops[target_cu->body.num_extops],
-                &extops[i], sizeof(MVMExtOpRecord));
+            MVMuint32 orig_size = target_cu->body.num_extops * sizeof(MVMExtOpRecord);
+            MVMuint32 new_size = (target_cu->body.num_extops + 1) * sizeof(MVMExtOpRecord);
+            MVMExtOpRecord *new_extops = MVM_fixed_size_alloc(tc,
+                tc->instance->fsa, new_size);
+            memcpy(new_extops, target_cu->body.extops, orig_size);
+            memcpy(&new_extops[target_cu->body.num_extops], &extops[i], sizeof(MVMExtOpRecord));
+            if (target_cu->body.extops)
+                MVM_fixed_size_free_at_safepoint(tc, tc->instance->fsa, orig_size,
+                   target_cu->body.extops);
+            target_cu->body.extops = new_extops;
             target_cu->body.num_extops++;
             uv_mutex_unlock(target_cu->body.inline_tweak_mutex);
             return;


### PR DESCRIPTION
This PR addresses:

* Issue #478 by avoiding a bunch of codepaths that could end up with us running GC during specialization, which were triggered by cross-compilation-unit inlining
* Three abuses of `realloc` that could lead to other threads reading freed memory (this accounts for the ASAN noise in spectest6, for example)