### PR TITLE
Multi cache no segfault on null

### DIFF
--- a/src/6model/reprs/MVMMultiCache.c
+++ b/src/6model/reprs/MVMMultiCache.c
@@ -185,8 +185,14 @@ MVMObject * MVM_multi_cache_add(MVMThreadContext *tc, MVMObject *cache_obj, MVMO
             i++;
         if ((cs->arg_flags[flag] & MVM_CALLSITE_ARG_MASK) == MVM_CALLSITE_ARG_OBJ) {
             MVMRegister  arg   = apc->args[i];
-            MVMSTable   *st    = STABLE(arg.o);
+            MVMSTable   *st;
             MVMuint32    is_rw = 0;
+
+            if (!arg.o) {
+                goto DONE;
+            }
+
+            st = STABLE(arg.o);
             if (st->container_spec && IS_CONCRETE(arg.o)) {
                 MVMContainerSpec const *contspec = st->container_spec;
                 if (!contspec->fetch_never_invokes)

--- a/src/6model/reprs/MVMMultiCache.c
+++ b/src/6model/reprs/MVMMultiCache.c
@@ -421,8 +421,14 @@ MVMObject * MVM_multi_cache_find_callsite_args(MVMThreadContext *tc, MVMObject *
         MVMuint64    arg_idx   = arg_match & MVM_MULTICACHE_ARG_IDX_FILTER;
         MVMuint64    type_id   = arg_match & MVM_MULTICACHE_TYPE_ID_FILTER;
         MVMRegister  arg       = args[arg_idx];
-        MVMSTable   *st        = STABLE(arg.o);
+        MVMSTable   *st;
         MVMuint64    is_rw     = 0;
+
+        if (MVM_is_null(tc, arg.o)) {
+            return NULL;
+        }
+
+        st = STABLE(arg.o);
         if (st->container_spec && IS_CONCRETE(arg.o)) {
             MVMContainerSpec const *contspec = st->container_spec;
             if (!contspec->fetch_never_invokes)

--- a/src/6model/reprs/MVMMultiCache.c
+++ b/src/6model/reprs/MVMMultiCache.c
@@ -430,7 +430,7 @@ MVMObject * MVM_multi_cache_find_callsite_args(MVMThreadContext *tc, MVMObject *
         MVMSTable   *st;
         MVMuint64    is_rw     = 0;
 
-        if (MVM_is_null(tc, arg.o)) {
+        if (!arg.o) {
             return NULL;
         }
 

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -988,7 +988,7 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
 
 /* Gets a code object for a frame, lazily deserializing it if needed. */
 MVMObject * MVM_frame_get_code_object(MVMThreadContext *tc, MVMCode *code) {
-    if (REPR(code)->ID != MVM_REPR_ID_MVMCode)
+    if (!code || REPR(code)->ID != MVM_REPR_ID_MVMCode)
         MVM_exception_throw_adhoc(tc, "getcodeobj needs a code ref");
 
     if (!code->body.code_object) {


### PR DESCRIPTION
liz' recent changes to how X works somehow managed to sneak a null pointer into these code paths, and i think it's much better to not segfault when that happens.

not 100% sure if the handling of null pointers in the cache is correct. I tried to make it "ignore the cache completely" when a null pointer arrives.