### PR TITLE
Add W->!X JIT support for NetBSD 8, SELinux with deny_execmem, PaX

### DIFF
--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -2,6 +2,9 @@ typedef MVMint32 (*MVMJitFunc)(MVMThreadContext *tc, MVMCompUnit *cu, void * lab
 
 struct MVMJitCode {
     MVMJitFunc func_ptr;
+#ifdef HAVE_LIBFFI
+    char      *writable_memory;
+#endif
     size_t     size;
     MVMuint8  *bytecode;
 


### PR DESCRIPTION
When MoarVM is compiled with --has-libffi, make the code produced by
the JIT compiler writable at an address but then never executable
through the same address (W->!X).

This allows MoarVM to be installed and used on systems that enforce
W->!X without any special filesystem permissions (NetBSD 8) or
writing special security policy (SELinux with deny_execmem). This
does not offer additional security beyond what is provided by
default when MoarVM uses mprotect(); it just makes MoarVM easier to
install and use on systems that require W->!X.