### PR TITLE
Remove impossible check

### DIFF
--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -1622,7 +1622,7 @@ size_t MVM_p6opaque_attr_offset(MVMThreadContext *tc, MVMObject *type,
                                 MVMObject *class_handle, MVMString *name) {
     MVMP6opaqueREPRData *repr_data = (MVMP6opaqueREPRData *)type->st->REPR_data;
     size_t slot = try_get_slot(tc, repr_data, class_handle, name);
-    return slot >= 0 ? repr_data->attribute_offsets[slot] : 0;
+    return repr_data->attribute_offsets[slot];
 }
 
 #ifdef DEBUG_HELPERS


### PR DESCRIPTION
slot is a size_t, so it can never be negative.