### PR TITLE
Enforce consistent commenting style

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -509,8 +509,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(div_i): {
                 MVMint64 num   = GET_REG(cur_op, 2).i64;
                 MVMint64 denom = GET_REG(cur_op, 4).i64;
-                // if we have a negative result, make sure we floor rather
-                // than rounding towards zero.
+                /* if we have a negative result, make sure we floor rather
+                 * than rounding towards zero. */
                 if (denom == 0)
                     MVM_exception_throw_adhoc(tc, "Division by zero");
                 if ((num < 0) ^ (denom < 0)) {
@@ -5550,7 +5550,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (tc->cur_frame->spesh_cand->jitcode == NULL) {
                     MVM_exception_throw_adhoc(tc, "Try to enter NULL jitcode");
                 }
-                // trampoline back to this opcode
+                /* trampoline back to this opcode */
                 cur_op -= 2;
                 if (MVM_jit_enter_code(tc, cu, tc->cur_frame->spesh_cand->jitcode)) {
                     if (MVM_frame_try_return(tc) == 0)

--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -281,7 +281,7 @@ MVMint64 MVM_file_isexecutable(MVMThreadContext *tc, MVMString *filename, MVMint
         if ((statbuf.st_mode & S_IFMT) == S_IFDIR)
             return 1;
         else {
-            // true if fileext is in PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
+            /* true if fileext is in PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC */
             MVMString *dot = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, ".");
             MVMROOT(tc, dot, {
                 MVMint64 n = MVM_string_index_from_end(tc, filename, dot, 0);

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -55,7 +55,7 @@ static void jgb_append_call_c(MVMThreadContext *tc, JitGraphBuilder *jgb,
     node->type             = MVM_JIT_NODE_CALL_C;
     node->u.call.func_ptr  = func_ptr;
     node->u.call.num_args  = num_args;
-    node->u.call.has_vargs = 0; // don't support them yet
+    node->u.call.has_vargs = 0; /* don't support them yet */
     /* Call argument array is typically stack allocated,
      * so they need to be copied */
     node->u.call.args      = MVM_spesh_alloc(tc, jgb->sg, args_size);
@@ -225,7 +225,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_unbox_n: return MVM_repr_get_num;
     case MVM_OP_istrue: case MVM_OP_isfalse: return MVM_coerce_istrue;
     case MVM_OP_istype: return MVM_6model_istype;
-    case MVM_OP_isint: case MVM_OP_isnum: case MVM_OP_isstr: // continued
+    case MVM_OP_isint: case MVM_OP_isnum: case MVM_OP_isstr: /* continued */
     case MVM_OP_islist: case MVM_OP_ishash: return MVM_repr_compare_repr_id;
     case MVM_OP_wval: case MVM_OP_wval_wide: return MVM_sc_get_sc_object;
     case MVM_OP_scgetobjidx: return MVM_sc_find_object_idx_jit;
@@ -574,10 +574,10 @@ static MVMint32 jgb_consume_jumplist(MVMThreadContext *tc, JitGraphBuilder *jgb,
     MVMJitNode *node;
     MVMint64 i;
     for (i = 0; i < num_labels; i++) {
-        bb = bb->linear_next; // take the next basic block
-        if (!bb || bb->first_ins != bb->last_ins) return 0; //  which must exist
-        ins = bb->first_ins;  //  and it's first and only entry
-        if (ins->info->opcode != MVM_OP_goto)  // which must be a goto
+        bb = bb->linear_next; /* take the next basic block */
+        if (!bb || bb->first_ins != bb->last_ins) return 0; /*  which must exist */
+        ins = bb->first_ins;  /*  and it's first and only entry */
+        if (ins->info->opcode != MVM_OP_goto)  /* which must be a goto */
             return 0;
         in_labels[i]  = get_label_for_bb(tc, jgb, bb);
         out_labels[i] = get_label_for_bb(tc, jgb, ins->operands[0].ins_bb);
@@ -1644,10 +1644,10 @@ static MVMint32 jgb_consume_ins(MVMThreadContext *tc, JitGraphBuilder *jgb,
         MVMint16 dst = jgb->sg->num_locals + jgb->sg->sf->body.cu->body.max_callsite_size - 1;
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL,  { obj } },
-                                 { MVM_JIT_REG_ADDR, { dst } }, // destination register (in args space)
-                                 { MVM_JIT_LITERAL, { 0 } }, // true code
-                                 { MVM_JIT_LITERAL, { 0 } }, // false code
-                                 { MVM_JIT_LITERAL, { op == MVM_OP_unless_o } }}; // switch
+                                 { MVM_JIT_REG_ADDR, { dst } }, /* destination register (in args space) */
+                                 { MVM_JIT_LITERAL, { 0 } }, /* true code */
+                                 { MVM_JIT_LITERAL, { 0 } }, /* false code */
+                                 { MVM_JIT_LITERAL, { op == MVM_OP_unless_o } }}; /* switch */
         MVMSpeshIns * branch = MVM_spesh_alloc(tc, jgb->sg, sizeof(MVMSpeshIns));
         if (dst + 1 <= jgb->sg->num_locals) {
             MVM_oops(tc, "JIT: no space in args buffer to store"

--- a/src/jit/graph.h
+++ b/src/jit/graph.h
@@ -155,9 +155,9 @@ struct MVMJitInvoke {
 struct MVMJitJumpList {
     MVMint64 num_labels;
     MVMint16 reg;
-    // labels of the goto's / jump instructions themselves
+    /* labels of the goto's / jump instructions themselves */
     MVMint32 *in_labels;
-    // labels the goto's jump to
+    /* labels the goto's jump to */
     MVMint32 *out_labels;
 };
 
@@ -181,8 +181,8 @@ typedef enum {
 } MVMJitNodeType;
 
 struct MVMJitNode {
-    MVMJitNode   * next; // linked list
-    MVMJitNodeType type; // tag
+    MVMJitNode   * next; /* linked list */
+    MVMJitNodeType type; /* tag */
     union {
         MVMJitPrimitive prim;
         MVMJitCallC     call;

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -495,9 +495,9 @@ MVMObject * MVM_bigint_mod(MVMThreadContext *tc, MVMObject *result_type, MVMObje
 
     bc = get_bigint_body(tc, result);
 
-    // XXX the behavior of C's mod operator is not correct
-    // for our purposes. So we rely on mp_mod for all our modulus
-    // calculations for now.
+    /* XXX the behavior of C's mod operator is not correct
+     * for our purposes. So we rely on mp_mod for all our modulus
+     * calculations for now. */
     if (1 || MVM_BIGINT_IS_BIG(ba) || MVM_BIGINT_IS_BIG(bb)) {
         mp_int *tmp[2] = { NULL, NULL };
         mp_int *ia = force_bigint(ba, tmp);
@@ -542,7 +542,7 @@ MVMObject *MVM_bigint_div(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
 
     bc = get_bigint_body(tc, result);
 
-    // we only care about MP_LT or !MP_LT, so we give MP_GT even for 0.
+    /* we only care about MP_LT or !MP_LT, so we give MP_GT even for 0. */
     if (MVM_BIGINT_IS_BIG(ba)) {
         cmp_a = !mp_iszero(ba->u.bigint) && SIGN(ba->u.bigint) == MP_NEG ? MP_LT : MP_GT;
     } else {
@@ -562,9 +562,9 @@ MVMObject *MVM_bigint_div(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
         ic = MVM_malloc(sizeof(mp_int));
         mp_init(ic);
 
-        // if we do a div with a negative, we need to make sure
-        // the result is floored rather than rounded towards
-        // zero, like C and libtommath would do.
+        /* if we do a div with a negative, we need to make sure
+         * the result is floored rather than rounded towards
+         * zero, like C and libtommath would do. */
         if ((cmp_a == MP_LT) ^ (cmp_b == MP_LT)) {
             mp_init(&remainder);
             mp_init(&intermediate);
@@ -932,8 +932,8 @@ MVMint64 MVM_bigint_is_prime(MVMThreadContext *tc, MVMObject *a, MVMint64 b) {
             return result;
         }
     } else {
-        // we only reach this if we have a smallint that's equal to 1.
-        // which we define as not-prime.
+        /* we only reach this if we have a smallint that's equal to 1.
+         * which we define as not-prime. */
         return 0;
     }
 }
@@ -1066,7 +1066,7 @@ MVMint64 MVM_bigint_is_big(MVMThreadContext *tc, MVMObject *a) {
             is_big = 1;
         return is_big;
     } else {
-        // if it's in a smallint, it's 32 bits big at most and fits into an INTVAL easily.
+        /* if it's in a smallint, it's 32 bits big at most and fits into an INTVAL easily. */
         return 0;
     }
 }

--- a/src/strings/normalize.c
+++ b/src/strings/normalize.c
@@ -559,11 +559,11 @@ static MVMint32 should_break(MVMThreadContext *tc, MVMCodepoint a, MVMCodepoint 
             break;
         /* Don't break after Prepend Grapheme_Cluster_Break=Prepend */
         case MVM_UNICODE_PVALUE_GCB_PREPEND:
-            // If it's a control character remember to break
+            /* If it's a control character remember to break */
             if (is_control_beyond_latin1(tc, b )) {
                 return 1;
             }
-            // Otherwise don't break
+            /* Otherwise don't break */
             return 0;
         /* Don't break after ZWJ for E_Base_GAZ or Glue_After_ZWJ */
         case MVM_UNICODE_PVALUE_GCB_ZWJ:


### PR DESCRIPTION
Use /* */ instead of //

// commenting is not part of C standards before C99