### PR TITLE
Optimize MVM_string_concat when the RHS is a...

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -615,14 +615,16 @@ static MVMString * string_from_strand_at_index(MVMThreadContext *tc, MVMString *
 /* Append one string to another. */
 static MVMuint16 final_strand_match_with_repetition_count(MVMThreadContext *tc, MVMString *a, MVMString *b) {
     if (a->body.storage_type == MVM_STRING_STRAND) {
-        MVMStringStrand *ss = &(a->body.storage.strands[a->body.num_strands - 1]);
-        if (ss->end - ss->start == MVM_string_graphs(tc, b)) {
-            if (MVM_string_equal_at(tc, ss->blob_string, b, ss->start))
+        MVMStringStrand *sa = &(a->body.storage.strands[a->body.num_strands - 1]);
+        if (sa->end - sa->start == MVM_string_graphs(tc, b)) {
+            if (MVM_string_equal_at(tc, sa->blob_string, b, sa->start))
                 return 1;
         }
         else if (b->body.storage_type == MVM_STRING_STRAND && b->body.num_strands == 1) {
-            if (MVM_string_equal(tc, string_from_strand_at_index(tc, a, a->body.num_strands - 1), string_from_strand_at_index(tc, b, 0)))
-                return b->body.storage.strands[0].repetitions + 1;
+            MVMStringStrand *sb = &(b->body.storage.strands[0]);
+            if (sa->end - sa->start == sb->end - sb->start)
+                if (MVM_string_equal(tc, string_from_strand_at_index(tc, a, a->body.num_strands - 1), string_from_strand_at_index(tc, b, 0)))
+                    return b->body.storage.strands[0].repetitions + 1;
 	}
     }
     return 0;


### PR DESCRIPTION
single strand that's equal to the LHS's final strand. In that case, just
increase the LHS's repetition count by the number of repetition of the
RHS.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

This adapted code from https://rt.perl.org/Ticket/Display.html?id=131774:
`$ /usr/bin/time perl6-m -e 'for (1, 10, 100, 1_000, 10_000, 100_000) -> $limit {my $x; my $y = "x" x 100; $x ~= $y for (1..$limit); say "$limit: ", now - ENTER now}'` used to report:
```
1: 0.0045150 
10: 0.0004916 
100: 0.00096704 
1000: 0.0077635 
10000: 0.4149077 
100000: 40.1284791 
37.36user 3.66system 0:41.02elapsed 100%CPU (0avgtext+0avgdata 3776812maxresident)k
```
and now reports:
```
1: 0.0043542
10: 0.0005357
100: 0.0008045
1000: 0.00442383
10000: 0.0260266
100000: 0.1531845
0.58user 0.01system 0:00.47elapsed 125%CPU (0avgtext+0avgdata 91024maxresident)k
```