### PR TITLE
Fix seekability detection on MacOS

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -55,7 +55,8 @@ PLATFORM_WIN32 = src/platform/win32/mmap@obj@ \
                  src/platform/win32/io@obj@
 
 PLATFORM_POSIX = src/platform/posix/mmap@obj@ \
-                 src/platform/posix/time@obj@
+                 src/platform/posix/time@obj@ \
+                 src/platform/posix/io@obj@
 
 DASM_FLAGS   = @dasm_flags@
 JIT_ARCH_X64 = src/jit/x64/emit@obj@ src/jit/x64/arch@obj@

--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -472,7 +472,7 @@ MVMObject * MVM_file_open_fh(MVMThreadContext *tc, MVMString *filename, MVMStrin
         MVMOSHandle   * const result = (MVMOSHandle *)MVM_repr_alloc_init(tc,
             tc->instance->boot_types.BOOTIO);
         data->fd          = fd;
-        data->seekable    = MVM_platform_lseek(fd, 0, SEEK_CUR) != -1;
+        data->seekable    = MVM_platform_is_fd_seekable(fd);
         result->body.ops  = &op_table;
         result->body.data = data;
         return (MVMObject *)result;
@@ -484,7 +484,7 @@ MVMObject * MVM_file_handle_from_fd(MVMThreadContext *tc, int fd) {
     MVMOSHandle   * const result = (MVMOSHandle *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTIO);
     MVMIOFileData * const data   = MVM_calloc(1, sizeof(MVMIOFileData));
     data->fd          = fd;
-    data->seekable    = MVM_platform_lseek(fd, 0, SEEK_CUR) != -1;
+    data->seekable    = MVM_platform_is_fd_seekable(fd);
     result->body.ops  = &op_table;
     result->body.data = data;
 #ifdef _WIN32

--- a/src/platform/io.h
+++ b/src/platform/io.h
@@ -7,3 +7,9 @@ int MVM_platform_fsync(int fd);
 #define MVM_platform_unlink unlink
 #define MVM_platform_fsync fsync
 #endif
+
+#if defined(__APPLE__) || defined(__Darwin__)
+short MVM_platform_is_fd_seekable(int fd);
+#else
+#define MVM_platform_is_fd_seekable(x) (MVM_platform_lseek((x), 0, SEEK_CUR) != -1)
+#endif

--- a/src/platform/posix/io.c
+++ b/src/platform/posix/io.c
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(__Darwin__)
+#include <moar.h>
+#include <platform/io.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+short MVM_platform_is_fd_seekable(int fd) {
+    off_t can_seek = MVM_platform_lseek(fd, 0, SEEK_CUR);
+    if (can_seek != -1) {
+        /*
+            On MacOS, lseek of TTYs still returns some seek position,
+            which makes us think they're seekable handles and messes up
+            our EOF detection. So if lseek tells us it's a seekable
+            handle, we do an extra check for whether it's a TTY
+            and claim non-seekability if it is one.
+        */
+        return isatty(fd) ? 0 : 1;
+    }
+    else
+        return 0;
+}
+#endif


### PR DESCRIPTION
This fixes [the bug](https://rt.perl.org/Ticket/Display.html?id=132349) it was meant to fix, but needs a spectest/stresstest on MacOS done and seeing if it introduces any significant performance degradation on MacOS. Also, I'm out of my depth here and poorly know what I'm doing.

-----

POSIX does not define which devices must support lseek() and on
MacOS it returns some non-zero value that isn't -1 indicating failure
when lseek()ing TTY STDIN. This results in such handles marked
as seekable and in turn causes issues, such as mvm_eof() trying
to figure out whether we've reached EOF and falsely returning True
even when we didn't because the statbuf.st_size is zero.

After discussion[^1] and some research, the solution in this patch
is what I came up with and that actually works. We try to seek
a handle with lseek and on MacOS, if it doesn't error out, then
try to see if the file is a regular file, which is guaranteed to
be seekable.

Does this work? It passes the rakudo test[^1] to cover the bug,
but so far I'm having trouble completing spectest on the macos VM
I got (maybe something with VM I dunno).

Is this sane? I've no idea. I'm a n00b at this.

[1] (Notes section) http://man7.org/linux/man-pages/man2/lseek.2.html
[2] https://irclog.perlgeek.de/perl6-dev/2017-10-23#i_15341511
[3] https://github.com/perl6/roast/commit/27833272b4
