### PR TITLE
Replace all uses of sprintf with snprintf

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -365,7 +365,7 @@ static const char *dlerror(void)
     DWORD dw = GetLastError();
     if (dw == 0)
         return NULL;
-    sprintf(buf, "error 0x%x", (unsigned int)dw);
+    snprintf(buf, 32, "error 0x%"PRIx32"", (MVMuint32)dw);
     return buf;
 }
 #endif

--- a/src/jit/log.c
+++ b/src/jit/log.c
@@ -15,9 +15,10 @@ void MVM_jit_log_bytecode(MVMThreadContext *tc, MVMJitCode *code) {
      * bytes, moar-jit-.bin is 13 bytes, one byte for the zero at the
      * end, one byte for the directory separator is 25 bytes, plus the
      * length of the bytecode directory itself */
-    char * filename = MVM_malloc(strlen(tc->instance->jit_bytecode_dir) + 25);
+    size_t filename_size = strlen(tc->instance->jit_bytecode_dir) + 25;
+    char * filename = MVM_malloc(filename_size);
     FILE * out;
-    sprintf(filename, "%s/moar-jit-%04d.bin", tc->instance->jit_bytecode_dir, code->seq_nr);
+    snprintf(filename, filename_size, "%s/moar-jit-%04d.bin", tc->instance->jit_bytecode_dir, code->seq_nr);
     out = fopen(filename, "w");
     if (out) {
         fwrite(code->func_ptr, sizeof(char), code->size, out);

--- a/src/moar.c
+++ b/src/moar.c
@@ -239,8 +239,9 @@ MVMInstance * MVM_vm_create_instance(void) {
         instance->jit_log_fh = fopen_perhaps_with_pid(jit_log, "w");
     jit_bytecode_dir = getenv("MVM_JIT_BYTECODE_DIR");
     if (jit_bytecode_dir && jit_bytecode_dir[0]) {
-        char *bytecode_map_name = MVM_malloc(strlen(jit_bytecode_dir) + strlen("/jit-map.txt") + 1);
-        sprintf(bytecode_map_name, "%s/jit-map.txt", jit_bytecode_dir);
+        size_t bytecode_map_name_size = strlen(jit_bytecode_dir) + strlen("/jit-map.txt") + 1;
+        char *bytecode_map_name = MVM_malloc(bytecode_map_name_size);
+        snprintf(bytecode_map_name, bytecode_map_name_size, "%s/jit-map.txt", jit_bytecode_dir);
         instance->jit_bytecode_map = fopen(bytecode_map_name, "w");
         instance->jit_bytecode_dir = jit_bytecode_dir;
         MVM_free(bytecode_map_name);

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -83,13 +83,12 @@ static char * NFG_checker (MVMThreadContext *tc, MVMString *orig, char *varname)
                     "Got %i but after re_nfg got %i\n"
                         "Differing grapheme at index %"PRIi64"\n"
                             "orig: %"PRIi32"  (%s)  after re_nfg: %"PRIi32"  (%s)\n";
-                char *out = MVM_malloc(sizeof(char) * (
-                    strlen(orig_render) + strlen(renorm_render)
-                    + strlen(varname) + strlen(format) + (5 * 7)
-                ) + 1);
+                int out_size = strlen(orig_render) + strlen(renorm_render)
+                    + strlen(varname) + strlen(format) + (5 * 7) + 1;
+                char *out = MVM_malloc(sizeof(char) * out_size);
                 char *waste[] = {orig_render, renorm_render, NULL};
                 char **w = waste;
-                sprintf(out,
+                snprintf(out, out_length,
                     format,
                     varname,
                         orig_graphs, renorm_graphs,


### PR DESCRIPTION
For extra security and ensuring we don't overflow the buffer.