### PR TITLE
Jit param_rp_s op

### DIFF
--- a/src/core/args.c
+++ b/src/core/args.c
@@ -301,6 +301,12 @@ MVMint64 MVM_args_get_required_pos_int(MVMThreadContext *tc, MVMArgProcContext *
     autounbox(tc, MVM_CALLSITE_ARG_INT, "integer", result);
     return result.arg.i64;
 }
+MVMString * MVM_args_get_required_pos_str(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
+    MVMArgInfo result;
+    args_get_pos(tc, ctx, pos, MVM_ARG_REQUIRED, result);
+    autounbox(tc, MVM_CALLSITE_ARG_STR, "string", result);
+    return result.arg.s;
+}
 MVMArgInfo MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
     MVMArgInfo result;
     args_get_pos(tc, ctx, pos, MVM_ARG_OPTIONAL, result);

--- a/src/core/args.h
+++ b/src/core/args.h
@@ -62,6 +62,7 @@ void MVM_args_throw_named_unused_error(MVMThreadContext *tc, MVMString *name);
 MVMObject * MVM_args_get_required_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMArgInfo MVM_args_get_optional_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMint64 MVM_args_get_required_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
+MVMString * MVM_args_get_required_pos_str(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMArgInfo MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMArgInfo MVM_args_get_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required);
 MVMArgInfo MVM_args_get_pos_str(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required);

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1642,6 +1642,16 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         jg_append_call_c(tc, jg, MVM_args_get_required_pos_int, 3, args, MVM_JIT_RV_INT, dst);
         break;
     }
+    case MVM_OP_param_rp_s: {
+        MVMint16  dst     = ins->operands[0].reg.orig;
+        MVMuint16 arg_idx = ins->operands[1].lit_ui16;
+
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_PARAMS } },
+                                 { MVM_JIT_LITERAL, { arg_idx } } };
+        jg_append_call_c(tc, jg, MVM_args_get_required_pos_str, 3, args, MVM_JIT_RV_INT, dst);
+        break;
+    }
     case MVM_OP_param_rp_o: {
         MVMint16  dst     = ins->operands[0].reg.orig;
         MVMuint16 arg_idx = ins->operands[1].lit_ui16;


### PR DESCRIPTION
Used to cause 22 BAILs when building the Rakudo core setting.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.