### PR TITLE
Fix overflow on 32 bit systems in is_full_collection()

### DIFF
--- a/src/gc/orchestrate.c
+++ b/src/gc/orchestrate.c
@@ -286,11 +286,11 @@ MVMint32 MVM_gc_is_thread_blocked(MVMThreadContext *tc) {
 }
 
 static MVMint32 is_full_collection(MVMThreadContext *tc) {
-    MVMuint64 percent_growth;
-    size_t rss, promoted;
+    MVMuint64 percent_growth, promoted;
+    size_t rss;
 
     /* If it's below the absolute minimum, quickly return. */
-    promoted = (size_t)MVM_load(&tc->instance->gc_promoted_bytes_since_last_full);
+    promoted = (MVMuint64)MVM_load(&tc->instance->gc_promoted_bytes_since_last_full);
     if (promoted < MVM_GC_GEN2_THRESHOLD_MINIMUM)
         return 0;
 
@@ -302,7 +302,8 @@ static MVMint32 is_full_collection(MVMThreadContext *tc) {
     /* Otherwise, consider percentage of resident set size. */
     if (uv_resident_set_memory(&rss) < 0 || rss == 0)
         rss = 50 * 1024 * 1024;
-    percent_growth = (100 * promoted) / rss;
+    percent_growth = (100 * promoted) / (MVMuint64)rss;
+
     return percent_growth >= MVM_GC_GEN2_THRESHOLD_PERCENT;
 }
 


### PR DESCRIPTION
In order to figure out whether a full GC should be made the code
has logic which calculates the percentage of 'promoted' bytes as part
of the resident set size. If the calculated percentage is equal to
or larger than MVM_GC_GEN2_THRESHOLD_PERCENT a full collection will
be made. However, the code which calculate the percent_growth does
not work properly on 32 bit systems due to the fact that size_t is
only 32 bits on such systems. When 'promoted' was multiplied by 100
an overflow would occur as soon as that variable contained a large
enough value. This, in turn, would lead to a situation where a full
collection would never be made which in the end lead to an out of
memory error.

Changing the type of the variable 'promoted' to MVMuint64 fixes the
problem on 32 bit systems. The problem didn't appear on 64-bit
systems since size_t is 64 bits there.