### PR TITLE
Fix alignment of sizes for gc allocated objects.

### DIFF
--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -874,6 +874,7 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
 
     /* Add allocated amount for body to have total object size. */
     st->size = sizeof(MVMP6opaque) + (cur_alloc_addr - sizeof(MVMP6opaqueBody));
+    ASSERT_ALIGNED(st->size, ALIGNOF(void *));
 
     /* Add sentinels/counts. */
     repr_data->gc_obj_mark_offsets_count = cur_obj_attr;
@@ -915,6 +916,7 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
     }
 
     st->size = cur_offset;
+    ASSERT_ALIGNED(st->size, ALIGNOF(void *));
 }
 
 /* Serializes the REPR data. */

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -24,7 +24,6 @@ MVM_STATIC_INLINE void set_obj_at_offset(MVMThreadContext *tc, MVMObject *root, 
 /* Helper for aligning sizes */
 MVM_STATIC_INLINE void align_to(MVMuint64 *size, MVMuint32 align) {
     if (*size % align) {
-        printf("Aligning something to %u\n", align);
         *size += align - *size % align;
     }
 }

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -872,7 +872,6 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
              * become unaligned.
              */
             cur_alloc_addr += bits / 8;
-            align_to(&cur_alloc_addr, ALIGNOF(void *));
 
             /* Increment slot count. */
             cur_slot++;

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -924,6 +924,7 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
         }
     }
 
+    align_to(&cur_offset, ALIGNOF(void *));
     st->size = cur_offset;
     ASSERT_ALIGNED(st->size, ALIGNOF(void *));
 }

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -885,7 +885,7 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
 
     /* Add allocated amount for body to have total object size. */
     st->size = sizeof(MVMP6opaque) + (cur_alloc_addr - sizeof(MVMP6opaqueBody));
-    ASSERT_ALIGNED(st->size, ALIGNOF(void *));
+    MVM_ASSERT_ALIGNED(st->size, ALIGNOF(void *));
 
     /* Add sentinels/counts. */
     repr_data->gc_obj_mark_offsets_count = cur_obj_attr;
@@ -926,7 +926,7 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
 
     align_to(&cur_offset, ALIGNOF(void *));
     st->size = cur_offset;
-    ASSERT_ALIGNED(st->size, ALIGNOF(void *));
+    MVM_ASSERT_ALIGNED(st->size, ALIGNOF(void *));
 }
 
 /* Serializes the REPR data. */

--- a/src/6model/reprs/ReentrantMutex.c
+++ b/src/6model/reprs/ReentrantMutex.c
@@ -125,6 +125,9 @@ void MVM_reentrantmutex_lock_checked(MVMThreadContext *tc, MVMObject *lock) {
 }
 void MVM_reentrantmutex_lock(MVMThreadContext *tc, MVMReentrantMutex *rm) {
     unsigned int interval_id;
+    /* Atomic access must be aligned, otherwise the lock will not work. */
+    ASSERT_ALIGNED(&rm->body.holder_id, ALIGNOF(AO_t));
+    ASSERT_ALIGNED(&rm->body.lock_count, ALIGNOF(AO_t));
     if (MVM_load(&rm->body.holder_id) == tc->thread_id) {
         /* We already hold the lock; bump the count. */
         MVM_incr(&rm->body.lock_count);

--- a/src/6model/reprs/ReentrantMutex.c
+++ b/src/6model/reprs/ReentrantMutex.c
@@ -126,8 +126,8 @@ void MVM_reentrantmutex_lock_checked(MVMThreadContext *tc, MVMObject *lock) {
 void MVM_reentrantmutex_lock(MVMThreadContext *tc, MVMReentrantMutex *rm) {
     unsigned int interval_id;
     /* Atomic access must be aligned, otherwise the lock will not work. */
-    ASSERT_ALIGNED(&rm->body.holder_id, ALIGNOF(AO_t));
-    ASSERT_ALIGNED(&rm->body.lock_count, ALIGNOF(AO_t));
+    MVM_ASSERT_ALIGNED(&rm->body.holder_id, ALIGNOF(AO_t));
+    MVM_ASSERT_ALIGNED(&rm->body.lock_count, ALIGNOF(AO_t));
     if (MVM_load(&rm->body.holder_id) == tc->thread_id) {
         /* We already hold the lock; bump the count. */
         MVM_incr(&rm->body.lock_count);

--- a/src/moar.h
+++ b/src/moar.h
@@ -63,6 +63,8 @@ typedef double   MVMnum64;
 #define ALIGNOF(t) ((char *)(&((struct { char c; t _h; } *)0)->_h) - (char *)0)
 #endif
 
+#define ASSERT_ALIGNED(var, align) assert(!((MVMuint64)(var) % (MVMuint64)(align)))
+
 #define MVM_ALIGN_SECTION_MASK ((MVMuint32)ALIGNOF(MVMint64) - 1)
 #define MVM_ALIGN_SECTION(offset) (((offset) + (MVM_ALIGN_SECTION_MASK)) & ~(MVM_ALIGN_SECTION_MASK))
 

--- a/src/moar.h
+++ b/src/moar.h
@@ -63,7 +63,7 @@ typedef double   MVMnum64;
 #define ALIGNOF(t) ((char *)(&((struct { char c; t _h; } *)0)->_h) - (char *)0)
 #endif
 
-#define ASSERT_ALIGNED(var, align) assert(!((MVMuint64)(var) % (MVMuint64)(align)))
+#define MVM_ASSERT_ALIGNED(var, align) assert(!((MVMuint64)(var) % (MVMuint64)(align)))
 
 #define MVM_ALIGN_SECTION_MASK ((MVMuint32)ALIGNOF(MVMint64) - 1)
 #define MVM_ALIGN_SECTION(offset) (((offset) + (MVM_ALIGN_SECTION_MASK)) & ~(MVM_ALIGN_SECTION_MASK))


### PR DESCRIPTION
Hi! 

So I discovered that there are some alignment problems sometimes in moarvm. I found this using the OpenBSD of rakudo, because the atomic_ops library has alignment assertions enabled by default. The noticed the bug the first time when I ran `zef install OpenSSL`. The output I get from a triggering program is this:
```
$ perl6 -I . -e "use CrashTest;"                         
assertion "((size_t)addr & (sizeof(*addr) - 1)) == 0" failed: file "/usr/local/include/atomic_ops/sysdeps/gcc/../loadstore/atomic_load.h", line 31, function "AO_load"
assertion "((size_t)addr & (sizeof(*addr) - 1)) == 0" failed: file "/usr/local/include/atomic_ops/sysdeps/gcc/../loadstore/atomic_load.h", line 31, function "AO_load"
Abort trap (core dumped)
```

I started investigating this issue in the garbage collector, but @jnthn suggested on IRC that it would be better to fix the issue when the types are created.

Anyhow, I have started with adding assertions all over the place, and I will check if the CI will give same results as I get on my system. After this I will commit a fix.