### PR TITLE
collapse_strands with memcpy if all strands are same type 4x faster

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -241,16 +241,81 @@ static void iterate_gi_into_string(MVMThreadContext *tc, MVMGraphemeIter *gi, MV
         }
     }
 }
-
+#define copy_strands_memcpy(BLOB_TYPE, SIZEOF_TYPE, STORAGE_TYPE) { \
+    result->body.storage.BLOB_TYPE = MVM_malloc(sizeof(SIZEOF_TYPE) * MVM_string_graphs_nocheck(tc, orig)); \
+    for (i = 0; i < orig->body.num_strands; i++) { \
+        size_t graphs_this_strand =  orig->body.storage.strands[i].end - orig->body.storage.strands[i].start; \
+        /* If it's 8bit format and there's only one grapheme */ \
+        if ((STORAGE_TYPE == MVM_STRING_GRAPHEME_ASCII || STORAGE_TYPE == MVM_STRING_GRAPHEME_8) && graphs_this_strand == 1) { \
+            /* If there are not repetitions we can directly set the grapheme */ \
+            if (!orig->body.storage.strands[i].repetitions) \
+                result->body.storage.BLOB_TYPE[graphs_so_far] = orig->body.storage.strands[i].blob_string->body.storage.BLOB_TYPE[orig->body.storage.strands[i].start]; \
+            /* Otherwise, use memset for the correct number of repetitions */ \
+            else { \
+                graphs_this_strand += orig->body.storage.strands[i].repetitions; \
+                memset(graphs_so_far + result->body.storage.BLOB_TYPE, \
+                    orig->body.storage.strands[i].blob_string->body.storage.BLOB_TYPE[orig->body.storage.strands[i].start], \
+                    graphs_this_strand \
+                ); \
+            } \
+            graphs_so_far += graphs_this_strand; \
+        } \
+        else { \
+            int j = 0; \
+            for (; j <= orig->body.storage.strands[i].repetitions; j++) { \
+                memcpy(graphs_so_far + result->body.storage.BLOB_TYPE, \
+                    orig->body.storage.strands[i].blob_string->body.storage.BLOB_TYPE + orig->body.storage.strands[i].start, \
+                    sizeof(SIZEOF_TYPE) * graphs_this_strand \
+                ); \
+                graphs_so_far += graphs_this_strand; \
+            } \
+        } \
+    } \
+}
 /* Collapses a bunch of strands into a single blob string. */
 static MVMString * collapse_strands(MVMThreadContext *tc, MVMString *orig) {
-    MVMString      *result = (MVMString *)MVM_repr_alloc_init(tc, tc->instance->VMString);
-    MVMGraphemeIter gi;
-    MVMROOT(tc, orig, {
-        MVM_string_gi_init(tc, &gi, orig);
-        result->body.num_graphs = MVM_string_graphs(tc, orig);
-        iterate_gi_into_string(tc, &gi, result);
-    });
+    MVMString      *result = NULL;
+    size_t graphs_so_far = 0;
+
+    /* If it's not a strand, just return it */
+    if (orig->body.storage_type != MVM_STRING_STRAND)
+        return orig;
+    /* If the original string is a STRAND and all the composite strands are
+     * of the same type, then we will collapse it using memcpy instead of
+     * using a grapheme iterator. */
+    else {
+        size_t i;
+        MVMint32 common_storage_type = orig->body.storage.strands[0].blob_string->body.storage_type;
+        MVMROOT(tc, orig, {
+            result = (MVMString *)MVM_repr_alloc_init(tc, tc->instance->VMString);
+            result->body.num_graphs = MVM_string_graphs(tc, orig);
+            for (i = 1; i < orig->body.num_strands; i++) {
+                if (common_storage_type != orig->body.storage.strands[i].blob_string->body.storage_type) {
+                    common_storage_type = -1;
+                    break;
+                }
+            }
+            result->body.storage_type = common_storage_type;
+            switch (common_storage_type) {
+                case MVM_STRING_GRAPHEME_32:
+                    copy_strands_memcpy(blob_32, MVMGrapheme32, MVM_STRING_GRAPHEME_32);
+                    break;
+                case MVM_STRING_GRAPHEME_ASCII:
+                case MVM_STRING_GRAPHEME_8:
+                    copy_strands_memcpy(blob_8, MVMGrapheme8, MVM_STRING_GRAPHEME_8);
+                    break;
+                default: {
+                    MVMGraphemeIter gi;
+                    MVM_string_gi_init(tc, &gi, orig);
+                    iterate_gi_into_string(tc, &gi, result);
+                }
+            }
+        });
+    }
+#if (MVM_DEBUG_STRANDS || MVM_DEBUG_NFG)
+    if (!MVM_string_equal(tc, result, orig))
+        MVM_exception_throw_adhoc(tc, "result and original were not eq in collapse_strands");
+#endif
     return result;
 }
 


### PR DESCRIPTION
If all the strands to collapse are of the same type (ASCII, 8bit, or
32bit) then use memcpy to collapse the strands. If they are not all the
same type then we use the traditional grapheme iterator based collapsing
that we previously used to collapse strands.

If it's 8bit and a repetition with only one grapheme, it will use memset
to more quickly write the memory.

This is 4-4.5x faster as long as all the strands are of the same type.