### PR TITLE
Rakudo RT#102994: Add flag indicating HLL init status on StaticFrame

### DIFF
--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -83,6 +83,8 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
         memcpy(dest_body->static_env, src_body->static_env, src_body->env_size);
         dest_body->static_env_flags = MVM_malloc(src_body->num_lexicals);
         memcpy(dest_body->static_env_flags, src_body->static_env_flags, src_body->num_lexicals);
+        dest_body->static_env_is_hll_init = MVM_malloc(src_body->num_lexicals);
+        memcpy(dest_body->static_env_is_hll_init, src_body->static_env_is_hll_init, src_body->num_lexicals);
 
         for (i = 0; i < count; i++) {
             if (type_map[i] == MVM_reg_str) {
@@ -163,6 +165,7 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVM_free(body->handlers);
     MVM_free(body->work_initial);
     MVM_free(body->static_env);
+    MVM_free(body->static_env_is_hll_init);
     MVM_free(body->static_env_flags);
     MVM_free(body->local_types);
     MVM_free(body->lexical_types);
@@ -214,8 +217,8 @@ static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data)
         /*
         size += sizeof(MVMuint8) * body->num_annotations
         */
-        size += body->env_size; /* static_env */
-        size += body->num_lexicals; /* static_env_flags */
+        size += body->env_size;         /* static_env */
+        size += body->num_lexicals * 2; /* static_env_flags and static_env_is_hll_init */
 
         if (body->instrumentation) {
             size += body->instrumentation->uninstrumented_bytecode_size;

--- a/src/6model/reprs/MVMStaticFrame.h
+++ b/src/6model/reprs/MVMStaticFrame.h
@@ -23,6 +23,9 @@ struct MVMStaticFrameBody {
     /* Flags for static environment (0 = static, 1 = clone, 2 = state). */
     MVMuint8 *static_env_flags;
 
+    /* Has the given lexical been assigned a value in the HLL? */
+    MVMuint8 *static_env_is_hll_init;
+
     /* If the frame has state variables. */
     MVMuint32 has_state_vars;
 

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -659,9 +659,10 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
     }
 
     /* Allocate default lexical environment storage. */
-    sf->body.env_size         = sf->body.num_lexicals * sizeof(MVMRegister);
-    sf->body.static_env       = MVM_calloc(1, sf->body.env_size);
-    sf->body.static_env_flags = MVM_calloc(1, sf->body.num_lexicals);
+    sf->body.env_size               = sf->body.num_lexicals * sizeof(MVMRegister);
+    sf->body.static_env             = MVM_calloc(1, sf->body.env_size);
+    sf->body.static_env_flags       = MVM_calloc(1, sf->body.num_lexicals);
+    sf->body.static_env_is_hll_init = MVM_calloc(1, sf->body.num_lexicals);
 
     /* Stash static lexical segment offset, so we can easily locate it to
      * resolve them later. */


### PR DESCRIPTION
Add a value that indicates whether the lexical in the static frame has
been assigned a value by the HLL (flag set via extop on HLL side).

This change is being made to coincide with a Rakudo development
regarding statevar initialization.

See [RT#102994](https://rt.perl.org/Public/Bug/Display.html?id=102994)