### PR TITLE
Fix warnings during compile

### DIFF
--- a/src/6model/reprs/NFA.c
+++ b/src/6model/reprs/NFA.c
@@ -454,7 +454,7 @@ static MVMint64 * nqp_nfa_run(MVMThreadContext *tc, MVMNFABody *nfa, MVMString *
         if (nfadeb) {
             if (offset < eos) {
                 MVMGrapheme32 cp = MVM_string_get_grapheme_at_nocheck(tc, target, offset);
-                fprintf(stderr,"%c with %ds target %lx offset %lld\n",cp,(int)numcur, (long)target, offset);
+                fprintf(stderr,"%c with %ds target %lx offset %ld\n",cp,(int)numcur, (long)target, offset);
             }
             else {
                 fprintf(stderr,"EOS with %ds\n",(int)numcur);

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -1650,7 +1650,7 @@ char *MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader *
         strbuf[len] = 0;
         *(reader->cur_read_offset) += len;
     } else if (len < 0) {
-        fail_deserialize(tc, reader, "Cannot read a c string with negative length %d.", len);
+        fail_deserialize(tc, reader, "Cannot read a c string with negative length %li.", len);
     }
     return strbuf;
 }

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1394,7 +1394,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                                 if (fcost+icost > 1)
                                   try_cache_dynlex(tc, initial_frame, cur_frame, name, result, *type, fcost, icost);
                                 if (dlog) {
-                                    fprintf(dlog, "I %s %d %d %d %d %llu %llu %llu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                                    fprintf(dlog, "I %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                                     fflush(dlog);
                                     MVM_free(c_name);
                                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1431,7 +1431,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                                 if (fcost+icost > 1)
                                   try_cache_dynlex(tc, initial_frame, cur_frame, name, result, *type, fcost, icost);
                                 if (dlog) {
-                                    fprintf(dlog, "I %s %d %d %d %d %llu %llu %llu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                                    fprintf(dlog, "I %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                                     fflush(dlog);
                                     MVM_free(c_name);
                                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1453,7 +1453,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                 if (fcost+icost > 5)
                     try_cache_dynlex(tc, initial_frame, cur_frame, name, result, *type, fcost, icost);
                 if (dlog) {
-                    fprintf(dlog, "C %s %d %d %d %d %llu %llu %llu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                    fprintf(dlog, "C %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                     fflush(dlog);
                     MVM_free(c_name);
                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1484,7 +1484,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                     });
                 }
                 if (dlog) {
-                    fprintf(dlog, "F %s %d %d %d %d %llu %llu %llu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                    fprintf(dlog, "F %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                     fflush(dlog);
                     MVM_free(c_name);
                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1499,7 +1499,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
         cur_frame = cur_frame->caller;
     }
     if (dlog) {
-        fprintf(dlog, "N %s %d %d %d %d %llu %llu %llu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+        fprintf(dlog, "N %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
         fflush(dlog);
         MVM_free(c_name);
         tc->instance->dynvar_log_lasttime = uv_hrtime();

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -130,7 +130,7 @@ MVMint32 MVM_jit_enter_code(MVMThreadContext *tc, MVMCompUnit *cu,
     void *label = tc->cur_frame->jit_entry_label;
     if (label < (void*)code->func_ptr || (char*)label > (((char*)code->func_ptr) + code->size))
         MVM_oops(tc, "JIT entry label out of range for code!\n"
-                 "(label %x, func_ptr %x, code size %d, offset %d, frame_nr %d, seq nr %d)",
+                 "(label %p, func_ptr %p, code size %lui, offset %li, frame_nr %i, seq nr %i)",
                  label, code->func_ptr, code->size, ((char*)label) - ((char*)code->func_ptr),
                  tc->cur_frame->sequence_nr, code->seq_nr);
     ctrl = code->func_ptr(tc, cu, label);

--- a/src/moar.c
+++ b/src/moar.c
@@ -233,7 +233,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     dynvar_log = getenv("MVM_DYNVAR_LOG");
     if (dynvar_log && strlen(dynvar_log)) {
         instance->dynvar_log_fh = fopen_perhaps_with_pid(dynvar_log, "w");
-        fprintf(instance->dynvar_log_fh, "+ x 0 0 0 0 0 %llu\n", uv_hrtime());
+        fprintf(instance->dynvar_log_fh, "+ x 0 0 0 0 0 %lui\n", uv_hrtime());
         fflush(instance->dynvar_log_fh);
         instance->dynvar_log_lasttime = uv_hrtime();
     }
@@ -350,7 +350,7 @@ void MVM_vm_exit(MVMInstance *instance) {
     if (instance->jit_bytecode_map)
         fclose(instance->jit_bytecode_map);
     if (instance->dynvar_log_fh) {
-        fprintf(instance->dynvar_log_fh, "- x 0 0 0 0 %lld %llu %llu\n", instance->dynvar_log_lasttime, uv_hrtime(), uv_hrtime());
+        fprintf(instance->dynvar_log_fh, "- x 0 0 0 0 %ld %lu %lu\n", instance->dynvar_log_lasttime, uv_hrtime(), uv_hrtime());
         fclose(instance->dynvar_log_fh);
     }
 


### PR DESCRIPTION
I get the format string warnings on my Kubuntu 16.10 machine (gcc 6.2.0), but not on my Arch Linux machine (gcc 6.3.1).