### PR TITLE
Remove impossible check

### DIFF
--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -304,10 +304,6 @@ static void set_size_internal(MVMThreadContext *tc, MVMArrayBody *body, MVMuint6
     MVMuint64   ssize = body->ssize;
     void       *slots = body->slots.any;
 
-    if (n < 0)
-        MVM_exception_throw_adhoc(tc,
-            "MVMArray: Can't resize to negative elements");
-
     if (n == elems)
         return;
 


### PR DESCRIPTION
n is an MVMuint64, so it can never be negative.