### PR TITLE
Use safer macro formatting

### DIFF
--- a/src/6model/reprs/P6bigint.h
+++ b/src/6model/reprs/P6bigint.h
@@ -2,7 +2,7 @@
 
 #define MVM_BIGINT_32_FLAG      0xFFFFFFFF
 #define MVM_BIGINT_IS_BIG(body) ((body)->u.smallint.flag != 0xFFFFFFFF)
-#define MVM_IS_32BIT_INT(i)     ((long long)i >= -2147483648LL && (long long)i <= 2147483647LL)
+#define MVM_IS_32BIT_INT(i)     ((long long)(i) >= -2147483648LL && (long long)(i) <= 2147483647LL)
 
 /* Representation used by big integers; inlined into P6bigint. We store any
  * values in 32-bit signed range without using the big integer library. */


### PR DESCRIPTION
To ensure it works right, regardless of what arg is used.

e.g. if one were to write `MVM_IS_32BIT_INT2(42 ? i : j)` the result would expand to `((long long)42 ? i : j >= -2147483648LL && (long long)42 ? i : j <= 2147483647LL))` and be incorrect.

The extra parens avoid this issue.