### PR TITLE
Fix overflow in div_i op

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -507,8 +507,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 6;
                 goto NEXT;
             OP(div_i): {
-                int num   = GET_REG(cur_op, 2).i64;
-                int denom = GET_REG(cur_op, 4).i64;
+                MVMint64 num   = GET_REG(cur_op, 2).i64;
+                MVMint64 denom = GET_REG(cur_op, 4).i64;
                 // if we have a negative result, make sure we floor rather
                 // than rounding towards zero.
                 if (denom == 0)


### PR DESCRIPTION
The op uses `int` which overflows on large numbers, making the op
produce wrong results.

Fix by using MVMint64 instead.

Fixes RT#130686: https://rt.perl.org/Ticket/Display.html?id=130686