### PR TITLE
Add windows-1251 (Cyrillic) decode/encode. Fix bug in windows-1252

### DIFF
--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -123,6 +123,9 @@ static MVMuint32 run_decode(MVMThreadContext *tc, MVMDecodeStream *ds, const MVM
     case MVM_encoding_type_windows1252:
         reached_stopper = MVM_string_windows1252_decodestream(tc, ds, stopper_chars, sep_spec);
         break;
+    case MVM_encoding_type_windows1251:
+        reached_stopper = MVM_string_windows1251_decodestream(tc, ds, stopper_chars, sep_spec);
+        break;
     case MVM_encoding_type_utf8_c8:
         reached_stopper = MVM_string_utf8_c8_decodestream(tc, ds, stopper_chars, sep_spec, eof);
         break;

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1531,6 +1531,8 @@ MVMString * MVM_string_decode(MVMThreadContext *tc,
             return MVM_string_utf16_decode(tc, type_object, Cbuf, byte_length);
         case MVM_encoding_type_windows1252:
             return MVM_string_windows1252_decode(tc, type_object, Cbuf, byte_length);
+        case MVM_encoding_type_windows1251:
+            return MVM_string_windows1251_decode(tc, type_object, Cbuf, byte_length);
         case MVM_encoding_type_utf8_c8:
             return MVM_string_utf8_c8_decode(tc, type_object, Cbuf, byte_length);
         default:
@@ -1553,6 +1555,8 @@ char * MVM_string_encode(MVMThreadContext *tc, MVMString *s, MVMint64 start,
             return MVM_string_utf16_encode_substr(tc, s, output_size, start, length, replacement, translate_newlines);
         case MVM_encoding_type_windows1252:
             return MVM_string_windows1252_encode_substr(tc, s, output_size, start, length, replacement, translate_newlines);
+        case MVM_encoding_type_windows1251:
+            return MVM_string_windows1251_encode_substr(tc, s, output_size, start, length, replacement, translate_newlines);
         case MVM_encoding_type_utf8_c8:
             return MVM_string_utf8_c8_encode_substr(tc, s, output_size, start, length, replacement);
         default:
@@ -2525,6 +2529,7 @@ static MVMString *encoding_ascii_name        = NULL;
 static MVMString *encoding_latin1_name       = NULL;
 static MVMString *encoding_utf16_name        = NULL;
 static MVMString *encoding_windows1252_name  = NULL;
+static MVMString *encoding_windows1251_name  = NULL;
 static MVMString *encoding_utf8_c8_name      = NULL;
 MVMuint8 MVM_string_find_encoding(MVMThreadContext *tc, MVMString *name) {
     MVM_string_check_arg(tc, name, "find encoding");
@@ -2540,6 +2545,8 @@ MVMuint8 MVM_string_find_encoding(MVMThreadContext *tc, MVMString *name) {
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&encoding_utf16_name, "Encoding name");
         encoding_windows1252_name = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "windows-1252");
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&encoding_windows1252_name, "Encoding name");
+        encoding_windows1251_name = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "windows-1251");
+        MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&encoding_windows1251_name, "Encoding name");
         encoding_utf8_c8_name     = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "utf8-c8");
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&encoding_utf8_c8_name, "Encoding name");
         encoding_name_init   = 1;
@@ -2557,6 +2564,9 @@ MVMuint8 MVM_string_find_encoding(MVMThreadContext *tc, MVMString *name) {
     }
     else if (MVM_string_equal(tc, name, encoding_windows1252_name)) {
         return MVM_encoding_type_windows1252;
+    }
+    else if (MVM_string_equal(tc, name, encoding_windows1251_name)) {
+        return MVM_encoding_type_windows1251;
     }
     else if (MVM_string_equal(tc, name, encoding_utf16_name)) {
         return MVM_encoding_type_utf16;

--- a/src/strings/ops.h
+++ b/src/strings/ops.h
@@ -6,7 +6,8 @@
 #define MVM_encoding_type_utf16         4
 #define MVM_encoding_type_windows1252   5
 #define MVM_encoding_type_utf8_c8       6
-#define MVM_encoding_type_MAX           6
+#define MVM_encoding_type_windows1251   7
+#define MVM_encoding_type_MAX           7
 #define ENCODING_VALID(enc) \
     (((enc) >= MVM_encoding_type_MIN && (enc) <= MVM_encoding_type_MAX) \
     || (MVM_exception_throw_adhoc(tc, "invalid encoding type flag: %d", (enc)),1))

--- a/src/strings/windows1252.h
+++ b/src/strings/windows1252.h
@@ -1,3 +1,6 @@
 MVMString * MVM_string_windows1252_decode(MVMThreadContext *tc, const MVMObject *result_type, char *windows1252, size_t bytes);
 MVM_PUBLIC MVMuint32 MVM_string_windows1252_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds, const MVMint32 *stopper_chars, MVMDecodeStreamSeparators *seps);
 char * MVM_string_windows1252_encode_substr(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length, MVMString *replacement, MVMint32 translate_newlines);
+MVMString * MVM_string_windows1251_decode(MVMThreadContext *tc, const MVMObject *result_type, char *windows1252, size_t bytes);
+MVM_PUBLIC MVMuint32 MVM_string_windows1251_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds, const MVMint32 *stopper_chars, MVMDecodeStreamSeparators *seps);
+char * MVM_string_windows1251_encode_substr(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length, MVMString *replacement, MVMint32 translate_newlines);

--- a/tools/generate_encoding_codetables.p6
+++ b/tools/generate_encoding_codetables.p6
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 # This code generates encoding tables for single byte encodings.
 # Currently Windows-1252 and Windows-1251
-sub make-windows-codepoints-table (Str:D $filename, Str:D $encoding, Str:D $comment) {
+sub process-file (Str:D $filename, Str:D $encoding) {
     my %to-hex1252;
     for $filename.IO.slurp.lines -> $line {
         next if $line.starts-with: '#';
@@ -17,6 +17,26 @@ sub make-windows-codepoints-table (Str:D $filename, Str:D $encoding, Str:D $comm
         $cp1252_hex ~~ s/^0x//;
         %to-hex1252{$cp1252_hex.parse-base(16)} = $Unicode_hex.parse-base(16);
     }
+    die unless elems %to-hex1252 == 256;
+    %to-hex1252;
+}
+sub MAIN {
+    my $DIR = "UNIDATA/CODETABLES";
+    my @info = %(encoding => 'windows1252', filename => "$DIR/CP1252.TXT", comment => "/* Windows-1252 Latin */"),
+        %( encoding => 'windows1251', filename => "$DIR/CP1251.TXT", comment => "/* Windows-1251 Cyrillic */");
+    my %win1252 = process-file(@info[0]<filename>, @info[0]<encoding>);
+    my %win1251 = process-file(@info[1]<filename>, @info[1]<encoding>);
+    for @info -> $inf {
+        say "#define {$inf<encoding>.uc}_CHAR_TO_CP(character) {$inf<encoding>}_codepoints[character];";
+    }
+    say "";
+
+    say create-windows1252_codepoints(%win1252, @info[0]<encoding>, @info[0]<comment>);
+    say create-windows1252_codepoints(%win1251, @info[1]<encoding>, @info[1]<comment>);
+    say create-windows1252_cp_to_char(%win1252, @info[0]<encoding>);
+    say create-windows1252_cp_to_char(%win1251, @info[1]<encoding>);
+}
+sub create-windows1252_codepoints (%to-hex1252, $encoding, $comment) {
     sub make_line (@lines, @out) {
         if @lines {
             my Str:D $out = join(",", @lines);
@@ -33,9 +53,26 @@ sub make-windows-codepoints-table (Str:D $filename, Str:D $encoding, Str:D $comm
     }
     make_line @lines, @out;
     my $out_str = "$comment\n" ~ "static const MVMuint16 {$encoding}_codepoints[] = \{\n" ~ @out.join(",\n").indent(4) ~ "\n\};";
-    say $out_str;
-    die unless elems %to-hex1252 == 256;
+    $out_str;
+
 }
-my $DIR = "UNIDATA/CODETABLES";
-make-windows-codepoints-table("$DIR/CP1252.TXT", "windows1252", "/* Windows-1252 Latin */");
-make-windows-codepoints-table("$DIR/CP1251.TXT", "windows1251", "/* Windows-1251 Cyrillic */");
+sub create-windows1252_cp_to_char (%to-hex1252, $encoding) {
+    my $max = %to-hex1252.values.max;
+    my $out_str2 = "static MVMuint8 {$encoding}_cp_to_char(MVMint32 codepoint) \{\n";
+    my $out_str3 = qq:to/END/;
+    if ($max < codepoint || codepoint < 0)
+        return '\\0';
+    switch (codepoint) \{
+    END
+    my @cases;
+    for %to-hex1252.keys.sort({%to-hex1252{$^a} <=> %to-hex1252{$^b}}) -> $win_cp {
+        @cases.push: make-case %to-hex1252{$win_cp}, $win_cp;
+    }
+    @cases.push: ‘default: return '\0';’;
+    my $indent = ' ' x 4;
+    $out_str2 ~= ($out_str3 ~ $indent ~ @cases.join("\n$indent") ~ "\n\};").indent(4) ~ "\n\}";
+    $out_str2;
+}
+sub make-case (Cool:D $from, Cool:D $to) {
+    "case $from: return $to;"
+}


### PR DESCRIPTION
We now have support for windows-1251 decoding and encoding.

This also fixes a bug with windows-1252 (Latin) which would cause
certain codepoints not to convert properly, for example the ™ mark and
likely at least one other.