### PR TITLE
Fix abs_n op for negative zeros

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -696,7 +696,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(abs_n):
                 {
                     MVMnum64 num = GET_REG(cur_op, 2).n64;
-                    if (num < 0) num = num * -1;
+                    /* The 1.0/num logic checks for a negative zero */
+                    if (num < 0 || num == 0 && 1.0/num < 0 ) num = num * -1;
                     GET_REG(cur_op, 0).n64 = num;
                     cur_op += 4;
                 }


### PR DESCRIPTION
Currently, abs_n(-0e0) leaves the sign intact, returning -0e0.

IEEE 754-2008[^1], section 5.5.1 says "abs(x) copies a floating-point
operand x to a destination in the same format, setting the sign bit
to 0 (positive)." Which means the -0e0 needs to become 0e0.

Fix by adding a check for negative zero together with a check for
other negatives.

[1] http://www.csee.umbc.edu/%7Etsimo1/CMSC455/IEEE-754-2008.pdf