### PR TITLE
Fix order of args in mvm callocs

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -3052,10 +3052,10 @@ void MVM_serialization_deserialize(MVMThreadContext *tc, MVMSerializationContext
         MVM_free(sc->body->root_objects);
     if (sc->body->root_stables)
         MVM_free(sc->body->root_stables);
-    sc->body->root_objects  = MVM_calloc(1, reader->root.num_objects * sizeof(MVMObject *));
+    sc->body->root_objects  = MVM_calloc(reader->root.num_objects, sizeof(MVMObject *));
     sc->body->num_objects   = reader->root.num_objects;
     sc->body->alloc_objects = reader->root.num_objects;
-    sc->body->root_stables  = MVM_calloc(1, reader->root.num_stables * sizeof(MVMSTable *));
+    sc->body->root_stables  = MVM_calloc(reader->root.num_stables, sizeof(MVMSTable *));
     sc->body->num_stables   = reader->root.num_stables;
     sc->body->alloc_stables = reader->root.num_stables;
     reader->contexts        = MVM_calloc(reader->root.num_contexts, sizeof(MVMFrame *));

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -43,7 +43,7 @@ void MVM_args_proc_cleanup(MVMThreadContext *tc, MVMArgProcContext *ctx) {
 }
 
 MVMCallsite * MVM_args_copy_callsite(MVMThreadContext *tc, MVMArgProcContext *ctx) {
-    MVMCallsite      *res   = MVM_calloc(sizeof(MVMCallsite), 1);
+    MVMCallsite      *res   = MVM_calloc(1, sizeof(MVMCallsite));
     MVMCallsiteEntry *flags = NULL;
     MVMCallsiteEntry *src_flags;
     MVMint32 fsize;

--- a/src/core/bytecodedump.c
+++ b/src/core/bytecodedump.c
@@ -65,7 +65,7 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
     MVMuint32 s = 1024;
     MVMuint32 l = 0;
     MVMuint32 i, j, k;
-    char *o = MVM_calloc(sizeof(char) * s, 1);
+    char *o = MVM_calloc(1, sizeof(char) * s);
     char ***frame_lexicals = MVM_malloc(sizeof(char **) * cu->body.num_frames);
     MVMString *name = MVM_string_utf8_decode(tc, tc->instance->VMString, "", 0);
 
@@ -176,8 +176,8 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
     /* current position in the bytestream */
     MVMuint8 *cur_op = bytecode_start;
     /* positions in the bytestream that are starts of ops and goto targets */
-    MVMuint8 *labels = MVM_calloc(bytecode_size, 1);
-    MVMuint32 *jumps = MVM_calloc(sizeof(MVMuint32) * bytecode_size, 1);
+    MVMuint8 *labels = MVM_calloc(1, bytecode_size);
+    MVMuint32 *jumps = MVM_calloc(1, sizeof(MVMuint32) * bytecode_size);
     char **lines = MVM_malloc(sizeof(char *) * bytecode_size);
     MVMuint32 *linelocs = MVM_malloc(sizeof(MVMuint32) * bytecode_size);
     MVMuint32 lineno = 0;
@@ -199,7 +199,7 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
         /* allocate a line buffer */
         s = 200;
         l = 0;
-        o = MVM_calloc(sizeof(char) * s, 1);
+        o = MVM_calloc(1, sizeof(char) * s);
 
         lineloc = cur_op - bytecode_start;
         /* mark that this line starts at this point in the bytestream */

--- a/src/core/bytecodedump.c
+++ b/src/core/bytecodedump.c
@@ -65,7 +65,7 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
     MVMuint32 s = 1024;
     MVMuint32 l = 0;
     MVMuint32 i, j, k;
-    char *o = MVM_calloc(1, sizeof(char) * s);
+    char *o = MVM_calloc(s, sizeof(char));
     char ***frame_lexicals = MVM_malloc(sizeof(char **) * cu->body.num_frames);
     MVMString *name = MVM_string_utf8_decode(tc, tc->instance->VMString, "", 0);
 
@@ -199,7 +199,7 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
         /* allocate a line buffer */
         s = 200;
         l = 0;
-        o = MVM_calloc(1, sizeof(char) * s);
+        o = MVM_calloc(s, sizeof(char));
 
         lineloc = cur_op - bytecode_start;
         /* mark that this line starts at this point in the bytestream */

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -7,7 +7,7 @@
 MVMRegister * MVM_frame_initial_work(MVMThreadContext *tc, MVMuint16 *local_types,
                                      MVMuint16 num_locals) {
     MVMuint16 i;
-    MVMRegister *work_initial = MVM_calloc(sizeof(MVMRegister), num_locals);
+    MVMRegister *work_initial = MVM_calloc(num_locals, sizeof(MVMRegister));
     for (i = 0; i < num_locals; i++)
         if (local_types[i] == MVM_reg_obj)
             work_initial[i].o = tc->instance->VMNull;

--- a/src/core/hll.c
+++ b/src/core/hll.c
@@ -13,7 +13,7 @@ MVMHLLConfig *MVM_hll_get_config_for(MVMThreadContext *tc, MVMString *name) {
     }
 
     if (!entry) {
-        entry = MVM_calloc(sizeof(MVMHLLConfig), 1);
+        entry = MVM_calloc(1, sizeof(MVMHLLConfig));
         entry->name = name;
         entry->int_box_type = tc->instance->boot_types.BOOTInt;
         entry->num_box_type = tc->instance->boot_types.BOOTNum;

--- a/src/core/regionalloc.c
+++ b/src/core/regionalloc.c
@@ -19,7 +19,7 @@ void * MVM_region_alloc(MVMThreadContext *tc, MVMRegionAlloc *al, size_t bytes) 
             : MVM_REGIONALLOC_MEMBLOCK_SIZE;
         if (buffer_size < bytes)
             buffer_size = bytes;
-        block->buffer = MVM_calloc(buffer_size, 1);
+        block->buffer = MVM_calloc(1, buffer_size);
         block->alloc  = block->buffer;
         block->limit  = block->buffer + buffer_size;
         block->prev   = al->block;

--- a/src/core/validation.c
+++ b/src/core/validation.c
@@ -654,7 +654,7 @@ void MVM_validate_static_frame(MVMThreadContext *tc,
     val->bc_size   = fb->bytecode_size;
     val->src_cur_op = fb->bytecode;
     val->src_bc_end = fb->bytecode + fb->bytecode_size;
-    val->labels    = MVM_calloc(fb->bytecode_size, 1);
+    val->labels    = MVM_calloc(1, fb->bytecode_size);
     val->cur_info  = NULL;
     val->cur_mark  = NULL;
     val->cur_instr = 0;

--- a/src/gc/collect.c
+++ b/src/gc/collect.c
@@ -462,7 +462,7 @@ static void pass_work_item(MVMThreadContext *tc, WorkToPass *wtp, MVMCollectable
 
     /* See if there's a currently active list; create it if not. */
     if (!target_info->work) {
-        target_info->work = MVM_calloc(sizeof(MVMGCPassedWork), 1);
+        target_info->work = MVM_calloc(1, sizeof(MVMGCPassedWork));
     }
 
     /* Add this item to the work list. */

--- a/src/gc/gen2.c
+++ b/src/gc/gen2.c
@@ -6,7 +6,7 @@ MVMGen2Allocator * MVM_gc_gen2_create(MVMInstance *i) {
     MVMGen2Allocator *al = MVM_malloc(sizeof(MVMGen2Allocator));
 
     /* Create empty size classes array data structure. */
-    al->size_classes = (MVMGen2SizeClass *)MVM_calloc(1, sizeof(MVMGen2SizeClass) * MVM_GEN2_BINS);
+    al->size_classes = (MVMGen2SizeClass *)MVM_calloc(MVM_GEN2_BINS, sizeof(MVMGen2SizeClass));
 
     /* Set up overflows area. */
     al->alloc_overflows = MVM_GEN2_OVERFLOWS;

--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -800,7 +800,7 @@ typedef struct {
 /* Creates an SSAVarInfo for each local, initializing it with a list of nodes
  * that assign to the local. */
 static SSAVarInfo * initialize_ssa_var_info(MVMThreadContext *tc, MVMSpeshGraph *g) {
-    SSAVarInfo *var_info = MVM_calloc(sizeof(SSAVarInfo), g->num_locals);
+    SSAVarInfo *var_info = MVM_calloc(g->num_locals, sizeof(SSAVarInfo));
     MVMint32 i;
 
     /* Visit all instructions, looking for local writes. */

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -274,7 +274,7 @@ MVMint32 MVM_unicode_name_to_property_code(MVMThreadContext *tc, MVMString *name
 }
 
 static void generate_unicode_property_values_hashes(MVMThreadContext *tc) {
-    MVMUnicodeNameRegistry **hash_array = MVM_calloc(sizeof(MVMUnicodeNameRegistry *), MVM_NUM_PROPERTY_CODES);
+    MVMUnicodeNameRegistry **hash_array = MVM_calloc(MVM_NUM_PROPERTY_CODES, sizeof(MVMUnicodeNameRegistry *));
     MVMuint32 index = 0;
     MVMUnicodeNameRegistry *entry = NULL, *binaries = NULL;
     for ( ; index < num_unicode_property_value_keypairs; index++) {


### PR DESCRIPTION
NQP builds and passes `make m-test` and Rakudo builds and passes `make m-spectest`.