### PR TITLE
Include the type of unhandled register in error messages

### DIFF
--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -486,7 +486,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
             break;
         }
         default:
-            MVM_exception_throw_adhoc(tc, "CStruct: invalid kind in attribute get");
+            MVM_exception_throw_adhoc(tc, "CStruct: invalid kind in attribute get for '%s'", MVM_reg_get_debug_name(tc, kind));
         }
     }
     else {

--- a/src/6model/reprs/MVMIter.c
+++ b/src/6model/reprs/MVMIter.c
@@ -291,7 +291,7 @@ MVMObject * MVM_iter(MVMThreadContext *tc, MVMObject *target) {
                             }
                             default:
                                 MVM_exception_throw_adhoc(tc,
-                                    "Unknown lexical type encountered while building context iterator");
+                                    "%s lexical type encountered while building context iterator", MVM_reg_get_debug_name(tc, type));
                         }
                     }
                 });

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -238,7 +238,7 @@ static void at_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *d
                 value->i64 = (MVMint64)body->slots.u8[body->start + index];
             break;
         default:
-            MVM_exception_throw_adhoc(tc, "MVMArray: Unhandled slot type");
+            MVM_exception_throw_adhoc(tc, "MVMArray: Unhandled slot type, got '%s'", MVM_reg_get_debug_name(tc, repr_data->slot_type));
     }
 }
 

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -1263,12 +1263,14 @@ static void serialize_context(MVMThreadContext *tc, MVMSerializationWriter *writ
             case MVM_reg_int8:
             case MVM_reg_int16:
             case MVM_reg_int32:
-                MVM_exception_throw_adhoc(tc, "unsupported lexical type");
+                MVM_exception_throw_adhoc(tc, "unsupported lexical type %s", MVM_reg_get_debug_name(tc, sf->body.lexical_types[i]));
+                break;
             case MVM_reg_int64:
                 MVM_serialization_write_int(tc, writer, frame->env[i].i64);
                 break;
             case MVM_reg_num32:
-                MVM_exception_throw_adhoc(tc, "unsupported lexical type");
+                MVM_exception_throw_adhoc(tc, "unsupported lexical type %s", MVM_reg_get_debug_name(tc, sf->body.lexical_types[i]));
+                break;
             case MVM_reg_num64:
                 MVM_serialization_write_num(tc, writer, frame->env[i].n64);
                 break;
@@ -1279,7 +1281,8 @@ static void serialize_context(MVMThreadContext *tc, MVMSerializationWriter *writ
                 MVM_serialization_write_ref(tc, writer, frame->env[i].o);
                 break;
             default:
-                MVM_exception_throw_adhoc(tc, "unsupported lexical type");
+                MVM_exception_throw_adhoc(tc, "unsupported lexical type %s", MVM_reg_get_debug_name(tc, sf->body.lexical_types[i]));
+                break;
         }
     }
 }

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1654,7 +1654,8 @@ MVMuint16 MVM_frame_lexical_primspec(MVMThreadContext *tc, MVMFrame *f, MVMStrin
                     char *c_name = MVM_string_utf8_encode_C_string(tc, name);
                     char *waste[] = { c_name, NULL };
                     MVM_exception_throw_adhoc_free(tc, waste,
-                        "Unhandled lexical type in lexprimspec for '%s'",
+                        "Unhandled lexical type '%s' in lexprimspec for '%s'",
+                        MVM_reg_get_debug_name(tc, f->static_info->body.lexical_types[entry->value]),
                         c_name);
                 }
             }

--- a/src/core/interp.h
+++ b/src/core/interp.h
@@ -117,3 +117,34 @@ MVM_STATIC_INLINE MVMnum64 MVM_BC_get_N64(const MVMuint8 *cur_op, int offset) {
     return temp;
 #endif
 }
+/* For MVM_reg_* types */
+static char * MVM_reg_get_debug_name(MVMThreadContext *tc, MVMuint16 type) {
+    switch (type) {
+        case MVM_reg_int8:
+            return "int8";
+        case MVM_reg_int16:
+            return "int16";
+        case MVM_reg_int32:
+            return "int32";
+        case MVM_reg_int64:
+            return "int64";
+        case MVM_reg_num32:
+            return "num32";
+        case MVM_reg_num64:
+            return "num64";
+        case MVM_reg_str:
+            return "str";
+        case MVM_reg_obj:
+            return "obj";
+        case MVM_reg_uint8:
+            return "uint8";
+        case MVM_reg_uint16:
+            return "uint16";
+        case MVM_reg_uint32:
+            return "uint32";
+        case MVM_reg_uint64:
+            return "uint64";
+        default:
+            return "unknown";
+    }
+}


### PR DESCRIPTION
Added better errors for CStruct, MVMiter, VMArray, and frame.c
Example: Unhandled lexical type 'int8' in lexprimspec for '$var'
Before: Unhandled lexical type in lexprimspec for '$var'