### PR TITLE
Avoid evaluating arguments to MVM_ASSERT_NOT_FROMSPACE 

### DIFF
--- a/src/gc/debug.h
+++ b/src/gc/debug.h
@@ -18,5 +18,5 @@
     } \
 } while (0)
 #else
-#define MVM_ASSERT_NOT_FROMSPACE
+#define MVM_ASSERT_NOT_FROMSPACE(tc, c)
 #endif


### PR DESCRIPTION
Don't evaluate those arguments when the macro is disabled. This prevents compiler warnings.