### PR TITLE
Remove arbitrary string repeat limit

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -464,7 +464,7 @@ MVMString * MVM_string_concatenate(MVMThreadContext *tc, MVMString *a, MVMString
     total_graphs = (MVMuint64)agraphs + (MVMuint64)bgraphs;
     if (total_graphs > MAX_GRAPHEMES)
         MVM_exception_throw_adhoc(tc,
-            "Can't concatenate strings, required number of graphemes %"PRIu64" > max allowed of %u",
+            "Can't concatenate strings, required number of graphemes %"PRIu64" > max allowed of %lld",
              total_graphs, MAX_GRAPHEMES);
 
     /* Otherwise, we'll assemble a result string. */
@@ -561,7 +561,7 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
     if (count < 0)
         MVM_exception_throw_adhoc(tc, "Repeat count (%"PRId64") cannot be negative", count);
     if (count > MAX_GRAPHEMES)
-        MVM_exception_throw_adhoc(tc, "Repeat count (%"PRId64") cannot be greater than max allowed number of graphemes %u", count, MAX_GRAPHEMES);
+        MVM_exception_throw_adhoc(tc, "Repeat count (%"PRId64") cannot be greater than max allowed number of graphemes %lld", count, MAX_GRAPHEMES);
 
     /* If input string is empty, repeating it is empty. */
     agraphs = MVM_string_graphs_nocheck(tc, a);
@@ -572,7 +572,7 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
     total_graphs = (MVMuint64)agraphs * (MVMuint64)count;
     if (total_graphs > MAX_GRAPHEMES)
         MVM_exception_throw_adhoc(tc,
-            "Can't repeat string, required number of graphemes (%"PRIu64" * %"PRIu64") greater than max allowed of %u",
+            "Can't repeat string, required number of graphemes (%"PRIu32" * %"PRIu64") greater than max allowed of %lld",
              agraphs, count, MAX_GRAPHEMES);
 
     /* Now build a result string with the repetition set. */

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -3,7 +3,7 @@
 #define MVM_DEBUG_STRANDS 0
 
 /* Max value possible for MVMuint32 MVMStringBody.num_graphs */
-#define MAX_GRAPHEMES     0xFFFFFFFF
+#define MAX_GRAPHEMES     0xFFFFFFFFLL
 
 #if MVM_DEBUG_STRANDS
 static void check_strand_sanity(MVMThreadContext *tc, MVMString *s) {
@@ -559,9 +559,9 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
     if (count == 1)
         return a;
     if (count < 0)
-        MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be negative", count);
+        MVM_exception_throw_adhoc(tc, "Repeat count (%"PRId64") cannot be negative", count);
     if (count > MAX_GRAPHEMES)
-        MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be greater than max allowed number of graphemes %u", count, MAX_GRAPHEMES);
+        MVM_exception_throw_adhoc(tc, "Repeat count (%"PRId64") cannot be greater than max allowed number of graphemes %u", count, MAX_GRAPHEMES);
 
     /* If input string is empty, repeating it is empty. */
     agraphs = MVM_string_graphs_nocheck(tc, a);

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1,6 +1,8 @@
 #include "platform/memmem.h"
 #include "moar.h"
 #define MVM_DEBUG_STRANDS 0
+
+/* Max value possible for MVMuint32 MVMStringBody.num_graphs */
 #define MAX_GRAPHEMES     0xFFFFFFFF
 
 #if MVM_DEBUG_STRANDS
@@ -559,7 +561,7 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
     if (count < 0)
         MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be negative", count);
     if (count > MAX_GRAPHEMES)
-        MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be > than max allowed number of graphemes %u", count, MAX_GRAPHEMES);
+        MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be greater than max allowed number of graphemes %u", count, MAX_GRAPHEMES);
 
     /* If input string is empty, repeating it is empty. */
     agraphs = MVM_string_graphs_nocheck(tc, a);
@@ -570,7 +572,7 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
     total_graphs = (MVMuint64)agraphs * (MVMuint64)count;
     if (total_graphs > MAX_GRAPHEMES)
         MVM_exception_throw_adhoc(tc,
-            "Can't repeat string, required number of graphemes %"PRIu64" > max allowed of %u",
+            "Can't repeat string, required number of graphemes %"PRIu64" greater than max allowed of %u",
              total_graphs, MAX_GRAPHEMES);
 
     /* Now build a result string with the repetition set. */

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1,6 +1,7 @@
 #include "platform/memmem.h"
 #include "moar.h"
 #define MVM_DEBUG_STRANDS 0
+#define MAX_GRAPHEMES     0xFFFFFFFF
 
 #if MVM_DEBUG_STRANDS
 static void check_strand_sanity(MVMThreadContext *tc, MVMString *s) {
@@ -459,10 +460,10 @@ MVMString * MVM_string_concatenate(MVMThreadContext *tc, MVMString *a, MVMString
 
     /* Total size of the resulting string can't be bigger than an MVMString is allowed to be. */
     total_graphs = (MVMuint64)agraphs + (MVMuint64)bgraphs;
-    if (total_graphs > 0xFFFFFFFF)
+    if (total_graphs > MAX_GRAPHEMES)
         MVM_exception_throw_adhoc(tc,
             "Can't concatenate strings, required number of graphemes %"PRIu64" > max allowed of %u",
-             total_graphs, 0xFFFFFFFF);
+             total_graphs, MAX_GRAPHEMES);
 
     /* Otherwise, we'll assemble a result string. */
     MVMROOT(tc, a, {
@@ -557,8 +558,8 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
         return a;
     if (count < 0)
         MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be negative", count);
-    if (count > 0xFFFFFFFF)
-        MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be > than max allowed number of graphemes %u", count, 0xFFFFFFFF);
+    if (count > MAX_GRAPHEMES)
+        MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be > than max allowed number of graphemes %u", count, MAX_GRAPHEMES);
 
     /* If input string is empty, repeating it is empty. */
     agraphs = MVM_string_graphs_nocheck(tc, a);
@@ -567,10 +568,10 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
 
     /* Total size of the resulting string can't be bigger than an MVMString is allowed to be. */
     total_graphs = (MVMuint64)agraphs * (MVMuint64)count;
-    if (total_graphs > 0xFFFFFFFF)
+    if (total_graphs > MAX_GRAPHEMES)
         MVM_exception_throw_adhoc(tc,
             "Can't repeat string, required number of graphemes %"PRIu64" > max allowed of %u",
-             total_graphs, 0xFFFFFFFF);
+             total_graphs, MAX_GRAPHEMES);
 
     /* Now build a result string with the repetition set. */
     MVMROOT(tc, a, {

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -572,8 +572,8 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
     total_graphs = (MVMuint64)agraphs * (MVMuint64)count;
     if (total_graphs > MAX_GRAPHEMES)
         MVM_exception_throw_adhoc(tc,
-            "Can't repeat string, required number of graphemes %"PRIu64" greater than max allowed of %u",
-             total_graphs, MAX_GRAPHEMES);
+            "Can't repeat string, required number of graphemes (%"PRIu64" * %"PRIu64") greater than max allowed of %u",
+             agraphs, count, MAX_GRAPHEMES);
 
     /* Now build a result string with the repetition set. */
     MVMROOT(tc, a, {

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -557,8 +557,8 @@ MVMString * MVM_string_repeat(MVMThreadContext *tc, MVMString *a, MVMint64 count
         return a;
     if (count < 0)
         MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be negative", count);
-    if (count > (1 << 30))
-        MVM_exception_throw_adhoc(tc, "repeat count > %d arbitrarily unsupported...", (1 << 30));
+    if (count > 0xFFFFFFFF)
+        MVM_exception_throw_adhoc(tc, "repeat count (%"PRId64") cannot be > than max allowed number of graphemes %u", count, 0xFFFFFFFF);
 
     /* If input string is empty, repeating it is empty. */
     agraphs = MVM_string_graphs_nocheck(tc, a);


### PR DESCRIPTION
Instead make the limit the same as the max number of graphemes possible
in a string. This is ok because there's a later check that the size of
the resulting string (i.e., size of original string * count) is also
less than the max number of graphemes possible.

NQP passes `make m-test` and Rakudo passes `make m-spectest`.