### PR TITLE
Alloc proc read buffer based on amount last read

### DIFF
--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -509,15 +509,19 @@ static void on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) 
     SpawnInfo *si = (SpawnInfo *)handle->data;
     size_t size   = si->last_read ? si->last_read : 64;
 
-    /* Equivalent to `size = pow(2, ceil(log2(size + 1)))`, but C89 compatible. */
-    size |= size >> 1;
-    size |= size >> 2;
-    size |= size >> 4;
-    size |= size >> 8;
-    size |= size >> 16;
-    size |= size >> 32;
-    size++;
-    if (size < 128)  size = 128;
+    if (size < 128) {
+        size = 128;
+    }
+    else {
+        /* Equivalent to `size = pow(2, ceil(log2(size + 1)))`, but C89 compatible. */
+        size |= size >> 1;
+        size |= size >> 2;
+        size |= size >> 4;
+        size |= size >> 8;
+        size |= size >> 16;
+        size |= size >> 32;
+        size++;
+    }
 
     buf->base = MVM_malloc(size);
     buf->len  = size;

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -508,6 +508,8 @@ static void async_spawn_on_exit(uv_process_t *req, MVMint64 exit_status, int ter
 static void on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) {
     SpawnInfo *si = (SpawnInfo *)handle->data;
     size_t size   = si->last_read ? si->last_read : 64;
+
+    /* Equivalent to `size = pow(2, ceil(log2(size + 1)))`, but C89 compatible. */
     size |= size >> 1;
     size |= size >> 2;
     size |= size >> 4;
@@ -515,6 +517,8 @@ static void on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) 
     size |= size >> 16;
     size |= size >> 32;
     size++;
+    if (size < 128)  size = 128;
+
     buf->base = MVM_malloc(size);
     buf->len  = size;
 }

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -1,6 +1,7 @@
 #include "moar.h"
 #include "platform/time.h"
 #include "tinymt64.h"
+#include "bithacks.h"
 
 /* concatenating with "" ensures that only literal strings are accepted as argument. */
 #define STR_WITH_LEN(str)  ("" str ""), (sizeof(str) - 1)
@@ -513,14 +514,7 @@ static void on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) 
         size = 128;
     }
     else {
-        /* Equivalent to `size = pow(2, ceil(log2(size + 1)))`, but C89 compatible. */
-        size |= size >> 1;
-        size |= size >> 2;
-        size |= size >> 4;
-        size |= size >> 8;
-        size |= size >> 16;
-        size |= size >> 32;
-        size++;
+        size = MVM_bithacks_next_greater_pow2(size + 1);
     }
 
     buf->base = MVM_malloc(size);


### PR DESCRIPTION
Instead of using the `suggested_size` (which is almost always 65536
according to http://docs.libuv.org/en/v1.x/handle.html#data-types), use
the next power of two greater than the amount last read (which has been
added to the `SpawnInfo` struct).

Passes NQP's `make m-test` and Rakudo's `make m-test m-spectest`.

For https://gist.github.com/MasterDuke17/685b627a6a2749483dc5ec09c6a777a4
with only 5 iterations, compared to HEAD, heaptrack reports 654m "bytes allocated in total"
instead of 1.1g, 255m peak memory consumption instead of 387m, and `on_alloc` in
"most memory allocated" using 4.4m instead of 480m.