### PR TITLE
Add a check that introspection->is_tty is not NULL

### DIFF
--- a/src/io/io.c
+++ b/src/io/io.c
@@ -35,7 +35,8 @@ MVMint64 MVM_io_close(MVMThreadContext *tc, MVMObject *oshandle) {
 
 MVMint64 MVM_io_is_tty(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "istty");
-    if (handle->body.ops->introspection) {
+    /* We need the extra check on is_tty because it is NULL for pipes. */
+    if (handle->body.ops->introspection && handle->body.ops->introspection->is_tty) {
         uv_mutex_t *mutex = acquire_mutex(tc, handle);
         MVMint64 ret = handle->body.ops->introspection->is_tty(tc, handle);
         release_mutex(tc, mutex);


### PR DESCRIPTION
Since it is for pipes. Fixes MoarVM issue #561 

`perl6 -e 'run(:out, "bash").out.t.say'` now returns `False`.

NQP passes `make m-test` and Rakudo passes `make m-spectest`.