### PR TITLE
ucd2c.pl: Fix White_Space/space Unicode Property +many other improvements

### DIFF
--- a/src/strings/unicode_gen.h
+++ b/src/strings/unicode_gen.h
@@ -4,7 +4,7 @@ struct MVMUnicodeNamedValue {
     const char *name;
     MVMint32 value;
 };
-#define num_unicode_property_keypairs 3144
+#define num_unicode_property_keypairs 3548
 
 #define MVM_NUM_UNICODE_EXTENTS 105
 
@@ -163,7 +163,7 @@ typedef struct MVMUnicodeNamedAlias MVMUnicodeNamedAlias;
 #define MVM_UNICODE_PVALUE_Numeric_Type_NONE 0
 #define MVM_UNICODE_PVALUE_Numeric_Type_NUMERIC 1
 
-#define num_unicode_property_value_keypairs 3609
+#define num_unicode_property_value_keypairs 4246
 
 typedef enum {
     MVM_UNICODE_PROPERTY_DECOMP_SPEC = 1,


### PR DESCRIPTION
* Fix Property Name 'space' so it doesn't incorrectly refer to the
  Line_Break=space property and fix White_Space property so it doesn't refer to
  Bidi_Class=White_Space and instead refers to the White_Space property.
   * Fixes "\t" ~~ /<:space>/ which now correctly matches
   * Fixes "1".uniprop('White_Space') so it doesn't return `True`
* Fix property names/values so that more variations of case and underline's
  are used. Before if we had a property name called `Foo_Bar` we would get:
  * FooBar (No underscore)
  * foobar (lowercase and no underscore)
  Now an additional one is added:
  * foo_bar (lowercase but with underscore retained)
* Add all property names first, before adding any property aliases. Also check
  that a property value does not have the same name as a property before
  putting it in the datastructure
* Remove workaround for correcting union property values which is no longer
  needed anymore since commit
* Rename some variables names to be more clear
* Fix sprintf warning by not escaping % signs as %%
* Add many more comments to this sub (emit_unicode_property_keypairs) than before