### PR TITLE
Inactivate async tasks

### DIFF
--- a/src/io/asyncsocket.c
+++ b/src/io/asyncsocket.c
@@ -36,8 +36,7 @@ static void on_read(uv_stream_t *handle, ssize_t nread, const uv_buf_t *buf) {
     ReadInfo         *ri  = (ReadInfo *)handle->data;
     MVMThreadContext *tc  = ri->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, ri->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, ri->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (nread >= 0) {
         MVMROOT(tc, t, {
@@ -261,8 +260,7 @@ static void on_write(uv_write_t *req, int status) {
     WriteInfo        *wi  = (WriteInfo *)req->data;
     MVMThreadContext *tc  = wi->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, wi->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, wi->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (status >= 0) {
         MVMROOT(tc, arr, {
@@ -529,8 +527,7 @@ static void on_connect(uv_connect_t* req, int status) {
     ConnectInfo      *ci  = (ConnectInfo *)req->data;
     MVMThreadContext *tc  = ci->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, ci->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, ci->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (status >= 0) {
         /* Allocate and set up handle. */
@@ -672,8 +669,7 @@ static void on_connection(uv_stream_t *server, int status) {
     ListenInfo       *li     = (ListenInfo *)server->data;
     MVMThreadContext *tc     = li->tc;
     MVMObject        *arr    = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t      = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, li->work_idx);
+    MVMAsyncTask     *t      = MVM_io_eventloop_get_active_work(tc, li->work_idx);
 
     uv_tcp_t         *client = MVM_malloc(sizeof(uv_tcp_t));
     int               r;
@@ -752,8 +748,7 @@ static void on_listen_cancelled(uv_handle_t *handle) {
     ListenInfo       *li = (ListenInfo *)handle->data;
     MVMThreadContext *tc = li->tc;
     MVM_io_eventloop_send_cancellation_notification(tc,
-        (MVMAsyncTask *)MVM_repr_at_pos_o(tc, tc->instance->event_loop_active,
-            li->work_idx));
+        MVM_io_eventloop_get_active_work(tc, li->work_idx));
 }
 static void listen_cancel(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task, void *data) {
     ListenInfo *li = (ListenInfo *)data;

--- a/src/io/asyncsocket.c
+++ b/src/io/asyncsocket.c
@@ -111,8 +111,7 @@ static void read_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_t
     /* Add to work in progress. */
     ReadInfo *ri  = (ReadInfo *)data;
     ri->tc        = tc;
-    ri->work_idx  = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    ri->work_idx  = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Start reading the stream. */
     handle_data = (MVMIOAsyncSocketData *)ri->handle->body.data;
@@ -303,8 +302,7 @@ static void write_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
     /* Add to work in progress. */
     WriteInfo *wi = (WriteInfo *)data;
     wi->tc        = tc;
-    wi->work_idx  = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    wi->work_idx  = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Encode the string, or extract buf data. */
     if (wi->str_data) {
@@ -571,8 +569,7 @@ static void connect_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *asyn
     /* Add to work in progress. */
     ConnectInfo *ci = (ConnectInfo *)data;
     ci->tc        = tc;
-    ci->work_idx  = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    ci->work_idx  = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Create and initialize socket and connection. */
     ci->socket        = MVM_malloc(sizeof(uv_tcp_t));
@@ -721,8 +718,7 @@ static void listen_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async
     /* Add to work in progress. */
     ListenInfo *li = (ListenInfo *)data;
     li->tc         = tc;
-    li->work_idx   = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    li->work_idx   = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Create and initialize socket and connection, and start listening. */
     li->socket        = MVM_malloc(sizeof(uv_tcp_t));

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -85,6 +85,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
         if (buf->base)
             MVM_free(buf->base);
         uv_udp_recv_stop(handle);
+        MVM_io_eventloop_remove_active_work(tc, &(ri->work_idx));
     }
     else {
         MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
@@ -101,6 +102,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
         if (buf->base)
             MVM_free(buf->base);
         uv_udp_recv_stop(handle);
+        MVM_io_eventloop_remove_active_work(tc, &(ri->work_idx));
     }
     MVM_repr_push_o(tc, t->body.queue, arr);
 }
@@ -293,6 +295,7 @@ static void on_write(uv_udp_send_t *req, int status) {
     if (wi->str_data)
         MVM_free(wi->buf.base);
     MVM_free(wi->req);
+    MVM_io_eventloop_remove_active_work(tc, &(wi->work_idx));
 }
 
 /* Does setup work for an asynchronous write. */
@@ -347,6 +350,7 @@ static void write_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
         /* Cleanup handle. */
         MVM_free(wi->req);
         wi->req = NULL;
+        MVM_io_eventloop_remove_active_work(tc, &(wi->work_idx));
     }
 }
 

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -114,8 +114,7 @@ static void read_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_t
     /* Add to work in progress. */
     ReadInfo *ri  = (ReadInfo *)data;
     ri->tc        = tc;
-    ri->work_idx  = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    ri->work_idx  = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Start reading the stream. */
     handle_data = (MVMIOAsyncUDPSocketData *)ri->handle->body.data;
@@ -307,8 +306,7 @@ static void write_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
     /* Add to work in progress. */
     WriteInfo *wi = (WriteInfo *)data;
     wi->tc        = tc;
-    wi->work_idx  = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    wi->work_idx  = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Encode the string, or extract buf data. */
     if (wi->str_data) {

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -39,8 +39,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
     ReadInfo         *ri  = (ReadInfo *)handle->data;
     MVMThreadContext *tc  = ri->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, ri->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, ri->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (nread >= 0) {
         MVMROOT(tc, t, {
@@ -265,8 +264,7 @@ static void on_write(uv_udp_send_t *req, int status) {
     WriteInfo        *wi  = (WriteInfo *)req->data;
     MVMThreadContext *tc  = wi->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, wi->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, wi->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (status >= 0) {
         MVMROOT(tc, arr, {

--- a/src/io/eventloop.c
+++ b/src/io/eventloop.c
@@ -173,3 +173,18 @@ MVMAsyncTask * MVM_io_eventloop_get_active_work(MVMThreadContext *tc, int work_i
         MVM_panic(1, "use of invalid eventloop work item index %d", work_idx);
     }
 }
+
+/* Removes an active work index from the active work list, enabling any
+ * memory associated with it to be collected. Replaces the work index with -1
+ * so that any future use of the task will be a failed lookup. */
+void MVM_io_eventloop_remove_active_work(MVMThreadContext *tc, int *work_idx_to_clear) {
+    int work_idx = *work_idx_to_clear;
+    if (work_idx >= 0 && work_idx < MVM_repr_elems(tc, tc->instance->event_loop_active)) {
+        *work_idx_to_clear = -1;
+        MVM_repr_bind_pos_o(tc, tc->instance->event_loop_active, work_idx, tc->instance->VMNull);
+        /* TODO: start to re-use the indices */
+    }
+    else {
+        MVM_panic(1, "cannot remove invalid eventloop work item index %d", work_idx);
+    }
+}

--- a/src/io/eventloop.c
+++ b/src/io/eventloop.c
@@ -153,3 +153,10 @@ void MVM_io_eventloop_send_cancellation_notification(MVMThreadContext *tc, MVMAs
     if (notify_queue && notify_schedulee)
         MVM_repr_push_o(tc, notify_queue, notify_schedulee);
 }
+
+/* Adds a work item to the active async task set. */
+int MVM_io_eventloop_add_active_work(MVMThreadContext *tc, MVMObject *async_task) {
+    int work_idx = MVM_repr_elems(tc, tc->instance->event_loop_active);
+    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    return work_idx;
+}

--- a/src/io/eventloop.c
+++ b/src/io/eventloop.c
@@ -160,3 +160,16 @@ int MVM_io_eventloop_add_active_work(MVMThreadContext *tc, MVMObject *async_task
     MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
     return work_idx;
 }
+
+/* Gets an active work item from the active work eventloop. */
+MVMAsyncTask * MVM_io_eventloop_get_active_work(MVMThreadContext *tc, int work_idx) {
+    if (work_idx >= 0 && work_idx < MVM_repr_elems(tc, tc->instance->event_loop_active)) {
+        MVMObject *task_obj = MVM_repr_at_pos_o(tc, tc->instance->event_loop_active, work_idx);
+        if (REPR(task_obj)->ID != MVM_REPR_ID_MVMAsyncTask)
+            MVM_panic(1, "non-AsyncTask fetched from eventloop active work list");
+        return (MVMAsyncTask *)task_obj;
+    }
+    else {
+        MVM_panic(1, "use of invalid eventloop work item index %d", work_idx);
+    }
+}

--- a/src/io/eventloop.h
+++ b/src/io/eventloop.h
@@ -21,3 +21,4 @@ void MVM_io_eventloop_send_cancellation_notification(MVMThreadContext *tc, MVMAs
 
 int MVM_io_eventloop_add_active_work(MVMThreadContext *tc, MVMObject *async_task);
 MVMAsyncTask * MVM_io_eventloop_get_active_work(MVMThreadContext *tc, int work_idx);
+void MVM_io_eventloop_remove_active_work(MVMThreadContext *tc, int *work_idx_to_clear);

--- a/src/io/eventloop.h
+++ b/src/io/eventloop.h
@@ -18,3 +18,5 @@ void MVM_io_eventloop_queue_work(MVMThreadContext *tc, MVMObject *work);
 void MVM_io_eventloop_cancel_work(MVMThreadContext *tc, MVMObject *task_obj,
     MVMObject *notify_queue, MVMObject *notify_schedulee);
 void MVM_io_eventloop_send_cancellation_notification(MVMThreadContext *tc, MVMAsyncTask *task_obj);
+
+int MVM_io_eventloop_add_active_work(MVMThreadContext *tc, MVMObject *async_task);

--- a/src/io/eventloop.h
+++ b/src/io/eventloop.h
@@ -20,3 +20,4 @@ void MVM_io_eventloop_cancel_work(MVMThreadContext *tc, MVMObject *task_obj,
 void MVM_io_eventloop_send_cancellation_notification(MVMThreadContext *tc, MVMAsyncTask *task_obj);
 
 int MVM_io_eventloop_add_active_work(MVMThreadContext *tc, MVMObject *async_task);
+MVMAsyncTask * MVM_io_eventloop_get_active_work(MVMThreadContext *tc, int work_idx);

--- a/src/io/filewatchers.c
+++ b/src/io/filewatchers.c
@@ -46,10 +46,9 @@ static void setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task, 
     int        r;
 
     /* Add task to active list. */
-    wi->work_idx    = MVM_repr_elems(tc, tc->instance->event_loop_active);
+    wi->work_idx    = MVM_io_eventloop_add_active_work(tc, async_task);
     wi->tc          = tc;
     wi->handle.data = wi;
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
 
     /* Start watching. */
     uv_fs_event_init(loop, &wi->handle);

--- a/src/io/filewatchers.c
+++ b/src/io/filewatchers.c
@@ -12,8 +12,7 @@ static void on_changed(uv_fs_event_t *handle, const char *filename, int events, 
     WatchInfo        *wi  = (WatchInfo *)handle->data;
     MVMThreadContext *tc  = wi->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, wi->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, wi->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     MVMROOT(tc, t, {
     MVMROOT(tc, arr, {

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -428,8 +428,7 @@ static void write_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
     /* Add to work in progress. */
     SpawnWriteInfo *wi = (SpawnWriteInfo *)data;
     wi->tc             = tc;
-    wi->work_idx       = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    wi->work_idx       = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Encode the string, or extract buf data. */
     if (wi->str_data) {
@@ -850,8 +849,7 @@ static void spawn_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
     /* Add to work in progress. */
     SpawnInfo *si = (SpawnInfo *)data;
     si->tc        = tc;
-    si->work_idx  = MVM_repr_elems(tc, tc->instance->event_loop_active);
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
+    si->work_idx  = MVM_io_eventloop_add_active_work(tc, async_task);
 
     /* Create input/output handles as needed. */
     if (MVM_repr_exists_key(tc, si->callbacks, tc->instance->str_consts.write)) {

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -385,8 +385,7 @@ static void on_write(uv_write_t *req, int status) {
     SpawnWriteInfo   *wi  = (SpawnWriteInfo *)req->data;
     MVMThreadContext *tc  = wi->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, wi->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, wi->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (status >= 0) {
         MVMROOT(tc, arr, {
@@ -698,8 +697,7 @@ static void async_spawn_on_exit(uv_process_t *req, MVMint64 exit_status, int ter
 
             /* Get what we'll need to build and convey the result. */
             MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-            MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-                tc->instance->event_loop_active, si->work_idx);
+            MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, si->work_idx);
 
             /* Box and send along status. */
             MVM_repr_push_o(tc, arr, done_cb);
@@ -741,7 +739,7 @@ static void async_read(uv_stream_t *handle, ssize_t nread, const uv_buf_t *buf, 
     MVMAsyncTask *t;
     MVMROOT(tc, callback, {
         arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-        t = (MVMAsyncTask *)MVM_repr_at_pos_o(tc, tc->instance->event_loop_active, si->work_idx);
+        t = MVM_io_eventloop_get_active_work(tc, si->work_idx);
     });
     MVM_repr_push_o(tc, arr, callback);
     if (nread >= 0) {

--- a/src/io/signals.c
+++ b/src/io/signals.c
@@ -20,8 +20,7 @@ static void signal_cb(uv_signal_t *handle, int sig_num) {
     SignalInfo       *si  = (SignalInfo *)handle->data;
     MVMThreadContext *tc  = si->tc;
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-    MVMAsyncTask     *t   = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, si->work_idx);
+    MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, si->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     MVMROOT(tc, t, {
     MVMROOT(tc, arr, {

--- a/src/io/signals.c
+++ b/src/io/signals.c
@@ -37,10 +37,9 @@ static void signal_cb(uv_signal_t *handle, int sig_num) {
 static void setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task, void *data) {
     SignalInfo *si = (SignalInfo *)data;
     uv_signal_init(loop, &si->handle);
-    si->work_idx    = MVM_repr_elems(tc, tc->instance->event_loop_active);
+    si->work_idx    = MVM_io_eventloop_add_active_work(tc, async_task);
     si->tc          = tc;
     si->handle.data = si;
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
     uv_signal_start(&si->handle, signal_cb, si->signum);
 }
 

--- a/src/io/timers.c
+++ b/src/io/timers.c
@@ -33,6 +33,7 @@ static void cancel(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task,
     uv_timer_stop(&ti->handle);
     MVM_io_eventloop_send_cancellation_notification(ti->tc,
         MVM_io_eventloop_get_active_work(tc, ti->work_idx));
+    MVM_io_eventloop_remove_active_work(tc, &(ti->work_idx));
 }
 
 /* Frees data associated with a timer async task. */

--- a/src/io/timers.c
+++ b/src/io/timers.c
@@ -22,10 +22,9 @@ static void timer_cb(uv_timer_t *handle) {
 static void setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task, void *data) {
     TimerInfo *ti = (TimerInfo *)data;
     uv_timer_init(loop, &ti->handle);
-    ti->work_idx    = MVM_repr_elems(tc, tc->instance->event_loop_active);
+    ti->work_idx    = MVM_io_eventloop_add_active_work(tc, async_task);
     ti->tc          = tc;
     ti->handle.data = ti;
-    MVM_repr_push_o(tc, tc->instance->event_loop_active, async_task);
     uv_timer_start(&ti->handle, timer_cb, ti->timeout, ti->repeat);
 }
 

--- a/src/io/timers.c
+++ b/src/io/timers.c
@@ -13,8 +13,7 @@ typedef struct {
 static void timer_cb(uv_timer_t *handle) {
     TimerInfo        *ti = (TimerInfo *)handle->data;
     MVMThreadContext *tc = ti->tc;
-    MVMAsyncTask     *t  = (MVMAsyncTask *)MVM_repr_at_pos_o(tc,
-        tc->instance->event_loop_active, ti->work_idx);
+    MVMAsyncTask     *t  = MVM_io_eventloop_get_active_work(tc, ti->work_idx);
     MVM_repr_push_o(tc, t->body.queue, t->body.schedulee);
 }
 
@@ -33,8 +32,7 @@ static void cancel(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task,
     TimerInfo *ti = (TimerInfo *)data;
     uv_timer_stop(&ti->handle);
     MVM_io_eventloop_send_cancellation_notification(ti->tc,
-        (MVMAsyncTask *)MVM_repr_at_pos_o(tc, ti->tc->instance->event_loop_active,
-            ti->work_idx));
+        MVM_io_eventloop_get_active_work(tc, ti->work_idx));
 }
 
 /* Frees data associated with a timer async task. */


### PR DESCRIPTION
This fixes a leak of async task handles, which was responsible for a managed memory leak (e.g. GC-managed objects that never became collectable). The mechanism to blame exists in order to safely have libuv callbacks able to obtain GC-managed references. We can't have the GC traverse libuv internals, so we stash the async task handles in an array, and store that index. This works well, but we needed to clear those array entries in the future, to avoid leaking AsyncTask handles. This is achieved by this work.

This gets rid of most of the leakage, but there is still a far more minor one: the task handles array itself will grow uboundedly. This will be fixed by re-using the indexes; that will happen in a future PR, once this one has gone in and had some real-world testing.