### PR TITLE
Fix typo in add_guard

### DIFF
--- a/src/spesh/arg_guard.c
+++ b/src/spesh/arg_guard.c
@@ -90,7 +90,7 @@ void add_guard(MVMThreadContext *tc, MVMSpeshArgGuard *ag, MVMCallsite *cs,
             arg_idx++; /* Skip over name */
         if (cs->arg_flags[i] & MVM_CALLSITE_ARG_OBJ) {
             MVMSpeshStatsType *type = &(types[i]);
-            if (types->type)
+            if (type->type)
                 current_node = get_type_node(tc, ag, current_node, type, arg_idx);
         }
         arg_idx++;


### PR DESCRIPTION
https://github.com/MoarVM/MoarVM/commit/c0ffc6df675a8bc34ef226189bfc4d8587b388b2#commitcomment-22931155

At least from reading the code it doesn't seem like the first of `types` should always be used, but I'd gladly be taught otherwise