### PR TITLE
UTF-8 Provide a better error when failing to encode surrogates or out of bounds characters

### DIFF
--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -468,11 +468,19 @@ char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
             result_pos += repl_length;
         }
         else {
+            const char *gencat = MVM_unicode_codepoint_get_property_cstr(tc, cp, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY);
             MVM_free(result);
             MVM_free(repl_bytes);
-            MVM_exception_throw_adhoc(tc,
-                "Error encoding UTF-8 string: could not encode codepoint %d",
-                cp);
+            if (strcmp("Cs", gencat) == 0) {
+                MVM_exception_throw_adhoc(tc,
+                    "Error encoding UTF-8 string: could not encode Unicode Surrogate codepoint %d",
+                    cp);
+            }
+            else {
+                MVM_exception_throw_adhoc(tc,
+                    "Error encoding UTF-8 string: could not encode codepoint %d",
+                    cp);
+            }
         }
     }
 

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -468,19 +468,9 @@ char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
             result_pos += repl_length;
         }
         else {
-            const char *gencat = MVM_unicode_codepoint_get_property_cstr(tc, cp, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY);
             MVM_free(result);
             MVM_free(repl_bytes);
-            if (strcmp("Cs", gencat) == 0) {
-                MVM_exception_throw_adhoc(tc,
-                    "Error encoding UTF-8 string: could not encode Unicode Surrogate codepoint %d",
-                    cp);
-            }
-            else {
-                MVM_exception_throw_adhoc(tc,
-                    "Error encoding UTF-8 string: could not encode codepoint %d",
-                    cp);
-            }
+            MVM_string_utf8_throw_encoding_exception(tc, cp);
         }
     }
 
@@ -509,4 +499,23 @@ char * MVM_string_utf8_encode_C_string(MVMThreadContext *tc, MVMString *str) {
     MVM_free(utf8_string);
     result[output_size] = (char)0;
     return result;
+}
+
+void MVM_string_utf8_throw_encoding_exception (MVMThreadContext *tc, MVMCodepoint cp) {
+    const char *gencat = MVM_unicode_codepoint_get_property_cstr(tc, cp, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY);
+    if(cp > 0x10FFFF) {
+        MVM_exception_throw_adhoc(tc,
+            "Error encoding UTF-8 string: could not encode codepoint %d (0x%X), codepoint out of bounds. Cannot encode higher than %d (0x%X)",
+            cp, cp, 0x10FFFF, 0x10FFFF);
+    }
+    else if (strcmp("Cs", gencat) == 0) {
+        MVM_exception_throw_adhoc(tc,
+            "Error encoding UTF-8 string: could not encode Unicode Surrogate codepoint %d",
+            cp);
+    }
+    else {
+        MVM_exception_throw_adhoc(tc,
+            "Error encoding UTF-8 string: could not encode codepoint %d",
+            cp);
+    }
 }

--- a/src/strings/utf8.h
+++ b/src/strings/utf8.h
@@ -5,3 +5,4 @@ MVM_PUBLIC char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
         MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length, MVMString *replacement, MVMint32 translate_newlines);
 MVM_PUBLIC char * MVM_string_utf8_encode(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size, MVMint32 translate_newlines);
 MVM_PUBLIC char * MVM_string_utf8_encode_C_string(MVMThreadContext *tc, MVMString *str);
+void MVM_string_utf8_throw_encoding_exception (MVMThreadContext *tc, MVMCodepoint cp);

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -620,11 +620,19 @@ static void emit_cp(MVMThreadContext *tc, MVMCodepoint cp, MVMuint8 **result,
         *result_pos += repl_length;
     }
     else {
+        const char *gencat = MVM_unicode_codepoint_get_property_cstr(tc, cp, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY);
         MVM_free(*result);
         MVM_free(repl_bytes);
-        MVM_exception_throw_adhoc(tc,
-            "Error encoding UTF-8 string: could not encode codepoint %d",
-            cp);
+        if (strcmp("Cs", gencat) == 0) {
+            MVM_exception_throw_adhoc(tc,
+                "Error encoding UTF-8 string: could not encode Unicode Surrogate codepoint %d",
+                cp);
+        }
+        else {
+            MVM_exception_throw_adhoc(tc,
+                "Error encoding UTF-8 string: could not encode codepoint %d",
+                cp);
+        }
     }
 }
 static int hex2int(MVMThreadContext *tc, MVMCodepoint cp) {

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -620,19 +620,9 @@ static void emit_cp(MVMThreadContext *tc, MVMCodepoint cp, MVMuint8 **result,
         *result_pos += repl_length;
     }
     else {
-        const char *gencat = MVM_unicode_codepoint_get_property_cstr(tc, cp, MVM_UNICODE_PROPERTY_GENERAL_CATEGORY);
         MVM_free(*result);
         MVM_free(repl_bytes);
-        if (strcmp("Cs", gencat) == 0) {
-            MVM_exception_throw_adhoc(tc,
-                "Error encoding UTF-8 string: could not encode Unicode Surrogate codepoint %d",
-                cp);
-        }
-        else {
-            MVM_exception_throw_adhoc(tc,
-                "Error encoding UTF-8 string: could not encode codepoint %d",
-                cp);
-        }
+        MVM_string_utf8_throw_encoding_exception(tc, cp);
     }
 }
 static int hex2int(MVMThreadContext *tc, MVMCodepoint cp) {


### PR DESCRIPTION
Check the general category is "Cs" (Control, Surrogates) and if so show
a more useful error message.

Share the exception code between both utf8 and utf8-c8
Have a new function MVM_exception_throw_utf8 so code does not have to
be repeated between utf8.c and utf8_c8.c implementations.

In addition add a seperate exception message if the codepoint that
is attempted to be encoded is > 0x10FFFF which is the legal limit for
UTF8

Roast has a [test](https://github.com/perl6/roast/blob/master/S29-conversions/ord_and_chr.t#L155) todo'd for [RT #124834](https://rt.perl.org/Ticket/Display.html?id=124834)