### PR TITLE
Use HTTPS protocol for fetching libtommath

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/MoarVM/dynasm.git
 [submodule "3rdparty/libtommath"]
 	path = 3rdparty/libtommath
-	url = git://github.com/MoarVM/libtommath
+	url = https://github.com/MoarVM/libtommath


### PR DESCRIPTION
Some organizations won't allow the git protocol, but will allow https.