### PR TITLE
Don't throw exception for EINTR when writing to fd

### DIFF
--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -72,13 +72,19 @@ static void perform_write(MVMThreadContext *tc, MVMIOFileData *data, char *buf, 
     MVMint64 bytes_written = 0;
     MVM_gc_mark_thread_blocked(tc);
     while (bytes > 0) {
-        int r = write(data->fd, buf, (int)bytes);
+        int r;
+
+        do {
+            r = write(data->fd, buf, (int)bytes);
+        } while (r == -1 && errno == EINTR);
+
         if (r == -1) {
             int save_errno = errno;
             MVM_gc_mark_thread_unblocked(tc);
             MVM_exception_throw_adhoc(tc, "Failed to write bytes to filehandle: %s",
                 strerror(save_errno));
         }
+
         bytes_written += r;
         buf += r;
         bytes -= r;


### PR DESCRIPTION
Fixes `Failed to write bytes to filehandle: Interrupted system call` when running:
`strace perl6 -e 'while 1 { use nqp; my $s := $*SCHEDULER; my $c := nqp::list("echo", "-n", q||); my $e := CLONE-HASH-DECONTAINERIZED %*ENV; await ^500 .map: { start nqp::spawnprocasync($s.queue, $c, "/", $e, nqp::hash()) }; print "." }'`