### PR TITLE
Fix unwanted null strings in VMArray holes

### DIFF
--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -153,7 +153,7 @@ static void at_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *d
             if (kind != MVM_reg_str)
                 MVM_exception_throw_adhoc(tc, "MVMArray: atpos expected string register");
             if (index >= body->elems)
-                value->s = NULL;
+                value->s = tc->instance->str_consts.empty;
             else
                 value->s = body->slots.s[body->start + index];
             break;
@@ -251,7 +251,7 @@ static MVMuint64 zero_slots(MVMThreadContext *tc, MVMArrayBody *body,
             break;
         case MVM_ARRAY_STR:
             while (elems < ssize)
-                body->slots.s[elems++] = NULL;
+                body->slots.s[elems++] = tc->instance->str_consts.empty;
             break;
         case MVM_ARRAY_I64:
             while (elems < ssize)


### PR DESCRIPTION
Whenever we read past end or zero out str VMArrays, stick empty strings instead of a null pointer there.

**Before:**
```
$ perl6 -e 'my str @a; @a[3] = "x"; dd @a'
chars requires a concrete string, but got null
  in block <unit> at -e line 1
```

**After:**
```
$ perl6 -e 'my str @a; @a[3] = "x"; dd @a'
array[str].new("", "", "", "x")
```

This fixes the issue, but I just did brute-force-fixage and...

![no-idea](https://user-images.githubusercontent.com/5747918/34329717-846c58ca-e8d8-11e7-81d1-a115e7a34976.jpg)
