### PR TITLE
Save a tiny bit of space in 6 of our structs

### DIFF
--- a/src/6model/reprs/MVMCompUnit.h
+++ b/src/6model/reprs/MVMCompUnit.h
@@ -44,6 +44,12 @@ struct MVMCompUnitBody {
     MVMuint8  *data_start;
     MVMuint32  data_size;
 
+    /* Refers to the extops pointer below. Lives here for struct layout */
+    MVMuint16       num_extops;
+
+    /* See callsites, num_callsites, and orig_callsites below. */
+    MVMuint16       max_callsite_size;
+
     /* The code objects for each frame, along with counts of frames. */
     MVMObject      **coderefs;
     MVMuint32        num_frames;    /* Total, inc. added by inliner. */
@@ -58,10 +64,8 @@ struct MVMCompUnitBody {
     MVMCallsite **callsites;
     MVMuint32     num_callsites;
     MVMuint32     orig_callsites;
-    MVMuint16     max_callsite_size;
 
     /* The extension ops used by the compilation unit. */
-    MVMuint16       num_extops;
     MVMExtOpRecord *extops;
 
     /* The string heap and number of strings. */
@@ -86,11 +90,15 @@ struct MVMCompUnitBody {
      * never have its update getting moved ahead of writes into the table. */
     MVMuint32 *string_heap_fast_table;
     MVMuint32  string_heap_fast_table_top;
+
+    /* Refers to serialized below. sneaked in here to optimize struct layout */
+    MVMint32  serialized_size;
+
     MVMuint8  *string_heap_start;
     MVMuint8  *string_heap_read_limit;
 
     /* Serialized data, if any. */
-    MVMint32  serialized_size;
+    /* For its size, see serialized_size above. */
     MVMuint8 *serialized;
 
     /* Array of the resolved serialization contexts, and how many we

--- a/src/6model/reprs/MVMStaticFrame.h
+++ b/src/6model/reprs/MVMStaticFrame.h
@@ -49,6 +49,9 @@ struct MVMStaticFrameBody {
     /* The size in bytes to allocate for the work and arguments area. */
     MVMuint32 work_size;
 
+    /* Count of lexicals. */
+    MVMuint32 num_lexicals;
+
     /* Inital contents of the work area, copied into place to make sure we have
      * VMNulls in all the object slots. */
     MVMRegister *work_initial;
@@ -59,14 +62,20 @@ struct MVMStaticFrameBody {
     /* Count of locals. */
     MVMuint32 num_locals;
 
-    /* Count of lexicals. */
-    MVMuint32 num_lexicals;
-
     /* Frame exception handlers information. */
     MVMFrameHandler *handlers;
 
     /* The number of exception handlers this frame has. */
     MVMuint32 num_handlers;
+
+    /* Is the frame full deserialized? */
+    MVMuint8 fully_deserialized;
+
+    /* Is the frame a thunk, and thus hidden to caller/outer? */
+    MVMuint8 is_thunk;
+
+    /* Does the frame have an exit handler we need to run? */
+    MVMuint8 has_exit_handler;
 
     /* The compilation unit unique ID of this frame. */
     MVMString *cuuid;
@@ -86,15 +95,6 @@ struct MVMStaticFrameBody {
     /* Annotation details */
     MVMuint32              num_annotations;
     MVMuint8              *annotations_data;
-
-    /* Does the frame have an exit handler we need to run? */
-    MVMuint8 has_exit_handler;
-
-    /* Is the frame a thunk, and thus hidden to caller/outer? */
-    MVMuint8 is_thunk;
-
-    /* Is the frame full deserialized? */
-    MVMuint8 fully_deserialized;
 
     /* The original bytecode for this frame (before endian swapping). */
     MVMuint8 *orig_bytecode;

--- a/src/6model/serialization.h
+++ b/src/6model/serialization.h
@@ -6,6 +6,9 @@ struct MVMSerializationRoot {
     /* The version of the serialization format. */
     MVMint32 version;
 
+    /* How many parameterized type intern entries we have */
+    MVMint32  num_param_interns;
+
     /* The SC we're serializing/deserializing. */
     MVMSerializationContext *sc;
 
@@ -44,9 +47,7 @@ struct MVMSerializationRoot {
     MVMint32  num_repos;
     char     *repos_table;
 
-    /* The number of parameterized type intern entries, and the data segment
-     * containing them. */
-    MVMint32  num_param_interns;
+    /* The the data segment containing them parameterized type intern entries */
     char     *param_interns_data;
 
     /* Array of strings making up the string heap we are constructing. If we
@@ -98,6 +99,9 @@ struct MVMSerializationReader {
     /* Number of static code objects. */
     MVMuint32 num_static_codes;
 
+    /* Whether we're already working on these worklists. */
+    MVMuint32 working;
+
     /* Array of contexts (num_contexts in length). */
     MVMFrame **contexts;
 
@@ -106,9 +110,6 @@ struct MVMSerializationReader {
      * done, and we have the required object graph. */
     MVMDeserializeWorklist wl_objects;
     MVMDeserializeWorklist wl_stables;
-
-    /* Whether we're already working on these worklists. */
-    MVMuint32 working;
 
     /* The current object we're deserializing. */
     MVMObject *current_object;

--- a/src/io/syncstream.h
+++ b/src/io/syncstream.h
@@ -3,6 +3,9 @@ struct MVMIOSyncStreamData {
     /* is it a TTY? */
     MVMint8 is_tty;
 
+    /* Should we translate newlines? */
+    MVMint32 translate_newlines;
+
     /* The libuv handle to the stream-readable thingy. */
     uv_stream_t *handle;
 
@@ -23,9 +26,6 @@ struct MVMIOSyncStreamData {
 
     /* Current separator specification for line-by-line reading. */
     MVMDecodeStreamSeparators sep_spec;
-
-    /* Should we translate newlines? */
-    MVMint32 translate_newlines;
 };
 
 void MVM_io_syncstream_set_encoding(MVMThreadContext *tc, MVMOSHandle *h, MVMint64 encoding);

--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -11,22 +11,19 @@ struct MVMJitCode {
      * runtime (because we need a second dereference to figure the
      * labels out), but very simple for me now, and super-easy to
      * optimise at a later date */
-    MVMint32   num_labels;
-    void     **labels;
-
+    MVMint32       num_labels;
     MVMint32       num_bbs;
+    void         **labels;
     MVMint32      *bb_labels;
 
     MVMint32       num_deopts;
-    MVMJitDeopt    *deopts;
-
     MVMint32       num_inlines;
+    MVMJitDeopt    *deopts;
     MVMJitInline  *inlines;
 
     MVMint32       num_handlers;
-    MVMJitHandler *handlers;
-
     MVMint32       seq_nr;
+    MVMJitHandler *handlers;
 };
 
 MVMJitCode* MVM_jit_compile_graph(MVMThreadContext *tc, MVMJitGraph *graph);


### PR DESCRIPTION
Since the struct members used to be grouped together, feel free to reject any of the individual patches. Of course, the comments can also be changed to make things easier to figure out.