### PR TITLE
JIT param_op_(i|o)

### DIFF
--- a/src/core/args.c
+++ b/src/core/args.c
@@ -289,11 +289,11 @@ MVMObject * MVM_args_get_required_pos_obj(MVMThreadContext *tc, MVMArgProcContex
     autobox_switch(tc, result);
     return result.arg.o;
 }
-MVMArgInfo MVM_args_get_optional_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
+MVMObject * MVM_args_get_optional_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
     MVMArgInfo result;
     args_get_pos(tc, ctx, pos, MVM_ARG_OPTIONAL, result);
     autobox_switch(tc, result);
-    return result;
+    return result.arg.o;
 }
 MVMint64 MVM_args_get_required_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
     MVMArgInfo result;
@@ -301,11 +301,11 @@ MVMint64 MVM_args_get_required_pos_int(MVMThreadContext *tc, MVMArgProcContext *
     autounbox(tc, MVM_CALLSITE_ARG_INT, "integer", result);
     return result.arg.i64;
 }
-MVMArgInfo MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
+MVMint64 MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
     MVMArgInfo result;
     args_get_pos(tc, ctx, pos, MVM_ARG_OPTIONAL, result);
     autounbox(tc, MVM_CALLSITE_ARG_INT, "integer", result);
-    return result;
+    return result.arg.i64;
 }
 MVMArgInfo MVM_args_get_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required) {
     MVMArgInfo result;

--- a/src/core/args.h
+++ b/src/core/args.h
@@ -60,9 +60,9 @@ void MVM_args_throw_named_unused_error(MVMThreadContext *tc, MVMString *name);
 
 /* Argument access by position. */
 MVMObject * MVM_args_get_required_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
-MVMArgInfo MVM_args_get_optional_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
+MVMObject * MVM_args_get_optional_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMint64 MVM_args_get_required_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
-MVMArgInfo MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
+MVMint64 MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMArgInfo MVM_args_get_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required);
 MVMArgInfo MVM_args_get_pos_str(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required);
 MVMArgInfo MVM_args_get_pos_uint(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required);

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -1013,10 +1013,10 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             }
             OP(param_op_i):
             {
-                MVMArgInfo param = MVM_args_get_optional_pos_int(tc, &tc->cur_frame->params,
+                MVMint64 param = MVM_args_get_optional_pos_int(tc, &tc->cur_frame->params,
                     GET_UI16(cur_op, 2));
-                if (param.exists) {
-                    GET_REG(cur_op, 0).i64 = param.arg.i64;
+                if (param) {
+                    GET_REG(cur_op, 0).i64 = param;
                     cur_op = bytecode_start + GET_UI32(cur_op, 4);
                 }
                 else {
@@ -1053,11 +1053,11 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(param_op_o):
             {
                 MVMuint16 arg_idx = GET_UI16(cur_op, 2);
-                MVMArgInfo param = MVM_args_get_optional_pos_obj(tc, &tc->cur_frame->params, arg_idx);
-                if (param.exists) {
-                    GET_REG(cur_op, 0).o = param.arg.o;
+                MVMObject *param = MVM_args_get_optional_pos_obj(tc, &tc->cur_frame->params, arg_idx);
+                if (param) {
+                    GET_REG(cur_op, 0).o = param;
                     if (MVM_spesh_log_is_logging(tc))
-                        MVM_spesh_log_parameter(tc, arg_idx, param.arg.o);
+                        MVM_spesh_log_parameter(tc, arg_idx, param);
                     cur_op = bytecode_start + GET_UI32(cur_op, 4);
                 }
                 else {

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1664,6 +1664,26 @@ static MVMint32 jgb_consume_ins(MVMThreadContext *tc, JitGraphBuilder *jgb,
         jgb_append_primitive(tc, jgb, ins);
         break;
         /* Unspecialized parameter access */
+    case MVM_OP_param_op_i: {
+        MVMint16  dst     = ins->operands[0].reg.orig;
+        MVMuint16 arg_idx = ins->operands[1].lit_ui16;
+
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_PARAMS } },
+                                 { MVM_JIT_LITERAL, { arg_idx } } };
+        jgb_append_call_c(tc, jgb, MVM_args_get_optional_pos_int, 3, args, MVM_JIT_RV_INT, dst);
+        break;
+    }
+    case MVM_OP_param_op_o: {
+        MVMint16  dst     = ins->operands[0].reg.orig;
+        MVMuint16 arg_idx = ins->operands[1].lit_ui16;
+
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_PARAMS } },
+                                 { MVM_JIT_LITERAL, { arg_idx } } };
+        jgb_append_call_c(tc, jgb, MVM_args_get_optional_pos_obj, 3, args, MVM_JIT_RV_PTR, dst);
+        break;
+    }
     case MVM_OP_param_rp_i: {
         MVMint16  dst     = ins->operands[0].reg.orig;
         MVMuint16 arg_idx = ins->operands[1].lit_ui16;


### PR DESCRIPTION
These were causing `INTERPOLATE` to bail. Follow the example of the recent
JITting of `param_rp_(i|o)` (e4e9c04).

NQP passes `make m-test` and Rakudo passes `make m-test m-spectest`.

`INTERPOLATE` now doesn't bail in the jit log, but still isn't being JITted according
to a profile, I don't know why.