### PR TITLE
Fix GC issues and misc.

### DIFF
--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -156,7 +156,7 @@ void MVM_decoder_set_separators(MVMThreadContext *tc, MVMDecoder *decoder, MVMOb
         STABLE(seps)).boxed_primitive == MVM_STORAGE_SPEC_BP_STR;
     get_ds(tc, decoder); /* Ensure we're sufficiently initialized. */
     if (is_str_array) {
-        MVMString **c_seps;
+        MVMString **c_seps = NULL;
         MVMuint64 i;
         MVMuint64 num_seps = MVM_repr_elems(tc, seps);
         if (num_seps > 0xFFFFFF)
@@ -181,7 +181,7 @@ void MVM_decoder_add_bytes(MVMThreadContext *tc, MVMDecoder *decoder, MVMObject 
     if (REPR(buffer)->ID == MVM_REPR_ID_VMArray) {
         /* To be safe, we need to make a copy of data in a resizable array; it
          * may change/move under us. */
-        char *output, *copy;
+        char *output = NULL, *copy = NULL;
         MVMint64 output_size;
         switch (((MVMArrayREPRData *)STABLE(buffer)->REPR_data)->slot_type) {
             case MVM_ARRAY_U8:
@@ -218,7 +218,7 @@ void MVM_decoder_add_bytes(MVMThreadContext *tc, MVMDecoder *decoder, MVMObject 
  * is not enough. */
 MVMString * MVM_decoder_take_chars(MVMThreadContext *tc, MVMDecoder *decoder, MVMint64 chars,
                                    MVMint64 eof) {
-    MVMString *result;
+    MVMString *result = NULL;
     enter_single_user(tc, decoder);
     MVMROOT(tc, decoder, {
         result = MVM_string_decodestream_get_chars(tc, get_ds(tc, decoder), (MVMint32)chars, eof);
@@ -229,7 +229,7 @@ MVMString * MVM_decoder_take_chars(MVMThreadContext *tc, MVMDecoder *decoder, MV
 
 /* Takes all chars from the decoder. */
 MVMString * MVM_decoder_take_all_chars(MVMThreadContext *tc, MVMDecoder *decoder) {
-    MVMString *result;
+    MVMString *result = NULL;
     enter_single_user(tc, decoder);
     MVMROOT(tc, decoder, {
         result = MVM_string_decodestream_get_all(tc, get_ds(tc, decoder));
@@ -240,7 +240,7 @@ MVMString * MVM_decoder_take_all_chars(MVMThreadContext *tc, MVMDecoder *decoder
 
 /* Takes all available chars from the decoder. */
 MVMString * MVM_decoder_take_available_chars(MVMThreadContext *tc, MVMDecoder *decoder) {
-    MVMString *result;
+    MVMString *result = NULL;
     enter_single_user(tc, decoder);
     MVMROOT(tc, decoder, {
         result = MVM_string_decodestream_get_available(tc, get_ds(tc, decoder));
@@ -254,7 +254,7 @@ MVMString * MVM_decoder_take_line(MVMThreadContext *tc, MVMDecoder *decoder,
                                   MVMint64 chomp, MVMint64 incomplete_ok) {
     MVMDecodeStream *ds = get_ds(tc, decoder);
     MVMDecodeStreamSeparators *sep_spec = get_sep_spec(tc, decoder);
-    MVMString *result;
+    MVMString *result = NULL;
     enter_single_user(tc, decoder);
     MVMROOT(tc, decoder, {
         result = incomplete_ok
@@ -280,9 +280,9 @@ MVMint64 MVM_decoder_bytes_available(MVMThreadContext *tc, MVMDecoder *decoder) 
 MVMObject * MVM_decoder_take_bytes(MVMThreadContext *tc, MVMDecoder *decoder,
                                    MVMObject *buf_type, MVMint64 bytes) {
     MVMDecodeStream *ds = get_ds(tc, decoder);
-    char *buf;
+    char *buf = NULL;
     MVMint64 read;
-    MVMObject *result;
+    MVMObject *result = NULL;
 
     /* Ensure the target is in the correct form. */
     if (REPR(buf_type)->ID != MVM_REPR_ID_VMArray)

--- a/src/strings/normalize.c
+++ b/src/strings/normalize.c
@@ -360,9 +360,11 @@ MVMint64 MVM_unicode_relative_ccc(MVMThreadContext *tc, MVMCodepoint cp) {
  * the Unicode Standard Annex #29). Full path. Fast path checks for controls
  * in the Latin-1 range. This works for those as well but needs a property lookup */
 MVMint32 MVM_string_is_control_full(MVMThreadContext *tc, MVMCodepoint in) {
-    /* U+200C ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER are excluded. */
+    /* U+200C ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER are excluded because
+     * they are Cf but not Control's */
     if (in != UNI_CP_ZERO_WIDTH_NON_JOINER && in != UNI_CP_ZERO_WIDTH_JOINER) {
-        /* Consider general property. */
+        /* Consider general property:
+         * Cc, Zl, Zp, and Cn which are also Default_Ignorable_Code_Point=True */
         const char *genprop = MVM_unicode_codepoint_get_property_cstr(tc, in,
             MVM_UNICODE_PROPERTY_GENERAL_CATEGORY);
         switch (genprop[0]) {

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -675,6 +675,7 @@ MVMString * MVM_string_concatenate(MVMThreadContext *tc, MVMString *a, MVMString
     MVMROOT(tc, a, {
     MVMROOT(tc, b, {
     MVMROOT(tc, renormalized_section, {
+    MVMROOT(tc, result, {
 
         /* Allocate it. */
         result = (MVMString *)MVM_repr_alloc_init(tc, tc->instance->VMString);
@@ -791,24 +792,16 @@ MVMString * MVM_string_concatenate(MVMThreadContext *tc, MVMString *a, MVMString
                 result->body.num_graphs += renormalized_section_graphs - consumed_b - consumed_a;
             }
         }
-    });
-    });
-    });
     STRAND_CHECK(tc, result);
-    if (is_concat_stable == 1) {
-        NFG_CHECK_CONCAT(tc, result, a, b, "'result' w/ is_concat_stable = 1");
+    if (is_concat_stable == 1 || (is_concat_stable == 0 && renormalized_section))
+        NFG_CHECK_CONCAT(tc, result, a, b, "'result'");
+    });
+    });
+    });
+    });
+    if (is_concat_stable == 1 || (is_concat_stable == 0 && renormalized_section))
         return result;
-    }
-    /* If it's regional indicator */
-    else if (is_concat_stable == 2) {
-        return re_nfg(tc, result);
-    }
-    else if (is_concat_stable == 0 && renormalized_section) {
-        NFG_CHECK_CONCAT(tc, renormalized_section, a, b, "renormalized_section");
-        NFG_CHECK_CONCAT(tc, result, a, b, "'result' w/ is_concat_stable = 0");
-        return result;
-    }
-    /* We should have returned by now, but if we did not, return re_nfg */
+    /* If it's regional indicator (is_concat_stable == 2) */
     return re_nfg(tc, result);
 }
 

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -572,9 +572,9 @@ MVMString * MVM_string_substring(MVMThreadContext *tc, MVMString *a, MVMint64 of
 
 MVMString * MVM_string_replace(MVMThreadContext *tc, MVMString *original, MVMint64 start, MVMint64 count, MVMString *replacement) {
     /* XXX this could probably be done more efficiently directly. */
-    MVMString *first_part;
-    MVMString *rest_part;
-    MVMString *result;
+    MVMString *first_part = NULL;
+    MVMString *rest_part  = NULL;
+    MVMString *result     = NULL;
 
     MVM_gc_root_temp_push(tc, (MVMCollectable **)&replacement);
     MVM_gc_root_temp_push(tc, (MVMCollectable **)&original);

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -36,7 +36,7 @@ static char * NFG_check_make_debug_string (MVMThreadContext *tc, MVMGrapheme32 g
         picked = "\\n";
     else if (g == MVM_nfg_crlf_grapheme(tc))
         picked = "\\r\\n";
-    else if (!MVM_string_is_control_full(tc, g))
+    else if (0 <= g && !MVM_string_is_control_full(tc, g))
         result = MVM_string_utf8_encode_C_string(tc, MVM_string_chr(tc, g));
     else
         picked = "[Control]";

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -325,10 +325,10 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
     MVMCodepoint codepoint = 0;
     MVMCodepoint lag_codepoint = -1;
     MVMint32 bufsize;
-    MVMGrapheme32 *buffer;
-    MVMDecodeStreamBytes *cur_bytes;
-    MVMDecodeStreamBytes *last_accept_bytes = ds->bytes_head;
-    MVMDecodeStreamBytes *lag_last_accept_bytes;
+    MVMGrapheme32 *buffer           = NULL;
+    MVMDecodeStreamBytes *cur_bytes = NULL;
+    MVMDecodeStreamBytes *last_accept_bytes     = ds->bytes_head;
+    MVMDecodeStreamBytes *lag_last_accept_bytes = NULL;
     MVMint32 last_accept_pos, lag_last_accept_pos, ready, at_start;
     MVMuint32 reached_stopper;
     MVMuint32 can_fast_path;
@@ -522,10 +522,10 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
 char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
         MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length,
         MVMString *replacement, MVMint32 translate_newlines) {
-    MVMuint8        *result;
+    MVMuint8        *result = NULL;
     size_t           result_pos, result_limit;
     MVMCodepointIter ci;
-    MVMStringIndex   strgraphs = MVM_string_graphs(tc, str);
+    MVMStringIndex   strgraphs  = MVM_string_graphs(tc, str);
     MVMuint8        *repl_bytes = NULL;
     MVMuint64        repl_length;
 
@@ -589,7 +589,7 @@ char * MVM_string_utf8_encode(MVMThreadContext *tc, MVMString *str, MVMuint64 *o
 /* Encodes the specified string to a UTF-8 C string. */
 char * MVM_string_utf8_encode_C_string(MVMThreadContext *tc, MVMString *str) {
     MVMuint64 output_size;
-    char * result;
+    char * result = NULL;
     char * utf8_string = MVM_string_utf8_encode(tc, str, &output_size, 0);
     /* this is almost always called from error-handling code. Don't care if it
      * contains embedded NULs. XXX TODO: Make sure all uses of this free what it returns */


### PR DESCRIPTION
* Make sure MVMROOT'd pointer is initialized as NULL   * Can cause issues if GC runs while the pointer is uninitialized.

* Revise some comments in MVM_string_is_control_full()

* NFG_check, make sure we don't lookup props of synthetics
  * Our call to check if a codepoint was or wasn't a Control character would
    cause us to throw. Fix this by adding a check.

* Only run NFG_CHECK on concat result that *should* be normalized
  * Before it could run NFG_CHECK when we knew our string was not properly
    normalized.
  * Add MVMROOT for `result` so it doesn't get garbage collected
    before we return.
  * Move strand and NFG_CHECK's inside the MVMROOT of concat

* Initialize more pointers to null cautiously