### PR TITLE
Fix a leak in CArray repr.

### DIFF
--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -121,12 +121,10 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
 static void gc_cleanup(MVMThreadContext *tc, MVMSTable *st, void *data) {
     MVMCArrayBody *body = (MVMCArrayBody *)data;
 
-    if (body->managed) {
+    if (body->managed) 
         MVM_free(body->storage);
-
-        if (body->child_objs)
-            MVM_free(body->child_objs);
-    }
+    if (body->child_objs)
+        MVM_free(body->child_objs);
 }
 
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {


### PR DESCRIPTION
 When expand is called (via at-pos) it make room for more perl6 object in the body, but this does not get free if the array is not managed by MoarVM.