### PR TITLE
getsockname / end of non-void function

### DIFF
--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -15,7 +15,7 @@
 #define snprintf _snprintf
 #endif
 
-/* Assuemd maximum packet size. If ever changing this to something beyond a
+/* Assumed maximum packet size. If ever changing this to something beyond a
  * 16-bit number, then make sure to change the receive offsets in the data
  * structure below. */
 #define PACKET_SIZE 65535

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -2,6 +2,7 @@
 
 #ifdef _WIN32
     #include <winsock2.h>
+    #include <ws2tcpip.h>
     typedef SOCKET Socket;
 #else
     #include "unistd.h"

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -343,7 +343,8 @@ MVMint64 socket_getport(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
 
     struct sockaddr_storage name;
-    int error, len = sizeof(struct sockaddr_storage);
+    int error;
+    socklen_t len = sizeof(struct sockaddr_storage);
     MVMint64 port = 0;
 
     error = getsockname(data->handle, (struct sockaddr *) &name, &len);
@@ -393,6 +394,10 @@ static const MVMIOOps op_table = {
     gc_free
 };
 
+/* since we'll throw an error in case of an error we can turn off -Wreturn-type here,
+works with GCC and clang, others will ignore this */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wreturn-type"
 static MVMObject * socket_accept(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
     Socket s;
@@ -416,6 +421,7 @@ static MVMObject * socket_accept(MVMThreadContext *tc, MVMOSHandle *h) {
         return (MVMObject *)result;
     }
 }
+#pragma GCC diagnostic pop
 
 MVMObject * MVM_io_socket_create(MVMThreadContext *tc, MVMint64 listen) {
     MVMOSHandle         * const result = (MVMOSHandle *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTIO);

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -394,10 +394,6 @@ static const MVMIOOps op_table = {
     gc_free
 };
 
-/* since we'll throw an error in case of an error we can turn off -Wreturn-type here,
-works with GCC and clang, others will ignore this */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-type"
 static MVMObject * socket_accept(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
     Socket s;
@@ -421,7 +417,6 @@ static MVMObject * socket_accept(MVMThreadContext *tc, MVMOSHandle *h) {
         return (MVMObject *)result;
     }
 }
-#pragma GCC diagnostic pop
 
 MVMObject * MVM_io_socket_create(MVMThreadContext *tc, MVMint64 listen) {
     MVMOSHandle         * const result = (MVMOSHandle *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTIO);

--- a/src/io/syncsocket.h
+++ b/src/io/syncsocket.h
@@ -1,3 +1,4 @@
+MVM_NO_RETURN static void throw_error(MVMThreadContext *tc, int r, char *operation) MVM_NO_RETURN_GCC;
 MVMObject * MVM_io_socket_create(MVMThreadContext *tc, MVMint64 listen);
 struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc, MVMString *host, MVMint64 port);
 MVMString * MVM_io_get_hostname(MVMThreadContext *tc);


### PR DESCRIPTION
`getsockname` expects a socklen_t* as third argument (which is an unsigned int*) and not a signed int.
pragma to turn off the "end of non-void function" warning (hope you don't find pragmas ugly)