### PR TITLE
Put op in same order relative to oplist

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3525,12 +3525,6 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 4;
                 goto NEXT;
             }
-            OP(coerce_II): {
-                MVMObject *   const type = GET_REG(cur_op, 4).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_from_bigint(tc, type, GET_REG(cur_op, 2).o);
-                cur_op += 6;
-                goto NEXT;
-            }
             OP(coerce_nI): {
                 MVMObject *   const type = GET_REG(cur_op, 4).o;
                 GET_REG(cur_op, 0).o = MVM_bigint_from_num(tc, type, GET_REG(cur_op, 2).n64);
@@ -5289,6 +5283,12 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 GET_REG(cur_op, 0).o = tc->cur_frame->args[GET_REG(cur_op, 2).u16].o;
                 cur_op += 4;
                 goto NEXT;
+            OP(coerce_II): {
+                MVMObject *   const type = GET_REG(cur_op, 4).o;
+                GET_REG(cur_op, 0).o = MVM_bigint_from_bigint(tc, type, GET_REG(cur_op, 2).o);
+                cur_op += 6;
+                goto NEXT;
+            }
             OP(sp_guard): {
                 MVMObject *check = GET_REG(cur_op, 0).o;
                 MVMSTable *want  = (MVMSTable *)tc->cur_frame


### PR DESCRIPTION
The ops should be in the same order here as in the oplist file, so the compiler can can optimize the switch properly.