### PR TITLE
Handle unsigned types to switch in MVM_iter()

### DIFF
--- a/src/6model/reprs/MVMIter.c
+++ b/src/6model/reprs/MVMIter.c
@@ -259,9 +259,21 @@ MVMObject * MVM_iter(MVMThreadContext *tc, MVMObject *target) {
                                 MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
                                 break;
                             }
+                            case MVM_reg_uint8: {
+                                MVMObject *bi = MVM_repr_box_int(tc, hll->int_box_type,
+                                    frame->env[idx].u8);
+                                MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
+                                break;
+                            }
                             case MVM_reg_int16: {
                                 MVMObject *bi = MVM_repr_box_int(tc, hll->int_box_type,
                                     frame->env[idx].i16);
+                                MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
+                                break;
+                            }
+                            case MVM_reg_uint16: {
+                                MVMObject *bi = MVM_repr_box_int(tc, hll->int_box_type,
+                                    frame->env[idx].u16);
                                 MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
                                 break;
                             }
@@ -271,9 +283,21 @@ MVMObject * MVM_iter(MVMThreadContext *tc, MVMObject *target) {
                                 MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
                                 break;
                             }
+                            case MVM_reg_uint32: {
+                                MVMObject *bi = MVM_repr_box_int(tc, hll->int_box_type,
+                                    frame->env[idx].u32);
+                                MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
+                                break;
+                            }
                             case MVM_reg_int64: {
                                 MVMObject *bi = MVM_repr_box_int(tc, hll->int_box_type,
                                     frame->env[idx].i64);
+                                MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
+                                break;
+                            }
+                            case MVM_reg_uint64: {
+                                MVMObject *bi = MVM_repr_box_int(tc, hll->int_box_type,
+                                    frame->env[idx].u64);
                                 MVM_repr_bind_key_o(tc, ctx_hash, lexreg[i]->key, bi);
                                 break;
                             }


### PR DESCRIPTION
Fixes "Unknown lexical type encountered while building context iterator"
error when MVM_iter() tries to handle unsigned integers.