### PR TITLE
Add two more missing MVMROOTs around managed mutex acquire

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2810,7 +2810,9 @@ MVMObject * MVM_serialization_demand_code(MVMThreadContext *tc, MVMSerialization
     /* Obtain lock and ensure we didn't lose a race to deserialize this
      * code object. */
     MVMSerializationReader *sr = sc->body->sr;
-    MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)sc->body->mutex);
+    MVMROOT(tc, sc, {
+        MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)sc->body->mutex);
+    });
     if (!MVM_is_null(tc, MVM_repr_at_pos_o(tc, sr->codes_list, idx))) {
         MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)sc->body->mutex);
         return MVM_repr_at_pos_o(tc, sr->codes_list, idx);
@@ -2872,7 +2874,9 @@ void MVM_serialization_finish_deserialize_method_cache(MVMThreadContext *tc, MVM
     if (sc && sc->body->sr) {
         /* Acquire mutex and ensure we didn't lose a race to do this. */
         MVMSerializationReader *sr = sc->body->sr;
-        MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)sc->body->mutex);
+        MVMROOT(tc, sc, {
+            MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)sc->body->mutex);
+        });
         if (st->method_cache_sc) {
             MVMObject *cache;
 


### PR DESCRIPTION
The mutex acquire may GC block and thus trigger GC, moving objects.