### PR TITLE
JIT the getexcategory op

### DIFF
--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -819,3 +819,10 @@ void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const
 void MVM_crash_on_error(void) {
     crash_on_error = 1;
 }
+
+MVMint32 MVM_get_exception_category(MVMThreadContext *tc, MVMObject *ex) {
+    if (IS_CONCRETE(ex) && REPR(ex)->ID == MVM_REPR_ID_MVMException)
+        return ((MVMException *)ex)->body.category;
+    else
+        MVM_exception_throw_adhoc(tc, "getexcategory needs a VMException, got %s (%s)", REPR(ex)->name, MVM_6model_get_debug_name(tc, ex));
+}

--- a/src/core/exceptions.h
+++ b/src/core/exceptions.h
@@ -93,6 +93,7 @@ MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *t
 MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) MVM_NO_RETURN_GCC;
 MVM_PUBLIC void MVM_crash_on_error(void);
 char * MVM_exception_backtrace_line(MVMThreadContext *tc, MVMFrame *cur_frame, MVMuint16 not_top, MVMuint8 *throw_address);
+MVMint32 MVM_get_exception_category(MVMThreadContext *tc, MVMObject *ex);
 
 /* Exit codes for panic. */
 #define MVM_exitcode_NYI            12

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -1245,11 +1245,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(getexcategory): {
-                MVMObject *ex = GET_REG(cur_op, 2).o;
-                if (IS_CONCRETE(ex) && REPR(ex)->ID == MVM_REPR_ID_MVMException)
-                    GET_REG(cur_op, 0).i64 = ((MVMException *)ex)->body.category;
-                else
-                    MVM_exception_throw_adhoc(tc, "getexcategory needs a VMException, got %s (%s)", REPR(ex)->name, MVM_6model_get_debug_name(tc, ex));
+                GET_REG(cur_op, 0).i64 = MVM_get_exception_category(tc, GET_REG(cur_op, 2).o);
                 cur_op += 4;
                 goto NEXT;
             }

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -336,6 +336,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_atomicstore_i: return MVM_6model_container_atomic_store_i;
     case MVM_OP_lock: return MVM_reentrantmutex_lock_checked;
     case MVM_OP_unlock: return MVM_reentrantmutex_unlock_checked;
+    case MVM_OP_getexcategory: return MVM_get_exception_category;
     default:
         MVM_oops(tc, "JIT: No function for op %d in op_to_func (%s)", opcode, MVM_op_get_op(opcode)->name);
     }
@@ -3032,6 +3033,14 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     }
     case MVM_OP_prepargs: {
         return consume_invoke(tc, jg, iter, ins);
+    }
+    case MVM_OP_getexcategory: {
+        MVMint16 dst     = ins->operands[0].reg.orig;
+        MVMint16 obj     = ins->operands[1].reg.orig;
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { obj } } };
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 2, args, MVM_JIT_RV_PTR, dst);
+        break;
     }
     default: {
         /* Check if it's an extop. */


### PR DESCRIPTION
Create an MVM_get_exception_category function and call that in interp.c
and graph.c.

Used to cause 15 BAILs when building the Rakudo core setting.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.