### PR TITLE
Convert MVM_malloc+memset to MVM_calloc

### DIFF
--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -331,8 +331,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
 
     /* Allocate object body. */
     MVMCUnionBody *body = (MVMCUnionBody *)data;
-    body->cunion = MVM_malloc(repr_data->struct_size > 0 ? repr_data->struct_size : 1);
-    memset(body->cunion, 0, repr_data->struct_size);
+    body->cunion = MVM_calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
 
     /* Allocate child obj array. */
     if (repr_data->num_child_objs > 0)

--- a/src/6model/reprs/MVMCallCapture.c
+++ b/src/6model/reprs/MVMCallCapture.c
@@ -26,8 +26,7 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
     MVMRegister *args = MVM_malloc(arg_size);
     memcpy(args, src_body->apc->args, arg_size);
 
-    dest_body->apc = MVM_malloc(sizeof(MVMArgProcContext));
-    memset(dest_body->apc, 0, sizeof(MVMArgProcContext));
+    dest_body->apc = (MVMArgProcContext *)MVM_calloc(1, sizeof(MVMArgProcContext));
     dest_body->mode = MVM_CALL_CAPTURE_MODE_SAVE;
 
     if (src_body->owns_callsite) {

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -627,8 +627,7 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
         MVM_exception_throw_adhoc(tc, "Type %s is already composed", st->debug_name);
 
     /* Allocate the representation data. */
-    repr_data = MVM_malloc(sizeof(MVMP6opaqueREPRData));
-    memset(repr_data, 0, sizeof(MVMP6opaqueREPRData));
+    repr_data = (MVMP6opaqueREPRData *)MVM_calloc(1, sizeof(MVMP6opaqueREPRData));
 
     /* Find attribute information. */
     info = MVM_repr_at_key_o(tc, info_hash, str_attribute);
@@ -665,17 +664,14 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
     repr_data->num_attributes = total_attrs;
     if (total_attrs) {
         repr_data->attribute_offsets   = MVM_malloc(total_attrs * sizeof(MVMuint16));
-        repr_data->flattened_stables   = MVM_malloc(total_attrs * sizeof(MVMSTable *));
-        repr_data->auto_viv_values     = MVM_malloc(total_attrs * sizeof(MVMObject *));
+        repr_data->flattened_stables   = (MVMSTable **)MVM_calloc(total_attrs, sizeof(MVMSTable *));
+        repr_data->auto_viv_values     = (MVMObject **)MVM_calloc(total_attrs, sizeof(MVMObject *));
         repr_data->gc_obj_mark_offsets = MVM_malloc(total_attrs * sizeof(MVMuint16));
-        memset(repr_data->flattened_stables, 0, total_attrs * sizeof(MVMSTable *));
-        memset(repr_data->auto_viv_values, 0, total_attrs * sizeof(MVMObject *));
     }
-    repr_data->name_to_index_mapping = MVM_malloc((mro_count + 1) * sizeof(MVMP6opaqueNameMap));
+    repr_data->name_to_index_mapping = (MVMP6opaqueNameMap *)MVM_calloc((mro_count + 1), sizeof(MVMP6opaqueNameMap));
     repr_data->initialize_slots      = MVM_malloc((total_attrs + 1) * sizeof(MVMuint16));
     repr_data->gc_mark_slots         = MVM_malloc((total_attrs + 1) * sizeof(MVMuint16));
     repr_data->gc_cleanup_slots      = MVM_malloc((total_attrs + 1) * sizeof(MVMuint16));
-    memset(repr_data->name_to_index_mapping, 0, (mro_count + 1) * sizeof(MVMP6opaqueNameMap));
 
     /* -1 indicates no unboxing or delegate possible for a type. */
     repr_data->unbox_int_slot = -1;

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -105,8 +105,7 @@ MVMObject * MVM_args_save_capture(MVMThreadContext *tc, MVMFrame *frame) {
 
     /* Set up the call capture. */
     cc->body.mode = MVM_CALL_CAPTURE_MODE_SAVE;
-    cc->body.apc  = MVM_malloc(sizeof(MVMArgProcContext));
-    memset(cc->body.apc, 0, sizeof(MVMArgProcContext));
+    cc->body.apc  = (MVMArgProcContext *)MVM_calloc(1, sizeof(MVMArgProcContext));
     MVM_args_proc_init(tc, cc->body.apc, cc->body.effective_callsite, args);
     return cc_obj;
 }
@@ -860,8 +859,7 @@ void MVM_args_bind_failed(MVMThreadContext *tc) {
 
     /* Set up the call capture. */
     cc->body.mode = MVM_CALL_CAPTURE_MODE_SAVE;
-    cc->body.apc  = MVM_malloc(sizeof(MVMArgProcContext));
-    memset(cc->body.apc, 0, sizeof(MVMArgProcContext));
+    cc->body.apc  = (MVMArgProcContext *)MVM_calloc(1, sizeof(MVMArgProcContext));
     MVM_args_proc_init(tc, cc->body.apc, cc->body.effective_callsite, args);
 
     /* Invoke the HLL's bind failure handler. */

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -150,8 +150,7 @@ static ReaderState * dissect_bytecode(MVMThreadContext *tc, MVMCompUnit *cu) {
         MVM_exception_throw_adhoc(tc, "Bytecode stream version too high");
 
     /* Allocate reader state. */
-    rs = MVM_malloc(sizeof(ReaderState));
-    memset(rs, 0, sizeof(ReaderState));
+    rs = (ReaderState *)MVM_calloc(1, sizeof(ReaderState));
     rs->version = version;
     rs->read_limit = cu_body->data_start + cu_body->data_size;
     cu->body.bytecode_version = version;

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -604,8 +604,7 @@ void MVM_frame_invoke(MVMThreadContext *tc, MVMStaticFrame *static_frame,
                         }
                         else {
                             /* Allocate storage for state vars. */
-                            state = MVM_malloc(frame->static_info->body.env_size);
-                            memset(state, 0, frame->static_info->body.env_size);
+                            state = (MVMRegister *)MVM_calloc(1, frame->static_info->body.env_size);
                             ((MVMCode *)frame->code_ref)->body.state_vars = state;
                             state_act = 1;
 

--- a/src/gc/gen2.c
+++ b/src/gc/gen2.c
@@ -6,8 +6,7 @@ MVMGen2Allocator * MVM_gc_gen2_create(MVMInstance *i) {
     MVMGen2Allocator *al = MVM_malloc(sizeof(MVMGen2Allocator));
 
     /* Create empty size classes array data structure. */
-    al->size_classes = MVM_malloc(sizeof(MVMGen2SizeClass) * MVM_GEN2_BINS);
-    memset(al->size_classes, 0, sizeof(MVMGen2SizeClass) * MVM_GEN2_BINS);
+    al->size_classes = (MVMGen2SizeClass *)MVM_calloc(1, sizeof(MVMGen2SizeClass) * MVM_GEN2_BINS);
 
     /* Set up overflows area. */
     al->alloc_overflows = MVM_GEN2_OVERFLOWS;

--- a/src/mast/compiler.c
+++ b/src/mast/compiler.c
@@ -1424,8 +1424,7 @@ static char * form_bytecode_output(VM, WriterState *ws, unsigned int *bytecode_s
         size += MVM_ALIGN_SECTION(vm->serialized_size);
 
     /* Allocate space for the bytecode output. */
-    output = (char *)MVM_malloc(size);
-    memset(output, 0, size);
+    output = (char *)MVM_calloc(1, size);
 
     /* Generate start of header. */
     memcpy(output, "MOARVM\r\n", 8);


### PR DESCRIPTION
In cases of `foo = MVM_malloc(...); memset(foo, 0, ...);`, convert them
to `foo = MVM_calloc(...);`

NQP builds and passes `make m-test` and Rakudo build and passes `make m-spectest`.