### PR TITLE
Disable tests on Appveyor until we can fix the build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,6 @@ branches:
     - master
 
 
-test_script:
-  - cd %APPVEYOR_BUILD_FOLDER%\nqp
-  - nmake m-test
+#test_script:
+#  - cd %APPVEYOR_BUILD_FOLDER%\nqp
+#  - nmake m-test


### PR DESCRIPTION
If it stalls during testing, we get no feedback on when the build itself
has broken.