### PR TITLE
Impl. of the new inline boundary indicators forgot to set action

### DIFF
--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -547,6 +547,7 @@ static void merge_graph(MVMThreadContext *tc, MVMSpeshGraph *inliner,
     *inline_boundary_handler = inliner->num_handlers + inlinee->num_handlers;
     resize_handlers_table(tc, inliner, *inline_boundary_handler + 1);
     inliner->handlers[*inline_boundary_handler].category_mask = MVM_EX_INLINE_BOUNDARY;
+    inliner->handlers[*inline_boundary_handler].action = 0;
     inliner->handlers[*inline_boundary_handler].inlinee = total_inlines - 1;
 
     /* If the inliner has handlers in effect at the point of the call that we


### PR DESCRIPTION
The newly implemented inline boundary indicators omitted to set
the action field. This led to a warning from valgrind. Although
the warning was benign in this case, it should be fixed anyway.
jnthn++ for providing the fix.