### PR TITLE
Add data section for JIT compiled code

### DIFF
--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -55,6 +55,9 @@ MVMJitCode * MVM_jit_compile_graph(MVMThreadContext *tc, MVMJitGraph *jg) {
         case MVM_JIT_NODE_CONTROL:
             MVM_jit_emit_control(tc, jg, &node->u.control, &state);
             break;
+        case MVM_JIT_NODE_DATA:
+            MVM_jit_emit_data(tc, jg, &node->u.data, &state);
+            break;
         }
         node = node->next;
     }

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -21,8 +21,8 @@ MVMJitCode * MVM_jit_compile_graph(MVMThreadContext *tc, MVMJitGraph *jg) {
 
     MVM_jit_log(tc, "Starting compilation\n");
 
-    /* setup dasm */
-    dasm_init(&state, 1);
+    /* setup dasm (data and code section) */
+    dasm_init(&state, 2);
     dasm_setupglobal(&state, dasm_globals, num_globals);
     dasm_setup(&state, MVM_jit_actions());
     dasm_growpc(&state, jg->num_labels);

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -21,3 +21,5 @@ void MVM_jit_emit_jumplist(MVMThreadContext *tc, MVMJitGraph *jg,
                            MVMJitJumpList *jumplist, dasm_State **Dst);
 void MVM_jit_emit_control(MVMThreadContext *tc, MVMJitGraph *jg,
                           MVMJitControl *ctrl, dasm_State **Dst);
+void MVM_jit_emit_data(MVMThreadContext *tc, MVMJitGraph *jg,
+                       MVMJitData *data, dasm_State **Dst);

--- a/src/jit/emit_x64.dasc
+++ b/src/jit/emit_x64.dasc
@@ -72,7 +72,7 @@
 
 |.arch x64
 |.actionlist actions
-|.section code
+|.section code, data
 |.globals MVM_JIT_LABEL_
 
 /* type declarations */
@@ -218,8 +218,11 @@ const unsigned int MVM_jit_num_globals(void) {
 
 
 |.macro callp, funcptr
-| mov64 FUNCTION, (uintptr_t)funcptr
-| call FUNCTION
+|.data
+|5:
+|.dword (MVMuint32)((uintptr_t)(funcptr)), (MVMuint32)((uintptr_t)(funcptr) >> 32);
+|.code
+| call qword [<5];
 |.endmacro
 
 
@@ -285,6 +288,7 @@ const unsigned int MVM_jit_num_globals(void) {
  * via a frame. All JIT entry points receive a prologue. */
 void MVM_jit_emit_prologue(MVMThreadContext *tc, MVMJitGraph *jg,
                            dasm_State **Dst) {
+    |.code
     /* Setup stack */
     | push rbp; // nb, this aligns the stack to 16 bytes again
     | mov rbp, rsp;

--- a/src/jit/emit_x64.dasc
+++ b/src/jit/emit_x64.dasc
@@ -1814,6 +1814,9 @@ static void load_call_arg(MVMThreadContext *tc, MVMJitGraph *jg,
         | mov TMP6, qword WORK[arg.v.reg];
         | lea TMP6, STOOGE:TMP6->data;
         break;
+    case MVM_JIT_DATA_LABEL:
+        | lea TMP6, [=>(arg.v.lit_i64)];
+        break;
     }
 }
 
@@ -1928,6 +1931,7 @@ static void emit_posix_callargs(MVMThreadContext *tc, MVMJitGraph *jg,
         case MVM_JIT_LITERAL:
         case MVM_JIT_LITERAL_64:
         case MVM_JIT_LITERAL_PTR:
+        case MVM_JIT_DATA_LABEL:
             if (num_gpr < 6) {
                 in_gpr[num_gpr++] = args[i];
             } else {
@@ -2481,4 +2485,15 @@ void MVM_jit_emit_control(MVMThreadContext *tc, MVMJitGraph *jg,
     } else {
         MVM_panic(1, "Unknown conrtol code: <%s>", ctrl->ins->info->name);
     }
+}
+
+void MVM_jit_emit_data(MVMThreadContext *tc, MVMJitGraph *jg, MVMJitData *data, dasm_State **Dst) {
+    MVMuint8 *bytes = data->data;
+    MVMint32 i;
+    |.data;
+    |=>(data->label):
+    for (i = 0; i < data->size; i++) {
+        |.byte bytes[i];
+    }
+    |.code
 }

--- a/src/jit/graph.h
+++ b/src/jit/graph.h
@@ -101,6 +101,7 @@ typedef enum {
     MVM_JIT_LITERAL_PTR,
     MVM_JIT_REG_STABLE,
     MVM_JIT_REG_OBJBODY,
+    MVM_JIT_DATA_LABEL,
 } MVMJitArgType;
 
 struct MVMJitCallArg {
@@ -160,6 +161,12 @@ struct MVMJitJumpList {
     MVMint32 *out_labels;
 };
 
+struct MVMJitData {
+    MVMint32 label;
+    void     *data;
+    size_t    size;
+};
+
 /* Node types */
 typedef enum {
     MVM_JIT_NODE_PRIMITIVE,
@@ -170,6 +177,7 @@ typedef enum {
     MVM_JIT_NODE_INVOKE,
     MVM_JIT_NODE_JUMPLIST,
     MVM_JIT_NODE_CONTROL,
+    MVM_JIT_NODE_DATA,
 } MVMJitNodeType;
 
 struct MVMJitNode {
@@ -184,6 +192,7 @@ struct MVMJitNode {
         MVMJitInvoke    invoke;
         MVMJitJumpList  jumplist;
         MVMJitControl   control;
+        MVMJitData      data;
     } u;
 };
 

--- a/src/jit/stub.c
+++ b/src/jit/stub.c
@@ -37,3 +37,4 @@ void MVM_jit_emit_jumplist(MVMThreadContext *tc, MVMJitGraph *jg,
                            MVMJitJumpList *jumplist, dasm_State **Dst) {}
 void MVM_jit_emit_control(MVMThreadContext *tc, MVMJitGraph *jg,
                           MVMJitControl *ctrl, dasm_State **Dst) {}
+void MVM_jit_emit_data(MVMThreadContext *tc, MVMJitGraph *jg, MVMJitData *data, dasm_State **Dst) {}

--- a/src/types.h
+++ b/src/types.h
@@ -227,6 +227,7 @@ typedef struct MVMJitGuard MVMJitGuard;
 typedef struct MVMJitInvoke MVMJitInvoke;
 typedef struct MVMJitJumpList MVMJitJumpList;
 typedef struct MVMJitControl MVMJitControl;
+typedef struct MVMJitData MVMJitData;
 typedef struct MVMJitCode MVMJitCode;
 typedef struct MVMProfileThreadData MVMProfileThreadData;
 typedef struct MVMProfileGC MVMProfileGC;


### PR DESCRIPTION
Adding a data section allows us to store large data blobs in code rather than loading them as constants or using externally allocated memory. This is expected to plug a memory leak of malloc()'ed extop 'fake registers', and it is used to store constant pointers to functions, avoiding emitting a large 'movabs' instruction.