### PR TITLE
FSA size debug: cooperate with valgrind

### DIFF
--- a/src/core/fixedsizealloc.c
+++ b/src/core/fixedsizealloc.c
@@ -274,13 +274,13 @@ void MVM_fixed_size_free(MVMThreadContext *tc, MVMFixedSizeAlloc *al, size_t byt
             char command[128];
             snprintf(&command, 128, "check_memory defined %p %d", dbg, bytes + 8);
             VALGRIND_MONITOR_COMMAND(command);
-            VALGRIND_PRINTF_BACKTRACE("Fixed size allocator: wrong size in free: expected %d, got %d", dbg->alloc_size, bytes);
+            VALGRIND_PRINTF_BACKTRACE("Fixed size allocator: wrong size in free: expected %lu, got %lu", dbg->alloc_size, bytes);
         }
         else {
-            MVM_panic(1, "Fixed size allocator: wrong size in free: expected %d, got %d", dbg->alloc_size, bytes);
+            MVM_panic(1, "Fixed size allocator: wrong size in free: expected %lu, got %lu", dbg->alloc_size, bytes);
         }
 #else
-        MVM_panic(1, "Fixed size allocator: wrong size in free: expected %d, got %d", dbg->alloc_size, bytes);
+        MVM_panic(1, "Fixed size allocator: wrong size in free: expected %lu, got %lu", dbg->alloc_size, bytes);
 #endif
     }
     MVM_free(dbg);
@@ -319,16 +319,16 @@ void MVM_fixed_size_free_at_safepoint(MVMThreadContext *tc, MVMFixedSizeAlloc *a
     if (dbg->alloc_size != bytes) {
 #ifdef MVM_VALGRIND_SUPPORT
         if (RUNNING_ON_VALGRIND) {
-            char command[128]; snprintf(&command, 128, "check_memory defined %p %d", dbg, bytes + 8); VALGRIND_MONITOR_COMMAND(command);
-            VALGRIND_PRINTF_BACKTRACE("Fixed size allocator: wrong size in free: expected %d, got %d", dbg->alloc_size, bytes);
+            char command[128]; snprintf(&command, 128, "check_memory defined %p %lu", dbg, bytes + 8); VALGRIND_MONITOR_COMMAND(command);
+            VALGRIND_PRINTF_BACKTRACE("Fixed size allocator: wrong size in free: expected %lu, got %lu", dbg->alloc_size, bytes);
         }
         else {
-            MVM_panic(1, "Fixed size allocator: wrong size in free: expected %d, got %d", dbg->alloc_size, bytes);
+            MVM_panic(1, "Fixed size allocator: wrong size in free: expected %lu, got %lu", dbg->alloc_size, bytes);
         }
 #else
-        MVM_panic(1, "Fixed size allocator: wrong size in free: expected %d, got %d", dbg->alloc_size, bytes);
+        MVM_panic(1, "Fixed size allocator: wrong size in free: expected %lu, got %lu", dbg->alloc_size, bytes);
 #endif
-        MVM_panic(1, "Fixed size allocator: wrong size in free");
+        MVM_panic(1, "Fixed size allocator: wrong size in free: expected %lu, got %lu", dbg->alloc_size, bytes);
     }
     add_to_overflows_safepoint_free_list(tc, al, dbg);
 #else


### PR DESCRIPTION
when the free size is wrong, it gives the stack trace for
where the corresponding data was allocated, how many bytes are
marked "defined" by valgrind, and of course the current stacktrace.
On top of that, it outputs the passed and expected size.

looks like this:

```
Address 0x8164E30 len 376 not defined:
Uninitialised value at 0x8164EA0
==11815==  Address 0x8164e30 is 0 bytes inside a block of size 192 alloc'd
==11815==    at 0x4C2DB9D: malloc (vg_replace_malloc.c:299)
==11815==    by 0x50428C2: MVM_malloc (alloc.h:2)
==11815==    by 0x5043497: MVM_fixed_size_alloc (fixedsizealloc.c:178)
==11815==    by 0x5026329: allocate_frame (frame.c:287)
==11815==    by 0x5026DC2: MVM_frame_invoke (frame.c:517)
==11815==    by 0x507C8BF: invoke_handler (MVMCode.c:10)
==11815==    by 0x4FFB99A: MVM_interp_run (interp.c:990)
==11815==    by 0x51108E2: MVM_vm_run_file (moar.c:387)
==11815==    by 0x4014D1: main (main.c:255)
**11815** Fixed size allocator: wrong size in free: expected 184, got 368   at 0x5042B86: VALGRIND_PRINTF_BACKTRACE (valgrind.h:6818)
==11815==    by 0x50439CD: MVM_fixed_size_free (fixedsizealloc.c:277)
==11815==    by 0x5027728: remove_one_frame (frame.c:771)
==11815==    by 0x5027C51: MVM_frame_try_return (frame.c:889)
==11815==    by 0x4FF77A5: MVM_interp_run (interp.c:486)
==11815==    by 0x51108E2: MVM_vm_run_file (moar.c:387)
==11815==    by 0x4014D1: main (main.c:255)
==11815== ```