### PR TITLE
Refactor eqatic and indexic and make Perl 6 :i regex 1.8x faster

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -628,7 +628,7 @@ MVMint64 MVM_string_equal_at_ignore_case(MVMThreadContext *tc, MVMString *haysta
         }
         else {
             /* Synthetics must use this function */
-            h_fc_cps = MVM_nfg_get_case_change(tc, h_g, MVM_unicode_case_change_type_fold, &h_result_cps);
+            h_fc_cps = MVM_nfg_get_case_change(tc, h_g, MVM_unicode_case_change_type_fold, (MVMGrapheme32**) &h_result_cps);
         }
         /* If we get 0 for the number that means the cp doesn't change when casefolded */
         if (h_fc_cps == 0) {

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -652,9 +652,7 @@ MVMint64 MVM_string_equal_at_ignore_case(MVMThreadContext *tc, MVMString *haysta
         return 0;
 
     MVMROOT(tc, haystack, {
-        MVMROOT(tc, needle_fc, {
-            needle_fc = MVM_string_fc(tc, needle);
-        });
+        needle_fc = MVM_string_fc(tc, needle);
     });
 
     return string_equal_at_ignore_case_INTERNAL_loop(tc, haystack, needle_fc, h_offset, h_graphs, n_graphs);
@@ -686,13 +684,11 @@ MVMint64 MVM_string_index_ignore_case(MVMThreadContext *tc, MVMString *haystack,
     if (ngraphs < 1)
         return -1;
 
-    needle_fc = MVM_string_fc(tc, needle);
+    MVMROOT(tc, haystack, {
+            needle_fc = MVM_string_fc(tc, needle);
+    });
     n_fc_graphs = MVM_string_graphs(tc, needle_fc);
 
-    MVMROOT(tc, haystack, {
-        MVMROOT(tc, needle_fc, {
-        });
-    });
     /* brute force for now. horrible, yes. halp. */
     while (index <= hgraphs) {
         if (string_equal_at_ignore_case_INTERNAL_loop(tc, haystack, needle_fc, index, hgraphs, n_fc_graphs))

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -657,35 +657,7 @@ MVMint64 MVM_string_equal_at_ignore_case(MVMThreadContext *tc, MVMString *haysta
         });
     });
 
-    for (i = 0; i + h_offset < h_graphs && i + n_offset < n_graphs; i++) {
-        const MVMCodepoint* h_result_cps;
-        h_g = MVM_string_get_grapheme_at_nocheck(tc, haystack, h_offset + i);
-        if (h_g >= 0 ) {
-            /* For codeponits we can get the case change directly */
-            h_fc_cps = MVM_unicode_get_case_change(tc, h_g, MVM_unicode_case_change_type_fold, &h_result_cps);
-        }
-        else {
-            /* Synthetics must use this function */
-            h_fc_cps = MVM_nfg_get_case_change(tc, h_g, MVM_unicode_case_change_type_fold, (MVMGrapheme32**) &h_result_cps);
-        }
-        /* If we get 0 for the number that means the cp doesn't change when casefolded */
-        if (h_fc_cps == 0) {
-            n_g = MVM_string_get_grapheme_at_nocheck(tc, needle_fc, i + n_offset);
-            if (h_g != n_g)
-                return 0;
-        }
-        else if (h_fc_cps >= 1) {
-            for (j = 0; j < h_fc_cps; j++) {
-                n_g = MVM_string_get_grapheme_at_nocheck(tc, needle_fc, i + n_offset);
-                h_g = h_result_cps[j];
-                if (h_g != n_g)
-                    return 0;
-                n_offset++;
-            }
-            n_offset--;
-        }
-    }
-    return 1;
+    return string_equal_at_ignore_case_INTERNAL_loop(tc, haystack, needle_fc, h_offset, h_graphs, n_graphs);
 }
 MVMint64 MVM_string_index_ignore_case(MVMThreadContext *tc, MVMString *haystack, MVMString *needle, MVMint64 start) {
     /* foldcase version of needle */


### PR DESCRIPTION
1.8x factor is dependent on not yet merged nqp code where it switches
MVM to use indexic instead of index + fc for locating sections of a string.

MVM_string_equal_at_ignore_case_INTERNAL_loop is the internal loop that
will be used be MVM_string_index_ignore_case. This will allow sharing
code between MVM_string_index_ignore_case and
MVM_string_equal_at_ignore_case and prevent the index function from getting
too messy.