### PR TITLE
On Windows, improve handling of Unicode in command line arguments and environment strings

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -512,11 +512,6 @@ print "\n", <<TERM, "\n";
   3rdparty: $thirdpartylibs
 TERM
 
-# make sure to link with the correct entry point */
-if ($config{win32_compiler_toolchain} eq 'mingw32') {
-    $config{ldflags} .= ' -municode';
-}
-
 # read list of files to generate
 
 open my $listfile, '<', $GENLIST

--- a/Configure.pl
+++ b/Configure.pl
@@ -512,6 +512,12 @@ print "\n", <<TERM, "\n";
   3rdparty: $thirdpartylibs
 TERM
 
+# make sure to link with the correct entry point */
+$config{mingw_unicode} = '';
+if ($config{os} eq 'mingw32') {
+    $config{mingw_unicode} = '-municode';
+}
+
 # read list of files to generate
 
 open my $listfile, '<', $GENLIST

--- a/Configure.pl
+++ b/Configure.pl
@@ -512,6 +512,11 @@ print "\n", <<TERM, "\n";
   3rdparty: $thirdpartylibs
 TERM
 
+# make sure to link with the correct entry point */
+if ($config{win32_compiler_toolchain} eq 'mingw32') {
+    $config{ldflags} .= ' -municode';
+}
+
 # read list of files to generate
 
 open my $listfile, '<', $GENLIST

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -14,7 +14,7 @@ RM_RF  = $(PERL) -MExtUtils::Command -e rm_rf
 RM_F   = $(PERL) -MExtUtils::Command -e rm_f
 DYNASM = $(LUA) @dynasmlua@
 
-
+MINGW_UNICODE = @mingw_unicode@
 
 CONFIG    = @config@
 ADDCONFIG =
@@ -488,7 +488,7 @@ clangcheck gcccheck:
 
 moar@exe@: $(MAIN_OBJECTS) @moar@
 	$(MSG) linking $@
-	$(CMD)$(LD) @ldout@$@ $(LDFLAGS) $(MAIN_OBJECTS) $(MAIN_LIBS)
+	$(CMD)$(LD) @ldout@$@ $(LDFLAGS) $(MINGW_UNICODE) $(MAIN_OBJECTS) $(MAIN_LIBS)
 
 @moarlib@: $(OBJECTS) $(THIRDPARTY)
 	$(MSG) linking $@

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -33,7 +33,7 @@ static wchar_t * ANSIToUnicode(MVMuint16 acp, const char *str)
 static char * UnicodeToUTF8(const wchar_t *str)
 {
      const int       len = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
-     char * const result = (char *)MVM_malloc(len * sizeof(char));
+     char * const result = (char *)MVM_malloc(len + 1);
 
      WideCharToMultiByte(CP_UTF8, 0, str, -1, result, len, NULL, NULL);
 
@@ -47,6 +47,19 @@ static char * ANSIToUTF8(MVMuint16 acp, const char * str)
 
     MVM_free(wstr);
     return result;
+}
+
+MVM_PUBLIC char **
+UnicodeToUTF8_argv(const int argc, const wchar_t **wargv)
+{
+    int i;
+    char **argv = MVM_malloc((argc + 1) * sizeof(*argv));
+    for (i = 0; i < argc; ++i)
+    {
+        argv[i] = UnicodeToUTF8(wargv[i]);
+    }
+    argv[i] = NULL;
+    return argv;
 }
 
 #endif

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -50,7 +50,7 @@ static char * ANSIToUTF8(MVMuint16 acp, const char * str)
 }
 
 MVM_PUBLIC char **
-UnicodeToUTF8_argv(const int argc, wchar_t **wargv)
+MVM_UnicodeToUTF8_argv(const int argc, wchar_t **wargv)
 {
     int i;
     char **argv = MVM_malloc((argc + 1) * sizeof(*argv));

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -1227,7 +1227,6 @@ MVMObject * MVM_proc_clargs(MVMThreadContext *tc) {
         });
 #else
         MVMROOT(tc, clargs, {
-            const MVMuint16 acp = GetACP();
             const MVMint64 num_clargs = instance->num_clargs;
             MVMint64 count;
 
@@ -1240,10 +1239,8 @@ MVMObject * MVM_proc_clargs(MVMThreadContext *tc) {
 
             for (count = 0; count < num_clargs; count++) {
                 char *raw_clarg = instance->raw_clargs[count];
-                char * const _tmp = ANSIToUTF8(acp, raw_clarg);
                 MVMString *string = MVM_string_utf8_c8_decode(tc,
-                    instance->VMString, _tmp, strlen(_tmp));
-                MVM_free(_tmp);
+                    instance->VMString, raw_clarg, strlen(raw_clarg));
                 boxed_str = MVM_repr_box_str(tc,
                     instance->boot_types.BOOTStr, string);
                 MVM_repr_push_o(tc, clargs, boxed_str);

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -49,11 +49,11 @@ static char * ANSIToUTF8(MVMuint16 acp, const char * str)
     return result;
 }
 
-MVM_PUBLIC char **
+MVM_PUBLIC const char **
 UnicodeToUTF8_argv(const int argc, const wchar_t **wargv)
 {
     int i;
-    char **argv = MVM_malloc((argc + 1) * sizeof(*argv));
+    const char **argv = MVM_malloc((argc + 1) * sizeof(*argv));
     for (i = 0; i < argc; ++i)
     {
         argv[i] = UnicodeToUTF8(wargv[i]);

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -17,7 +17,6 @@ extern char **environ;
 #  endif
 #else
 #include <stdlib.h>
-extern char **_wenvrion;
 #endif
 
 #ifdef _WIN32

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -13,11 +13,11 @@
 #    include <crt_externs.h>
 #    define environ (*_NSGetEnviron())
 #  else
-#include <stdlib.h>
-extern char ** _wenvrion;
+extern char **environ;
 #  endif
 #else
-#  include <process.h>
+#include <stdlib.h>
+extern char **_wenvrion;
 #endif
 
 #ifdef _WIN32

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -49,11 +49,11 @@ static char * ANSIToUTF8(MVMuint16 acp, const char * str)
     return result;
 }
 
-MVM_PUBLIC const char **
-UnicodeToUTF8_argv(const int argc, const wchar_t **wargv)
+MVM_PUBLIC char **
+UnicodeToUTF8_argv(const int argc, wchar_t **wargv)
 {
     int i;
-    const char **argv = MVM_malloc((argc + 1) * sizeof(*argv));
+    char **argv = MVM_malloc((argc + 1) * sizeof(*argv));
     for (i = 0; i < argc; ++i)
     {
         argv[i] = UnicodeToUTF8(wargv[i]);

--- a/src/io/procops.h
+++ b/src/io/procops.h
@@ -29,3 +29,9 @@ MVMint64 MVM_proc_time_i(MVMThreadContext *tc);
 MVMObject * MVM_proc_clargs(MVMThreadContext *tc);
 MVMnum64 MVM_proc_time_n(MVMThreadContext *tc);
 MVMString * MVM_executable_name(MVMThreadContext *tc);
+
+#ifdef _WIN32
+#include <wchar.h>
+MVM_PUBLIC char ** MVM_UnicodeToUTF8_argv(const int argc, wchar_t **argv);
+#endif
+

--- a/src/main.c
+++ b/src/main.c
@@ -97,18 +97,31 @@ static int parse_flag(const char *arg)
         return UNKNOWN_FLAG;
 }
 
+#ifndef _WIN32
 int main(int argc, char *argv[])
+#else
+
+char ** UnicodeToUTF8_argv(const int argc, const wchar_t **wargv);
+
+int wmain(int argc, wchar_t *wargv[])
+
+#endif
 {
     MVMInstance *instance;
     const char  *input_file;
     const char  *executable_name = NULL;
     const char  *lib_path[8];
 
+#ifdef _WIN32
+    char **argv = UnicodeToUTF8_argv(argc, wargv);
+#endif
+
     int dump         = 0;
     int full_cleanup = 0;
     int argi         = 1;
     int lib_path_i   = 0;
     int flag;
+
     for (; (flag = parse_flag(argv[argi])) != NOT_A_FLAG; ++argi) {
         switch (flag) {
             case FLAG_CRASH:

--- a/src/main.c
+++ b/src/main.c
@@ -100,11 +100,7 @@ static int parse_flag(const char *arg)
 #ifndef _WIN32
 int main(int argc, char *argv[])
 #else
-
-char ** UnicodeToUTF8_argv(const int argc, wchar_t **wargv);
-
 int wmain(int argc, wchar_t *wargv[])
-
 #endif
 {
     MVMInstance *instance;
@@ -113,7 +109,7 @@ int wmain(int argc, wchar_t *wargv[])
     const char  *lib_path[8];
 
 #ifdef _WIN32
-    char **argv = UnicodeToUTF8_argv(argc, wargv);
+    char **argv = MVM_UnicodeToUTF8_argv(argc, wargv);
 #endif
 
     int dump         = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -101,7 +101,7 @@ static int parse_flag(const char *arg)
 int main(int argc, char *argv[])
 #else
 
-char ** UnicodeToUTF8_argv(const int argc, const wchar_t **wargv);
+char ** UnicodeToUTF8_argv(const int argc, wchar_t **wargv);
 
 int wmain(int argc, wchar_t *wargv[])
 


### PR DESCRIPTION
These changes relate to issue #527. With the changes included in this request, I get:

```
C:\> chcp 65001
Active code page: 65001

C:\> set iş=kârlı

C:\> perl6 -e "say %*ENV<iş>"
kârlı

C:\> perl6 -e "say 'kârlı iş'"
kârlı iş
```

This the kind of thing that "works on my machine" ... I'd rather see someone else try them out with the full test suite before recommending any merges.

I tried to make the smallest number of edits to get the desired output. I am not very familiar with the ins and outs of the source code and I might have missed something important, but I hope this helps.

PS: Most importantly, I couldn't decide where/if the `wargv` array and the strings to which it points should be freed.