### PR TITLE
Remove workaround for tommath issue $56

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -934,17 +934,8 @@ void MVM_bigint_rand(MVMThreadContext *tc, MVMObject *a, MVMObject *b) {
     mp_int *rnd = MVM_malloc(sizeof(mp_int));
     mp_int *max = force_bigint(bb, tmp);
 
-    /* Workaround tommath issue #56 */
-    mp_int workaround;
-    mp_init (&workaround);
-    mp_rand(&workaround, USED(max) + 1);
-    mp_mul_2d(&workaround, 29, &workaround);
-
     mp_init(rnd);
     mp_rand(rnd, USED(max) + 1);
-
-    mp_xor(rnd, &workaround, rnd);
-    mp_clear(&workaround);
 
     mp_mod(rnd, max, rnd);
     store_bigint_result(ba, rnd);


### PR DESCRIPTION
As fas as I know, we've upgraded tommath and the issue there is fixed.

If we didn't upgrade yet, maybe we should also have a libtommath upgrade?

This would make nqp::rand_I a lot faster again, so it can actually be used in many cases.