### PR TITLE
Fix mp_get_int64 and mp_get_uint64 for realz

### DIFF
--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -8,10 +8,10 @@
 static MVMint64 mp_get_int64(MVMThreadContext *tc, mp_int * a) {
     MVMuint64 res;
     MVMuint64 signed_max = 9223372036854775807ULL;
-    int bits = mp_count_bits(a);
+    const int bits = mp_count_bits(a);
 
-    /* For 64-bit 2's complement numbers the positive max is 2**63-1
-     * but the negative max is 2**63. */
+    /* For 64-bit 2's complement numbers the positive max is 2**63-1, which is 63 bits,
+     * but the negative max is -(2**63), which is 64 bits. */
     if (MP_NEG == SIGN(a)) {
         if (bits > 64) {
             MVM_exception_throw_adhoc(tc, "Cannot unbox %d bit wide bigint into native integer", bits);
@@ -36,7 +36,7 @@ static MVMint64 mp_get_int64(MVMThreadContext *tc, mp_int * a) {
 
 /* Get a native uint64 from an mp_int. */
 static MVMuint64 mp_get_uint64(MVMThreadContext *tc, mp_int * a) {
-    int bits = mp_count_bits(a);
+    const int bits = mp_count_bits(a);
 
     if (bits > 64) {
         MVM_exception_throw_adhoc(tc, "Cannot unbox %d bit wide bigint into native integer", bits);


### PR DESCRIPTION
mp_get_long_long does in fact overflow/wrap around when the mp_int is
too large. So bring back checking the number of bits in the mp_int
before calling it. Also, remove the redundant check for whether the
mp_int is 0, since the exact same check is done in mp_get_long_long.

NQP passes `make m-test` and Rakudo passes `make m-spectest`.

Before https://github.com/MoarVM/MoarVM/pull/557, `sub (int $x) {dd $x}(999999999999999999999999999999999999999999999)` gave `Cannot unbox 150 bit wide bigint into native integer`. After that PR was merged, it then gave `802379605485813759`. This PR corrects it back to  `Cannot unbox 150 bit wide bigint into native integer`, while still keeping the other fixes from https://github.com/MoarVM/MoarVM/pull/557.

I'm not exactly sure how it happened, since I did do lots of testing before, but I guess I just used values that were multiples of the size needed to get the correct behavior I was testing. MasterDuke17--