### PR TITLE
Use memmem in string index. Uses Knuth-Morris-Pratt on glibc 2.2x+ faster

### DIFF
--- a/3rdparty/freebsd/memmem.c
+++ b/3rdparty/freebsd/memmem.c
@@ -1,0 +1,181 @@
+/*-
+ * Copyright (c) 2005-2014 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <sys/cdefs.h>
+/*__FBSDID("$FreeBSD$");*/
+
+#include <string.h>
+#include <stdint.h>
+
+static char *twobyte_memmem(const unsigned char *h, size_t k, const unsigned char *n)
+{
+	uint16_t nw = n[0]<<8 | n[1], hw = h[0]<<8 | h[1];
+	for (h++, k--; k; k--, hw = hw<<8 | *++h)
+		if (hw == nw) return (char *)h-1;
+	return 0;
+}
+
+static char *threebyte_memmem(const unsigned char *h, size_t k, const unsigned char *n)
+{
+	uint32_t nw = n[0]<<24 | n[1]<<16 | n[2]<<8;
+	uint32_t hw = h[0]<<24 | h[1]<<16 | h[2]<<8;
+	for (h+=2, k-=2; k; k--, hw = (hw|*++h)<<8)
+		if (hw == nw) return (char *)h-2;
+	return 0;
+}
+
+static char *fourbyte_memmem(const unsigned char *h, size_t k, const unsigned char *n)
+{
+	uint32_t nw = n[0]<<24 | n[1]<<16 | n[2]<<8 | n[3];
+	uint32_t hw = h[0]<<24 | h[1]<<16 | h[2]<<8 | h[3];
+	for (h+=3, k-=3; k; k--, hw = hw<<8 | *++h)
+		if (hw == nw) return (char *)h-3;
+	return 0;
+}
+
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+/*
+ * Two Way string search algorithm, with a bad shift table applied to the last
+ * byte of the window. A bit array marks which entries in the shift table are
+ * initialized to avoid fully initializing a 1kb/2kb table.
+ *
+ * Reference: CROCHEMORE M., PERRIN D., 1991, Two-way string-matching,
+ * Journal of the ACM 38(3):651-675
+ */
+static char *twoway_memmem(const unsigned char *h, const unsigned char *z, const unsigned char *n, size_t l)
+{
+	size_t i, ip, jp, k, p, ms, p0, mem, mem0;
+	size_t byteset[32 / sizeof(size_t)] = { 0 };
+	size_t shift[256];
+
+	/* Computing length of needle and fill shift table */
+	for (i=0; i<l; i++)
+		BITOP(byteset, n[i], |=), shift[n[i]] = i+1;
+
+	/* Compute maximal suffix */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] > n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	ms = ip;
+	p0 = p;
+
+	/* And with the opposite comparison */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] < n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	if (ip+1 > ms+1) ms = ip;
+	else p = p0;
+
+	/* Periodic needle? */
+	if (memcmp(n, n+p, ms+1)) {
+		mem0 = 0;
+		p = MAX(ms, l-ms-1) + 1;
+	} else mem0 = l-p;
+	mem = 0;
+
+	/* Search loop */
+	for (;;) {
+		/* If remainder of haystack is shorter than needle, done */
+		if (z-h < l) return 0;
+
+		/* Check last byte first; advance by shift on mismatch */
+		if (BITOP(byteset, h[l-1], &)) {
+			k = l-shift[h[l-1]];
+			if (k) {
+				if (mem0 && mem && k < p) k = l-p;
+				h += k;
+				mem = 0;
+				continue;
+			}
+		} else {
+			h += l;
+			mem = 0;
+			continue;
+		}
+
+		/* Compare right half */
+		for (k=MAX(ms+1,mem); k<l && n[k] == h[k]; k++);
+		if (k < l) {
+			h += k-ms;
+			mem = 0;
+			continue;
+		}
+		/* Compare left half */
+		for (k=ms+1; k>mem && n[k-1] == h[k-1]; k--);
+		if (k <= mem) return (char *)h;
+		h += p;
+		mem = mem0;
+	}
+}
+
+void *memmem(const void *h0, size_t k, const void *n0, size_t l)
+{
+	const unsigned char *h = h0, *n = n0;
+
+	/* Return immediately on empty needle */
+	if (!l) return (void *)h;
+
+	/* Return immediately when needle is longer than haystack */
+	if (k<l) return 0;
+
+	/* Use faster algorithms for short needles */
+	h = memchr(h0, *n, k);
+	if (!h || l==1) return (void *)h;
+	k -= h - (const unsigned char *)h0;
+	if (k<l) return 0;
+	if (l==2) return twobyte_memmem(h, k, n);
+	if (l==3) return threebyte_memmem(h, k, n);
+	if (l==4) return fourbyte_memmem(h, k, n);
+
+	return twoway_memmem(h, h+k, n, l);
+}

--- a/3rdparty/freebsd/memmem.c
+++ b/3rdparty/freebsd/memmem.c
@@ -20,8 +20,8 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#include <sys/cdefs.h>
-/*__FBSDID("$FreeBSD$");*/
+/*#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");*/
 
 #include <string.h>
 #include <stdint.h>

--- a/LICENSE
+++ b/LICENSE
@@ -30,3 +30,4 @@ Unofficial summary of the intended application of the Artistic License 2.0:
 - sha1       Public Domain
 - tinymt     MIT
 - uthash.h   MIT
+- freebsd    MIT

--- a/src/platform/memmem.h
+++ b/src/platform/memmem.h
@@ -1,13 +1,22 @@
-#if defined _WIN32
+/* On Linux we use glibc's memmem which uses the Knuth-Morris-Pratt algorithm.
+ * We use FreeBSD's libc memmem on Windows and MacOS, which uses
+ * Crochemore-Perrin two-way string matching.
+ * Reasoning:
+ * Windows, does not include any native memmem
+ * MacOS has a memmem but is slower and originates from FreeBSD dated to 2005 */
+
+#if defined(_WIN32) || defined(__APPLE__) || defined(__Darwin__)
 #include "../3rdparty/freebsd/memmem.c"
 #else
-/* On systems that use Glibc, you must defined _GNU_SOURCE before including string.h
- * to get access to memmem. On BSD and MacOS this is not needed, though if they
- * happen to be using glibc instead of libc, it shouldn't hurt have defined _GNU_SOURCE */
+/* On systems that use glibc, you must define _GNU_SOURCE before including string.h
+ * to get access to memmem. */
 #define _GNU_SOURCE
-#endif
 #include <string.h>
+#endif
 
 void * MVM_memmem(const void *haystack, size_t haystacklen, const void *needle, size_t needlelen) {
     return memmem(haystack, haystacklen, needle, needlelen);
 }
+
+/* Extended info:
+ * In glibc, the Knuth-Morris-Pratt algorithm was added as of git tag glibc-2.8-44-g0caca71ac9 */

--- a/src/platform/memmem.h
+++ b/src/platform/memmem.h
@@ -1,0 +1,13 @@
+#if defined _WIN32
+#include "../3rdparty/freebsd/memmem.c"
+#else
+/* On systems that use Glibc, you must defined _GNU_SOURCE before including string.h
+ * to get access to memmem. On BSD and MacOS this is not needed, though if they
+ * happen to be using glibc instead of libc, it shouldn't hurt have defined _GNU_SOURCE */
+#define _GNU_SOURCE
+#endif
+#include <string.h>
+
+void * MVM_memmem(const void *haystack, size_t haystacklen, const void *needle, size_t needlelen) {
+    return memmem(haystack, haystacklen, needle, needlelen);
+}

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -234,7 +234,7 @@ MVMint64 MVM_string_index(MVMThreadContext *tc, MVMString *haystack, MVMString *
                         return -1;
                     start_ptr = mm_return_32;
                 } /* If we aren't on a 32 bit boundary then continue from where we left off (unlikely but possible) */
-                while ( ( (intptr_t)mm_return_32 - (intptr_t)haystack->body.storage.blob_32) % sizeof(MVMGrapheme32) );
+                while ( ( (char*)mm_return_32 - (char*)haystack->body.storage.blob_32) % sizeof(MVMGrapheme32) );
 
                 return (MVMGrapheme32*)mm_return_32 - haystack->body.storage.blob_32;
             }

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1,10 +1,4 @@
-/* Needed with glibc to allow use of memmem function */
-#if defined _WIN32
-#include "../3rdparty/freebsd/memmem.c"
-#else
-#define _GNU_SOURCE
-#endif
-
+#include "platform/memmem.h"
 #include "moar.h"
 #define MVM_DEBUG_STRANDS 0
 
@@ -230,7 +224,7 @@ MVMint64 MVM_string_index(MVMThreadContext *tc, MVMString *haystack, MVMString *
                 void *mm_return_32;
                 do {
                     /* Keep as void* to not lose precision */
-                    mm_return_32 = memmem(
+                    mm_return_32 = MVM_memmem(
                         start_ptr, /* start position */
                         (hgraphs - start) * sizeof(MVMGrapheme32), /* length of haystack from start position to end */
                         needle->body.storage.blob_32, /* needle start */
@@ -247,7 +241,7 @@ MVMint64 MVM_string_index(MVMThreadContext *tc, MVMString *haystack, MVMString *
             break;
         case MVM_STRING_GRAPHEME_8:
             if (needle->body.storage_type == MVM_STRING_GRAPHEME_8) {
-                void *mm_return_8 = memmem(
+                void *mm_return_8 = MVM_memmem(
                     haystack->body.storage.blob_8 + start, /* start position */
                     (hgraphs - start) * sizeof(MVMGrapheme8), /* length of haystack from start position to end */
                     needle->body.storage.blob_8, /* needle start */

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1,7 +1,11 @@
 /* Needed with glibc to allow use of memmem function */
+#if defined _WIN32
+#include "../3rdparty/freebsd/memmem.c"
+#else
 #define _GNU_SOURCE
-#include "moar.h"
+#endif
 
+#include "moar.h"
 #define MVM_DEBUG_STRANDS 0
 
 #if MVM_DEBUG_STRANDS

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -216,7 +216,8 @@ MVMint64 MVM_string_index(MVMThreadContext *tc, MVMString *haystack, MVMString *
         return -1;
 
     /* Fast paths when storage types are identical. Uses memmem function, which
-     * in glibc uses Knuth-Morris-Pratt algorithm as of glibc-2.8-44-g0caca71ac9 */
+     * uses Knuth-Morris-Pratt algorithm on Linux and on others
+     * Crochemore+Perrin two-way string matching */
     switch (haystack->body.storage_type) {
         case MVM_STRING_GRAPHEME_32:
             if (needle->body.storage_type == MVM_STRING_GRAPHEME_32) {
@@ -245,7 +246,8 @@ MVMint64 MVM_string_index(MVMThreadContext *tc, MVMString *haystack, MVMString *
                     haystack->body.storage.blob_8 + start, /* start position */
                     (hgraphs - start) * sizeof(MVMGrapheme8), /* length of haystack from start position to end */
                     needle->body.storage.blob_8, /* needle start */
-                    ngraphs * sizeof(MVMGrapheme8)); /* needle length */
+                    ngraphs * sizeof(MVMGrapheme8) /* needle length */
+                );
                 if (mm_return_8 == NULL)
                     return -1;
                 else


### PR DESCRIPTION
Update:
All checks pass on [Windows Appveyor](https://ci.appveyor.com/project/samcv/moarvm) and Travis CI on MacOS and Linux. The PR now uses FreeBSD's memmem on both Windows and MacOS to take advantage of the Crochemore-Perrin two-way string matching algorithm it uses. [Link to PDF of paper ](https://cry.nu/files/Two-way%20string-matching%20Crochemore%2C%20Perrin%20%201991.pdf ) which describes it and interestingly compares it to Knuth-Morris-Pratt and Boyer-Moore for any interested. We will still use glibc's Knuth-Morris-Pratt based memmem on Linux, since it is 13% faster in this test:
```perl6
say 'a' x 1000000000 ~ 'b' ~~ /abcde/; say now - INIT now; # FreeBSD libc 4.29s, glibc 3.78s
```
FreeBSD's memmem is included in `3rdparty/freebsd/memmem.c` and the `#ifdef`'s and new `MVM_memmem` function are in `src/platform/memmem.h`.

Comments within the code explain this as well. :-)

-------------------------

Opening this Pull Request to allow for comments. In perl 6 matching in regex becomes
2.2x faster (in case needle is at very end of string). It is likely that the
index operation itself is slightly faster than that.

On BSD memmem does not use Knuth-Morris-Pratt algorithm, and just searches in a standard
way. We should get some benchmarks on MacOS and see how they compare.

It may be beneficial to (eventually) put parts of glibc in 3rdparty or somehow incorporate the code
for memmem() so we can use it on MacOS and Windows as well.

~~Even better would be to adapt the code to make a memmem that can skip a specified number of bytes,
so we can index 32bit strings faster. Although unlikely, at the moment it just panics if it gets back
and pointer that isn't along the boundaries of a 32bit integer. Preliminary plan is to run memmem from
from the returned pointer to continue searching inside the string in the rare (but possible) chance this
were to occur.~~

* Windows now uses FreeBSD's memmem implementation, and has been tested with nqp test suite on Windows

Feedback requested :-)

P.S. glibc-2.8 was released in 2008-04-12, previous to this it did not use a special algorithm but should still work fine with 2.1 or newer (1999-02-03)