### PR TITLE
Yet another attempt at silencing the pthread_yield warnings

### DIFF
--- a/build/probe.pm
+++ b/build/probe.pm
@@ -412,15 +412,21 @@ sub pthread_yield {
     _spew('try.c', <<'EOT');
 #include <stdlib.h>
 #include <pthread.h>
+#include <unistd.h>
 
 int main(int argc, char **argv) {
+#ifdef _POSIX_PRIORITY_SCHEDULING
+    /* hide pthread_yield so we fall back to the recommended sched_yield() */
+    return EXIT_FAILURE;
+#else
     pthread_yield();
     return EXIT_SUCCESS;
+#endif
 }
 EOT
 
     print ::dots('    probing pthread_yield support');
-    my $has_pthread_yield = compile($config, 'try');
+    my $has_pthread_yield = compile($config, 'try') && system('./try') == 0;
     print $has_pthread_yield ? "YES\n": "NO\n";
     $config->{has_pthread_yield} = $has_pthread_yield || 0
 }


### PR DESCRIPTION
According to commit d47dec1c1c229e22037b9e2bf8429a1a713b1c80 sched_yield
should be used when _POSIX_PRIORITY_SCHEDULING is defined. We lost that
with commit ddb1bf9e47715c03209153fa7fe06f6a9cc61bd3.

According to sched_yield(2) POSIX systems on which sched_yield() is
available define _POSIX_PRIORITY_SCHEDULING in <unistd.h>.
As src/platform/threads.h falls back to sched_yield if pthread_yield is
unavailable we sabotage pthread_yield detection if _POSIX_PRIORITY_SCHEDULING
is defined. I hope that this roundabout way has minimal impact on other
situations.