### PR TITLE
Update libuv to v1.11.0

### DIFF
--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -96,7 +96,7 @@ static void seek(MVMThreadContext *tc, MVMOSHandle *h, MVMint64 offset, MVMint64
     data->ds = MVM_string_decodestream_create(tc, data->encoding, r, 1);
 }
 
-/* Get curernt position in the file. */
+/* Get current position in the file. */
 static MVMint64 mvm_tell(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOFileData *data = (MVMIOFileData *)h->body.data;
     MVMint64 r;


### PR DESCRIPTION
NQP builds and passes `make m-test`. Rakudo builds t/spec/S11-modules/nested.t didn't run during a `make m-spectest`, however I did a whole bunch (~500) of `make t/spec/S11-modules/nested.t` in a loop and they all passed.