### PR TITLE
Add more jit templates

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -355,5 +355,13 @@
       (carg $1 ptr)
       (carg $2 ptr)) int_sz))
 
+(template: box_i!
+  (callv (^func &MVM_box_int)
+    (arglist
+      (carg (tc) ptr)
+      (carg $1 int)
+      (carg $2 ptr)
+      (carg $0 ptr))))
+
 (template: isnull
    (or (flagval (zr $1)) (flagval (eq $1 (^vmnull)))))

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -319,5 +319,12 @@
       (carg (tc) ptr)
       (carg $1 ptr)) ptr_sz))
 
+(template: smrt_strify!
+  (callv (^func &MVM_coerce_smart_stringify)
+    (arglist
+      (carg (tc) ptr)
+      (carg $1 ptr)
+      (carg $0 ptr))))
+
 (template: isnull
    (or (flagval (zr $1)) (flagval (eq $1 (^vmnull)))))

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -333,5 +333,20 @@
       (carg $1 ptr)
       (carg $0 ptr))))
 
+(template: push_i!
+  (dov
+    (callv (^getf (^repr $0) MVMREPROps pos_funcs.push)
+      (arglist
+        (carg (tc) ptr)
+        (carg (^stable $0) ptr)
+        (carg $0 ptr)
+        (carg (^body $0) ptr)
+        (carg $1 ptr)
+        (carg (const (&QUOTE MVM_reg_int64) int_sz) int)))
+    (callv (^func &MVM_SC_WB_OBJ)
+      (arglist
+        (carg (tc) ptr)
+        (carg $0 ptr)))))
+
 (template: isnull
    (or (flagval (zr $1)) (flagval (eq $1 (^vmnull)))))

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -363,5 +363,12 @@
       (carg $2 ptr)
       (carg $0 ptr))))
 
+(template: getdynlex
+  (call (^func &MVM_frame_getdynlex)
+    (arglist
+      (carg (tc) ptr)
+      (carg $1 ptr)
+      (carg (^caller) ptr)) ptr_sz))
+
 (template: isnull
    (or (flagval (zr $1)) (flagval (eq $1 (^vmnull)))))

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -313,5 +313,11 @@
               (arglist (carg (tc) ptr) (carg $1 ptr) (carg $0 ptr)))
        (store $0 $1 ptr_sz)))
 
+(template: sp_resolvecode
+  (call (^func &MVM_frame_resolve_invokee_spesh)
+    (arglist
+      (carg (tc) ptr)
+      (carg $1 ptr)) ptr_sz))
+
 (template: isnull
    (or (flagval (zr $1)) (flagval (eq $1 (^vmnull)))))

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -348,5 +348,12 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
+(template: eq_s
+  (call (^func &MVM_string_equal)
+    (arglist
+      (carg (tc) ptr)
+      (carg $1 ptr)
+      (carg $2 ptr)) int_sz))
+
 (template: isnull
    (or (flagval (zr $1)) (flagval (eq $1 (^vmnull)))))

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -326,5 +326,12 @@
       (carg $1 ptr)
       (carg $0 ptr))))
 
+(template: smrt_numify!
+  (callv (^func &MVM_coerce_smart_numify)
+    (arglist
+      (carg (tc) ptr)
+      (carg $1 ptr)
+      (carg $0 ptr))))
+
 (template: isnull
    (or (flagval (zr $1)) (flagval (eq $1 (^vmnull)))))

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -11,7 +11,7 @@
 (macro: ^parg (,a) (idx (^getf (^frame) MVMFrame params.args) ,a reg_sz))
 
 (macro: ^params () (addr (^frame) (&offsetof MVMFrame params)))
-(macro: ^caller () (addr (^frame) (&offsetof MVMFrame caller)))
+(macro: ^caller () (^getf (^frame) MVMFrame caller))
 
 # get spesh slot address
 (macro: ^spesh_slot (,a)


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

`box_i` caused the Rakudo build to break when I first added it, but after rebasing against master it's now fine. I didn't try to bisect, but I guess @niner's JIT related commits fixed it. @bdw any thoughts?

`getdynlex` caused a segv when building NQP, but @timo++ gave me a fix for the `^caller` macro and now everything works just fine.