### PR TITLE
[WIN32] Fix ->seakable detection on TTY handles

### DIFF
--- a/src/platform/win32/io.c
+++ b/src/platform/win32/io.c
@@ -28,6 +28,10 @@ MVMint64 MVM_platform_lseek(int fd, MVMint64 offset, int origin)
         errno = EBADF;
         return -1;
     }
+    if (GetFileType(hf) != 1) {
+        errno = ESPIPE;
+        return -1;
+    }
 
     li.QuadPart = offset;
     li.LowPart = SetFilePointer(hf, li.LowPart, &li.HighPart, origin);


### PR DESCRIPTION
Fixes RT#132254: https://rt.perl.org/Ticket/Display.html?id=132254
Fixes all t/02-rakudo/repl.t failures

The SetFilePointer() routine silently fails[^1] when the handle is
not a seekable handle, so check the handle is a disk handle[^2] before
trying to seek stuf.

[1] (Remarks section)
https://msdn.microsoft.com/en-us/library/windows/desktop/aa365541(v=vs.85).aspx

[2]
https://msdn.microsoft.com/en-us/library/windows/desktop/aa364960(v=vs.85).aspx