### PR TITLE
Use -1 instead of 0 when long right-shifting negative smallints

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -741,7 +741,7 @@ MVMObject *MVM_bigint_shr(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
         clear_temp_bigints(tmp, 1);
         adjust_nursery(tc, bb);
     } else if (n >= 32) {
-        store_int64_result(bb, 0);
+        store_int64_result(bb, -1);
     } else {
         MVMint32 value = ba->u.smallint.value;
         value = value >> n;


### PR DESCRIPTION
Passes Rakudo's stresstest.

- The value of -1 is what falls out when you calculate with
    fakely-big big ints, like -15**1 (that ends up going through the
    "big int" path 'cause the flag is apparently set)
- This is also the value you get with `div` (e.g. dd -12 div 2**32)
- This is also the value you get on JVM backend
- This is also the value you get with Perl 5 `use integer; say -12 >> 32`
- This is also the value Zefram mentions in RT#126942:

Together with a Rakudo patch I'm preparing, fixes
RT#126942: https://rt.perl.org/Ticket/Display.html?id=126942
and RT#13278: https://rt.perl.org/Ticket/Display.html?id=131278