### PR TITLE
Optimize MVM_string_gi_move_to and use for index* ops

### DIFF
--- a/src/strings/iter.h
+++ b/src/strings/iter.h
@@ -320,12 +320,8 @@ MVM_STATIC_INLINE MVMGrapheme32 MVM_string_gi_cached_get_grapheme(MVMThreadConte
     }
     /* If we have to backtrack we need to reinitialize the grapheme iterator */
     else {
-        MVM_exception_throw_adhoc(tc, "Internal error: Requested an index %"PRIi64" that was less than the last_location %"PRIu32"",
-            index, gic->last_location);
-        /* Not yet tested, but we may be able to access previous graphemes by reinitializing
-         * MVM_string_gi_cached_init(tc, gic, gic->string, index);
-         * MVM_string_gi_move_to(tc, &(gic->gi), index);
-         * MVM_string_gi_get_grapheme(tc, &(gic->gi)); */
+        MVM_string_gi_cached_init(tc, gic, gic->string, index);
+        return gic->last_g;
     }
     gic->last_location = index;
     return (gic->last_g = MVM_string_gi_get_grapheme(tc, &(gic->gi)));


### PR DESCRIPTION
Use grapheme iterator cached for ignorecase/ignoremark index ops

For a haystack made up of 10 strands, shows a speedup of 2x.


Move some gi struct variables so they only have to be set once instead of
every time of the loop which locates the correct strand.

Optimize the loop which finds the correct location within a strand so that
it isn't a loop and is just conditionals.


If we didn't move from the very start of a string, and the string had
repetitions, we could iterate past the end of a grapheme iterator. Fix this
by making sure to not assume we are always at the start, since gi->start
may not equal gi->pos.