### PR TITLE
Make sure libffi callbacks can be reused.

### DIFF
--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -432,7 +432,6 @@ static void callback_handler(ffi_cif *cif, void *cb_result, void **cb_args, void
     /* Clean up. */
     MVM_gc_root_temp_pop_n(tc, num_roots);
     MVM_free(args);
-    MVM_free(cif);
 
     /* Re-block GC if needed, so other threads will be able to collect. */
     if (was_blocked)


### PR DESCRIPTION
Rakudo test t/04-nativecall/21-callback-other-thread.t tests 2..9
fail with a segmentation fault or glibc error (double free or
malloc() problem) when MoarVM is built with --has-libffi.

The problem is due to the callback handler freeing the memory for
its first argument (the libffi call interface, cif).  Doing this
makes the callback not reusable (the callback still exists in
tc->native_callback_cache).  Fix the problem by not freeing
the memory.