### PR TITLE
Fix getaddrinfo failing with EAI_HINTS on FreeBSD

### DIFF
--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -299,6 +299,10 @@ struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc, MVMString *host
     hints.ai_socktype = 0;
     hints.ai_flags = AI_PASSIVE;
     hints.ai_protocol = 0;
+    hints.ai_addrlen = 0;
+    hints.ai_addr = NULL;
+    hints.ai_canonname = NULL;
+    hints.ai_next = NULL;
 
     snprintf(port_cstr, 8, "%d", (int)port);
 


### PR DESCRIPTION
This fixes spectest failures (e.g. in S32-io/IO-Socket-INET.t) on FreeBSD.

According to the man page of getaddrinfo() '[a]ll other elements of the
addrinfo structure passed via hints must be zero or the null pointer'
(similiar wording on Linux). This requirement is actually enforced on
FreeBSD:

  https://github.com/freebsd/freebsd/blob/89c48e12204df05d7db296d3ae5d2fd002b4b510/lib/libc/net/getaddrinfo.c#L429