### PR TITLE
Change realloc condition in MVM_string_utf8_decode

### DIFF
--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -199,7 +199,7 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
             MVMGrapheme32 g;
             ready = MVM_unicode_normalizer_process_codepoint_to_grapheme(tc, &norm, codepoint, &g);
             if (ready) {
-                while (count + ready >= bufsize) { /* if the buffer's full make a bigger one */
+                while (count + ready > bufsize) { /* if the buffer's full make a bigger one */
                     buffer = MVM_realloc(buffer, sizeof(MVMGrapheme32) * (
                         bufsize >= UTF8_MAXINC ? (bufsize += UTF8_MAXINC) : (bufsize *= 2)
                     ));
@@ -262,7 +262,7 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
     MVM_unicode_normalizer_eof(tc, &norm);
     ready = MVM_unicode_normalizer_available(tc, &norm);
     if (ready) {
-        if (count + ready >= bufsize) {
+        if (count + ready > bufsize) {
             buffer = MVM_realloc(buffer, sizeof(MVMGrapheme32) * (count + ready));
         }
         while (ready--) {


### PR DESCRIPTION
The conditional being `>=` instead of `>` meant that the buffer was
frequently being realloced to the same size.

Callgrind reports ~13k fewer instructions and heaptrack reports ~90
fewer realloc calls for `perl6 -e ''`.

NQP builds ok and passes `make m-test` and Rakudo builds ok and
passes `make m-test m-spectest`.