### PR TITLE
Add -Werror=pointer-arith for gcc

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -265,7 +265,7 @@ our %COMPILERS = (
         cc => 'gcc',
         ld => undef,
 
-        ccmiscflags  => '-Wdeclaration-after-statement -Werror=declaration-after-statement',
+        ccmiscflags  => '-Werror=declaration-after-statement -Werror=pointer-arith',
         ccwarnflags  => '',
         ccoptiflags  => '-O%s -DNDEBUG',
         ccdebugflags => '-g%s',


### PR DESCRIPTION
This disables the GNU extension that allows arithmetic on pointers to
void and functions, which standard C (and MSVC) don't allow.

Also remove redundant -Wdeclaration-after-statement: -Werror=foo implies
-Wfoo.