### PR TITLE
Fix typo in MVM_6model_container_atomic_store

### DIFF
--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -582,7 +582,7 @@ void MVM_6model_container_atomic_store(MVMThreadContext *tc, MVMObject *cont, MV
     if (IS_CONCRETE(cont)) {
         MVMContainerSpec const *cs = cont->st->container_spec;
         if (cs) {
-            if (cs->atomic_load)
+            if (cs->atomic_store)
                 cs->atomic_store(tc, cont, value);
             else
                 MVM_exception_throw_adhoc(tc,


### PR DESCRIPTION
In containers.c
The function checked for cs->atomic_load being present, but then went on using cs->atomic_store.