### PR TITLE
Fix Various Compiler Warnings

### DIFF
--- a/src/6model/reprs/NFA.c
+++ b/src/6model/reprs/NFA.c
@@ -337,7 +337,7 @@ MVMObject * MVM_nfa_from_statelist(MVMThreadContext *tc, MVMObject *states, MVMO
                 MVMint64 to  = MVM_coerce_simple_intify(tc,
                     MVM_repr_at_pos_o(tc, edge_info, j + 2));
                 if (to <= 0 && act != MVM_NFA_EDGE_FATE)
-                    MVM_exception_throw_adhoc(tc, "Invalid to edge %ld in NFA statelist", to);
+                    MVM_exception_throw_adhoc(tc, "Invalid to edge %"PRId64" in NFA statelist", to);
 
                 nfa->states[i][cur_edge].act = act;
                 nfa->states[i][cur_edge].to = to;
@@ -456,7 +456,7 @@ static MVMint64 * nqp_nfa_run(MVMThreadContext *tc, MVMNFABody *nfa, MVMString *
         if (nfadeb) {
             if (offset < eos) {
                 MVMGrapheme32 cp = MVM_string_get_grapheme_at_nocheck(tc, target, offset);
-                fprintf(stderr,"%c with %ds target %lx offset %ld\n",cp,(int)numcur, (long)target, offset);
+                fprintf(stderr,"%c with %ds target %lx offset %"PRId64"\n",cp,(int)numcur, (long)target, offset);
             }
             else {
                 fprintf(stderr,"EOS with %ds\n",(int)numcur);

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -7,7 +7,7 @@ MVM_STATIC_INLINE void enter_single_user(MVMThreadContext *tc, MVMArrayBody *arr
 #if MVM_ARRAY_CONC_DEBUG
     if (!MVM_trycas(&(arr->in_use), 0, 1)) {
         MVM_dump_backtrace(tc);
-        MVM_exception_throw_adhoc(tc, "Array may not be used concurrently"); 
+        MVM_exception_throw_adhoc(tc, "Array may not be used concurrently");
     }
 #endif
 }
@@ -343,7 +343,7 @@ static void set_size_internal(MVMThreadContext *tc, MVMArrayBody *body, MVMuint6
     }
     if (ssize > (1UL << (8 * sizeof(size_t) - repr_data->elem_size)))
         MVM_exception_throw_adhoc(tc,
-            "Unable to allocate an array of %lu elements",
+            "Unable to allocate an array of %"PRIu64" elements",
             ssize);
 
     /* now allocate the new slot buffer */

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -1650,7 +1650,7 @@ char *MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader *
         strbuf[len] = 0;
         *(reader->cur_read_offset) += len;
     } else if (len < 0) {
-        fail_deserialize(tc, reader, "Cannot read a c string with negative length %li.", len);
+        fail_deserialize(tc, reader, "Cannot read a c string with negative length %"PRIi64".", len);
     }
     return strbuf;
 }

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1393,7 +1393,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                                 if (fcost+icost > 1)
                                   try_cache_dynlex(tc, initial_frame, cur_frame, name, result, *type, fcost, icost);
                                 if (dlog) {
-                                    fprintf(dlog, "I %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                                    fprintf(dlog, "I %s %d %d %d %d %"PRIu64" %"PRIu64" %"PRIu64"\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                                     fflush(dlog);
                                     MVM_free(c_name);
                                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1430,7 +1430,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                                 if (fcost+icost > 1)
                                   try_cache_dynlex(tc, initial_frame, cur_frame, name, result, *type, fcost, icost);
                                 if (dlog) {
-                                    fprintf(dlog, "I %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                                    fprintf(dlog, "I %s %d %d %d %d %"PRIu64" %"PRIu64" %"PRIu64"\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                                     fflush(dlog);
                                     MVM_free(c_name);
                                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1452,7 +1452,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                 if (fcost+icost > 5)
                     try_cache_dynlex(tc, initial_frame, cur_frame, name, result, *type, fcost, icost);
                 if (dlog) {
-                    fprintf(dlog, "C %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                    fprintf(dlog, "C %s %d %d %d %d %"PRIu64" %"PRIu64" %"PRIu64"\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                     fflush(dlog);
                     MVM_free(c_name);
                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1483,7 +1483,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
                     });
                 }
                 if (dlog) {
-                    fprintf(dlog, "F %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+                    fprintf(dlog, "F %s %d %d %d %d %"PRIu64" %"PRIu64" %"PRIu64"\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
                     fflush(dlog);
                     MVM_free(c_name);
                     tc->instance->dynvar_log_lasttime = uv_hrtime();
@@ -1498,7 +1498,7 @@ MVMRegister * MVM_frame_find_contextual_by_name(MVMThreadContext *tc, MVMString 
         cur_frame = cur_frame->caller;
     }
     if (dlog) {
-        fprintf(dlog, "N %s %d %d %d %d %lu %lu %lu\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
+        fprintf(dlog, "N %s %d %d %d %d %"PRIu64" %"PRIu64" %"PRIu64"\n", c_name, fcost, icost, ecost, xcost, last_time, start_time, uv_hrtime());
         fflush(dlog);
         MVM_free(c_name);
         tc->instance->dynvar_log_lasttime = uv_hrtime();

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -13,7 +13,7 @@ MVM_STATIC_INLINE void adjust_nursery(MVMThreadContext *tc, MVMP6bigintBody *bod
     if (MVM_BIGINT_IS_BIG(body)) {
         int used = USED(body->u.bigint);
         int adjustment = MIN(used, 32768) & ~0x7;
-        if (adjustment && (((char *)(tc->nursery_alloc_limit) - adjustment) > tc->nursery_alloc)) {
+        if (adjustment && (char *)tc->nursery_alloc_limit - adjustment > tc->nursery_alloc) {
             tc->nursery_alloc_limit = (char *)(tc->nursery_alloc_limit) - adjustment;
         }
     }

--- a/src/moar.c
+++ b/src/moar.c
@@ -234,7 +234,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     dynvar_log = getenv("MVM_DYNVAR_LOG");
     if (dynvar_log && strlen(dynvar_log)) {
         instance->dynvar_log_fh = fopen_perhaps_with_pid(dynvar_log, "w");
-        fprintf(instance->dynvar_log_fh, "+ x 0 0 0 0 0 %lui\n", uv_hrtime());
+        fprintf(instance->dynvar_log_fh, "+ x 0 0 0 0 0 %lu\n", uv_hrtime());
         fflush(instance->dynvar_log_fh);
         instance->dynvar_log_lasttime = uv_hrtime();
     }
@@ -351,7 +351,7 @@ void MVM_vm_exit(MVMInstance *instance) {
     if (instance->jit_bytecode_map)
         fclose(instance->jit_bytecode_map);
     if (instance->dynvar_log_fh) {
-        fprintf(instance->dynvar_log_fh, "- x 0 0 0 0 %ld %lu %lu\n", instance->dynvar_log_lasttime, uv_hrtime(), uv_hrtime());
+        fprintf(instance->dynvar_log_fh, "- x 0 0 0 0 %"PRId64" %"PRIu64" %"PRIu64"\n", instance->dynvar_log_lasttime, uv_hrtime(), uv_hrtime());
         fclose(instance->dynvar_log_fh);
     }
 

--- a/src/moar.c
+++ b/src/moar.c
@@ -234,7 +234,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     dynvar_log = getenv("MVM_DYNVAR_LOG");
     if (dynvar_log && strlen(dynvar_log)) {
         instance->dynvar_log_fh = fopen_perhaps_with_pid(dynvar_log, "w");
-        fprintf(instance->dynvar_log_fh, "+ x 0 0 0 0 0 %lu\n", uv_hrtime());
+        fprintf(instance->dynvar_log_fh, "+ x 0 0 0 0 0 %"PRIu64"\n", uv_hrtime());
         fflush(instance->dynvar_log_fh);
         instance->dynvar_log_lasttime = uv_hrtime();
     }

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -767,7 +767,7 @@ MVMObject * references_str(MVMThreadContext *tc, MVMHeapSnapshot *s) {
     MVMuint64 i;
     for (i = 0; i < s->num_references; i++) {
         char tmp[128];
-        int item_chars = snprintf(tmp, 128, "%lu,%lu,%lu;",
+        int item_chars = snprintf(tmp, 128, "%"PRIu64",%"PRIu64",%"PRIu64";",
             s->references[i].description & ((1 << MVM_SNAPSHOT_REF_KIND_BITS) - 1),
             s->references[i].description >> MVM_SNAPSHOT_REF_KIND_BITS,
             s->references[i].collectable_index);

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -412,7 +412,7 @@ MVMString * MVM_string_concatenate(MVMThreadContext *tc, MVMString *a, MVMString
     total_graphs = (MVMuint64)agraphs + (MVMuint64)bgraphs;
     if (total_graphs > 0xFFFFFFFF)
         MVM_exception_throw_adhoc(tc,
-            "Can't concatenate strings, required number of graphemes %lu > max allowed of %u",
+            "Can't concatenate strings, required number of graphemes %"PRIu64" > max allowed of %u",
              total_graphs, 0xFFFFFFFF);
 
     /* Otherwise, we'll assemble a result string. */
@@ -520,7 +520,7 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
     total_graphs = (MVMuint64)agraphs * (MVMuint64)count;
     if (total_graphs > 0xFFFFFFFF)
         MVM_exception_throw_adhoc(tc,
-            "Can't repeat string, required number of graphemes %lu > max allowed of %u",
+            "Can't repeat string, required number of graphemes %"PRIu64" > max allowed of %u",
              total_graphs, 0xFFFFFFFF);
 
     /* Now build a result string with the repetition set. */

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -467,7 +467,7 @@ MVMuint32 MVM_string_utf8_c8_decodestream(MVMThreadContext *tc, MVMDecodeStream 
         state.orig_codes = MVM_realloc(state.orig_codes,
             sizeof(MVMCodepoint) * (state.orig_codes_pos + bytes));
         state.result_pos = 0;
-        state.utf8 = cur_bytes->bytes;
+        state.utf8 = (const MVMuint8*)cur_bytes->bytes;
         state.cur_byte = cur_bytes == ds->bytes_head ? ds->bytes_head_pos : 0;
         state.unaccepted_start = state.cur_byte;
 


### PR DESCRIPTION
* Explicitly cast as (const MVMuint*) in utf8_c8.c
* Fix another compiler warning in src/moar.c
* Make if statement in adjust_nursery() more readable
* Fix warning in VMArray.c
* Fix compiler warnings using PRIu64 for three more files
* Fix compiler warnings from moar.c and heapsnapshot.c (PRIu64)
* Use PRIu64 in fprintf's to fix compiler warning RE incorrect types