### PR TITLE
Nativecall code : fix invalid pointer creation

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -752,13 +752,13 @@ void MVM_nativecall_refresh(MVMThreadContext *tc, MVMObject *cthingy) {
         for (i = 0; i < repr_data->num_attributes; i++) {
             MVMint32 kind = repr_data->attribute_locations[i] & MVM_CSTRUCT_ATTR_MASK;
             MVMint32 slot = repr_data->attribute_locations[i] >> MVM_CSTRUCT_ATTR_SHIFT;
-            void *cptr;   /* The pointer in the C storage. */
-            void *objptr; /* The pointer in the object representing the C object. */
+            void *cptr = NULL;   /* The pointer in the C storage. */
+            void *objptr = NULL; /* The pointer in the object representing the C object. */
 
             if (kind == MVM_CSTRUCT_ATTR_IN_STRUCT || !body->child_objs[slot])
                 continue;
 
-            cptr = *((void **)(storage + repr_data->struct_offsets[i]));
+            cptr = (void*)((uintptr_t)storage + (uintptr_t)repr_data->struct_offsets[i]);
             if (IS_CONCRETE(body->child_objs[slot])) {
                 switch (kind) {
                     case MVM_CSTRUCT_ATTR_CARRAY:
@@ -801,13 +801,13 @@ void MVM_nativecall_refresh(MVMThreadContext *tc, MVMObject *cthingy) {
         for (i = 0; i < repr_data->num_attributes; i++) {
             MVMint32 kind = repr_data->attribute_locations[i] & MVM_CPPSTRUCT_ATTR_MASK;
             MVMint32 slot = repr_data->attribute_locations[i] >> MVM_CPPSTRUCT_ATTR_SHIFT;
-            void *cptr;   /* The pointer in the C storage. */
-            void *objptr; /* The pointer in the object representing the C object. */
+            void *cptr = NULL;   /* The pointer in the C storage. */
+            void *objptr = NULL; /* The pointer in the object representing the C object. */
 
             if (kind == MVM_CPPSTRUCT_ATTR_IN_STRUCT || !body->child_objs[slot])
                 continue;
 
-            cptr = *((void **)(storage + repr_data->struct_offsets[i]));
+            cptr = (void*)((uintptr_t)storage + (uintptr_t)repr_data->struct_offsets[i]);
             if (IS_CONCRETE(body->child_objs[slot])) {
                 switch (kind) {
                     case MVM_CPPSTRUCT_ATTR_CARRAY:


### PR DESCRIPTION
This fix what is probably an extra indirection. If I understand this correctly cptr is the address of a field inside a CStruct, the previous code was assigning to cptr the value of the field.
This make efence/valgrind/asan happy (fix an invalid read size of 8 errors message  in this function)
The uintptr _t cast are to respect https://www.securecoding.cert.org/confluence/display/c/INT36-C.+Converting+a+pointer+to+integer+or+integer+to+pointer

All nativecall tests in rakudo still run fine with this fix