### PR TITLE
On Windows (not using Visual Studio), print size_t with %Iu

### DIFF
--- a/src/platform/inttypes.h
+++ b/src/platform/inttypes.h
@@ -2,6 +2,9 @@
 #include <msinttypes/inttypes.h>
 /* Print size_t values. */
 #define MVM_PRSz "Iu"
+#elif defined(_WIN32) && !defined(_MSC_VER)
+#include <inttypes.h>
+#define MVM_PRSz "Iu"
 #else
 #include <inttypes.h>
 #define MVM_PRSz "zu" /* C99 */


### PR DESCRIPTION
Don't use the %zu format string because it's not handled, so a literal
"zu" is printed.

See issue #769.