### PR TITLE
Issue #533: MoarVM does not build on `cygwin`.

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -834,8 +834,7 @@ turns on Address Sanitizer when compiling with C<clang>.  Defaults to off.
 Set the operating system name which you are compiling to.
 
 Currently supported operating systems are C<posix>, C<linux>, C<darwin>,
-C<openbsd>, C<netbsd>, C<freebsd>, C<solaris>, C<win32>, C<cygwin> and
-C<mingw32>.
+C<openbsd>, C<netbsd>, C<freebsd>, C<solaris>, C<win32>, and C<mingw32>.
 
 If not explicitly set, the option will be provided by the Perl runtime.
 In case of unknown operating systems, a POSIX userland is assumed.


### PR DESCRIPTION
Remove mention of `cygwin` support from `Configure.pl`.