### PR TITLE
Alloc asyncsocket read buffer based on amount last read

### DIFF
--- a/src/io/asyncsocket.c
+++ b/src/io/asyncsocket.c
@@ -1,4 +1,5 @@
 #include "moar.h"
+#include "bithacks.h"
 
 /* Data that we keep for an asynchronous socket handle. */
 typedef struct {
@@ -25,15 +26,9 @@ static void on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) 
         size = 128;
     }
     else {
-        /* Equivalent to `size = pow(2, ceil(log2(size + 1)))`, but C89 compatible. */
-        size |= size >> 1;
-        size |= size >> 2;
-        size |= size >> 4;
-        size |= size >> 8;
-        size |= size >> 16;
-        size |= size >> 32;
-        size++;
+        size = MVM_bithacks_next_greater_pow2(size + 1);
     }
+
     buf->base   = MVM_malloc(size);
     buf->len    = size;
 }


### PR DESCRIPTION
Instead of using the suggested_size (which is almost always 65536
according to http://docs.libuv.org/en/v1.x/handle.html#data-types), use
the next power of two greater than the amount last read (which has been
added to the ReadInfo struct).

Passes NQP's `make m-test` and Rakudo's `make m-test m-spectest`.