### PR TITLE
Rakudo RT#102994: Add flag indicating HLL init status on CodeRef (CodeRef edition)

### DIFF
--- a/src/6model/reprs/MVMCode.c
+++ b/src/6model/reprs/MVMCode.c
@@ -69,6 +69,7 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMCode *code_obj = (MVMCode *)obj;
     MVM_free(code_obj->body.state_vars);
+    MVM_free(code_obj->body.state_vars_is_hll_init);
 }
 
 static const MVMStorageSpec storage_spec = {

--- a/src/6model/reprs/MVMCode.h
+++ b/src/6model/reprs/MVMCode.h
@@ -6,6 +6,7 @@ struct MVMCodeBody {
     MVMObject      *code_object;
     MVMString      *name;
     MVMRegister    *state_vars;
+    MVMuint8       *state_vars_is_hll_init;
     MVMuint16       is_static;
     MVMuint16       is_compiler_stub;
 };

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -572,7 +572,7 @@ void MVM_frame_invoke(MVMThreadContext *tc, MVMStaticFrame *static_frame,
         MVMRegister *state     = NULL;
         MVMint64     state_act = 0; /* 0 = none so far, 1 = first time, 2 = later */
         MVMint64 i;
-        MVMROOT(tc, frame, {
+        MVMROOT2(tc, frame, cref, {
             for (i = 0; i < numlex; i++) {
                 if (flags[i] == 2) {
                     redo_state:


### PR DESCRIPTION
Add a value that indicates whether the statevar in the coderef has been
assigned a value by the HLL (flag set via extop on HLL side).

This change is being made to coincide with a Rakudo development
regarding statevar initialization.

See [RT#102994](https://rt.perl.org/Public/Bug/Display.html?id=102994)