### PR TITLE
Fix ARM build

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -35,7 +35,7 @@ our %TP_MT = (
 our %TP_DC = (
     name  => 'dyncall_s',
     path  => '3rdparty/dyncall/dyncall',
-    rule  => 'cd 3rdparty/dyncall &&  ./configure && CC=\'$(CC)\' CFLAGS=\'$(CFLAGS)\' $(MAKE) -f Makefile ',
+    rule  => 'cd 3rdparty/dyncall &&  ./configure && CC=\'$(CC)\' CFLAGS=\'-fPIC\' $(MAKE) -f Makefile ',
     clean => 'cd 3rdparty/dyncall && $(MAKE) -f Makefile clean',
 );
 


### PR DESCRIPTION
Don't pass CFLAGS (which includes -Werror=declaration-after-statement)
to dyncall. Just pass -fPIC. Otherwise we see a fatal warning with
dyncall_callvm_arm32_arm_armhf.c