### PR TITLE
Use FSA for string storage

### DIFF
--- a/src/6model/6model.h
+++ b/src/6model/6model.h
@@ -150,6 +150,9 @@ typedef enum {
     /* Has this item been chained into a gen2 freelist? This is only used in
      * GC debug more. */
     MVM_CF_DEBUG_IN_GEN2_FREE_LIST = 4096,
+
+    /* A flag for behavior specific to a REPR. */
+    MVM_CF_REPR_DEFINED = 8192,
 } MVMCollectableFlags;
 
 #ifdef MVM_USE_OVERFLOW_SERIALIZATION_INDEX

--- a/src/6model/reprs/MVMString.c
+++ b/src/6model/reprs/MVMString.c
@@ -1,4 +1,5 @@
 #include "moar.h"
+#define MVM_STRING_USES_FSA MVM_CF_REPR_DEFINED
 
 /* This representation's function pointer table. */
 static const MVMREPROps MVMString_this_repr;
@@ -28,7 +29,8 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
     switch (dest_body->storage_type) {
         case MVM_STRING_GRAPHEME_32:
             if (dest_body->num_graphs) {
-                dest_body->storage.blob_32 = MVM_malloc(dest_body->num_graphs * sizeof(MVMGrapheme32));
+                dest_body->storage.blob_32 = MVM_fixed_size_alloc(tc, tc->instance->fsa, dest_body->num_graphs * sizeof(MVMGrapheme32));
+                dest_root->header.flags |= MVM_STRING_USES_FSA;
                 memcpy(dest_body->storage.blob_32, src_body->storage.blob_32,
                     dest_body->num_graphs * sizeof(MVMGrapheme32));
             }
@@ -36,13 +38,15 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
         case MVM_STRING_GRAPHEME_ASCII:
         case MVM_STRING_GRAPHEME_8:
             if (dest_body->num_graphs) {
-                dest_body->storage.blob_8 = MVM_malloc(dest_body->num_graphs);
+                dest_body->storage.blob_8 = MVM_fixed_size_alloc(tc, tc->instance->fsa, dest_body->num_graphs);
+                dest_root->header.flags |= MVM_STRING_USES_FSA;
                 memcpy(dest_body->storage.blob_8, src_body->storage.blob_8,
                     dest_body->num_graphs);
             }
             break;
         case MVM_STRING_STRAND:
-            dest_body->storage.strands = MVM_malloc(dest_body->num_strands * sizeof(MVMStringStrand));
+            dest_body->storage.strands = MVM_fixed_size_alloc(tc, tc->instance->fsa, dest_body->num_strands * sizeof(MVMStringStrand));
+            dest_root->header.flags |= MVM_STRING_USES_FSA;
             memcpy(dest_body->storage.strands, src_body->storage.strands,
                 dest_body->num_strands * sizeof(MVMStringStrand));
             break;
@@ -65,7 +69,30 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 /* Called by the VM in order to free memory associated with this object. */
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMString *str = (MVMString *)obj;
-    MVM_free(str->body.storage.any);
+    if (obj->header.flags & MVM_STRING_USES_FSA) {
+        size_t type;
+        switch (str->body.storage_type) {
+            case MVM_STRING_GRAPHEME_8:
+                type = sizeof(MVMGrapheme8);
+                break;
+            case MVM_STRING_GRAPHEME_32:
+                type = sizeof(MVMGrapheme32);
+                break;
+            case MVM_STRING_GRAPHEME_ASCII:
+                type = sizeof(MVMGraphemeASCII);
+                break;
+            case MVM_STRING_STRAND:
+                type = sizeof(MVMStringStrand);
+                break;
+            default:
+                MVM_exception_throw_adhoc(tc, "Unknown string body type\n");
+                break;
+        }
+        MVM_fixed_size_free(tc, tc->instance->fsa, (str->body.storage_type == MVM_STRING_STRAND ? str->body.num_strands : str->body.num_graphs) * type , str->body.storage.any);
+    }
+    else {
+        MVM_free(str->body.storage.any);
+    }
     str->body.num_graphs = str->body.num_strands = 0;
 }
 


### PR DESCRIPTION
This covers a lot of `MVMString` usage, but not everything. E.g., it might be possible to do the same thing in `src/strings/normalize.c`.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.