### PR TITLE
Add proper support for replacements in decodestream for windows1252/1

### DIFF
--- a/src/6model/bootstrap.c
+++ b/src/6model/bootstrap.c
@@ -581,6 +581,8 @@ static void string_consts(MVMThreadContext *tc) {
     string_creator(translate_newlines, "translate_newlines");
     string_creator(platform_newline, MVM_TRANSLATE_NEWLINE_OUTPUT ? "\r\n" : "\n");
     string_creator(path, "path");
+    string_creator(config, "config");
+    string_creator(replacement, "replacement");
 }
 
 /* Drives the overall bootstrap process. */

--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -125,11 +125,9 @@ static int should_translate_newlines(MVMThreadContext *tc, MVMObject *config) {
     return 0;
 }
 static MVMString * has_replacement(MVMThreadContext *tc, MVMObject *config) {
-    char *replacement_const = "replacement";
-    int replacement_const_length = strlen(replacement_const);
     if (IS_CONCRETE(config) && REPR(config)->ID == MVM_REPR_ID_MVMHash) {
         MVMObject *value = MVM_repr_at_key_o(tc, config,
-            MVM_string_ascii_decode(tc, tc->instance->VMString, replacement_const, replacement_const_length));
+            tc->instance->str_consts.replacement);
         return IS_CONCRETE(value)
             ? MVM_repr_get_str(tc, value)
             : NULL;
@@ -137,11 +135,9 @@ static MVMString * has_replacement(MVMThreadContext *tc, MVMObject *config) {
     return NULL;
 }
 static int has_config(MVMThreadContext *tc, MVMObject *config) {
-    char * config_const = "config";
-    int config_const_length = strlen(config_const);
     if (IS_CONCRETE(config) && REPR(config)->ID == MVM_REPR_ID_MVMHash) {
         MVMObject *value = MVM_repr_at_key_o(tc, config,
-            MVM_string_ascii_decode(tc, tc->instance->VMString, config_const, config_const_length));
+            tc->instance->str_consts.config);
         return IS_CONCRETE(value) ? MVM_repr_get_int(tc, value) : 0;
     }
     return 0;

--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -24,6 +24,10 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
 
 /* Called by the VM to mark any GCable items. */
 static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorklist *worklist) {
+    MVMDecoderBody *decoder = (MVMDecoderBody*)data;
+    if (decoder->ds) {
+        MVM_gc_worklist_add(tc, worklist, &(decoder->ds->replacement));
+    }
 }
 
 /* Called by the VM in order to free memory associated with this object. */
@@ -152,7 +156,8 @@ void MVM_decoder_configure(MVMThreadContext *tc, MVMDecoder *decoder,
             should_translate_newlines(tc, config));
         decoder->body.sep_spec = MVM_malloc(sizeof(MVMDecodeStreamSeparators));
         MVM_string_decode_stream_sep_default(tc, decoder->body.sep_spec);
-        decoder->body.ds->replacement = has_replacement(tc, config);
+        MVM_ASSIGN_REF(tc, &(decoder->common.header), decoder->body.ds->replacement,
+            has_replacement(tc, config));
         decoder->body.ds->config      = has_config(tc, config);
         exit_single_user(tc, decoder);
     }

--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -124,6 +124,29 @@ static int should_translate_newlines(MVMThreadContext *tc, MVMObject *config) {
     }
     return 0;
 }
+static MVMString * has_replacement(MVMThreadContext *tc, MVMObject *config) {
+    char *replacement_const = "replacement";
+    int replacement_const_length = strlen(replacement_const);
+    if (IS_CONCRETE(config) && REPR(config)->ID == MVM_REPR_ID_MVMHash) {
+        MVMObject *value = MVM_repr_at_key_o(tc, config,
+            MVM_string_ascii_decode(tc, tc->instance->VMString, replacement_const, replacement_const_length));
+        return IS_CONCRETE(value)
+            ? MVM_repr_get_str(tc, value)
+            : NULL;
+    }
+    return NULL;
+}
+static int has_config(MVMThreadContext *tc, MVMObject *config) {
+    char * config_const = "config";
+    int config_const_length = strlen(config_const);
+    if (IS_CONCRETE(config) && REPR(config)->ID == MVM_REPR_ID_MVMHash) {
+        MVMObject *value = MVM_repr_at_key_o(tc, config,
+            MVM_string_ascii_decode(tc, tc->instance->VMString, config_const, config_const_length));
+        return IS_CONCRETE(value) ? MVM_repr_get_int(tc, value) : 0;
+    }
+    return 0;
+
+}
 void MVM_decoder_configure(MVMThreadContext *tc, MVMDecoder *decoder,
                            MVMString *encoding, MVMObject *config) {
     if (!decoder->body.ds) {
@@ -133,6 +156,8 @@ void MVM_decoder_configure(MVMThreadContext *tc, MVMDecoder *decoder,
             should_translate_newlines(tc, config));
         decoder->body.sep_spec = MVM_malloc(sizeof(MVMDecodeStreamSeparators));
         MVM_string_decode_stream_sep_default(tc, decoder->body.sep_spec);
+        decoder->body.ds->replacement = has_replacement(tc, config);
+        decoder->body.ds->config      = has_config(tc, config);
         exit_single_user(tc, decoder);
     }
     else {

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -84,6 +84,8 @@ struct MVMStringConsts {
     MVMString *translate_newlines;
     MVMString *platform_newline;
     MVMString *path;
+    MVMString *config;
+    MVMString *replacement;
 };
 
 /* An entry in the representations registry. */

--- a/src/strings/decode_stream.h
+++ b/src/strings/decode_stream.h
@@ -38,7 +38,12 @@ struct MVMDecodeStream {
      * decode calls. Will be freed when the decode stream is destroyed. */
     void *decoder_state;
 
+    /* Stores a replacement which is used upon encountering undecodable characters.
+     * Set to NULL if a replacement is not desired. */
     MVMString *replacement;
+
+    /* Currently stores only whether or not the decoder should decode strictly or
+     * permissively. Set to 1 for permissive decoding, default is strict */
     MVMuint32 config;
 };
 

--- a/src/strings/decode_stream.h
+++ b/src/strings/decode_stream.h
@@ -37,6 +37,9 @@ struct MVMDecodeStream {
     /* Optional place for the decoder to keep any extra state it needs between
      * decode calls. Will be freed when the decode stream is destroyed. */
     void *decoder_state;
+
+    MVMString *replacement;
+    MVMuint32 config;
 };
 
 /* A single bunch of bytes added to a decode stream, with a link to the next

--- a/src/strings/windows1252.c
+++ b/src/strings/windows1252.c
@@ -340,9 +340,8 @@ static MVMuint8 windows1251_cp_to_char(MVMint32 codepoint) {
  * buffers, or until a stopper is reached. */
 MVMuint32 MVM_string_windows125X_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds,
                                          const MVMint32 *stopper_chars,
-                                         MVMDecodeStreamSeparators *seps, MVMString *replacement,
-                                         const MVMuint16 *codetable,
-                                         MVMint64 config) {
+                                         MVMDecodeStreamSeparators *seps,
+                                         const MVMuint16 *codetable) {
     MVMint32 count = 0, total = 0;
     MVMint32 bufsize;
     MVMGrapheme32 *buffer = NULL;
@@ -465,28 +464,14 @@ MVMuint32 MVM_string_windows125X_decodestream(MVMThreadContext *tc, MVMDecodeStr
 MVMuint32 MVM_string_windows1252_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds,
                                          const MVMint32 *stopper_chars,
                                          MVMDecodeStreamSeparators *seps) {
-    return MVM_string_windows125X_decodestream(tc, ds, stopper_chars, seps, NULL, windows1252_codepoints, MVM_ENCODING_PERMISSIVE);
+    return MVM_string_windows125X_decodestream(tc, ds, stopper_chars, seps, windows1252_codepoints);
 }
 /* Decodes using a decodestream. Decodes as far as it can with the input
  * buffers, or until a stopper is reached. */
 MVMuint32 MVM_string_windows1251_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds,
                                          const MVMint32 *stopper_chars,
                                          MVMDecodeStreamSeparators *seps) {
-    return MVM_string_windows125X_decodestream(tc, ds, stopper_chars, seps, NULL, windows1251_codepoints, MVM_ENCODING_PERMISSIVE);
-}
-/* Decodes using a decodestream. Decodes as far as it can with the input
- * buffers, or until a stopper is reached. */
-MVMuint32 MVM_string_windows1252_decodestream_config(MVMThreadContext *tc, MVMDecodeStream *ds,
-                                         const MVMint32 *stopper_chars,
-                                         MVMDecodeStreamSeparators *seps, MVMString *replacement, MVMint64 config) {
-    return MVM_string_windows125X_decodestream(tc, ds, stopper_chars, seps, replacement, windows1252_codepoints, config);
-}
-/* Decodes using a decodestream. Decodes as far as it can with the input
- * buffers, or until a stopper is reached. */
-MVMuint32 MVM_string_windows1251_decodestream_config(MVMThreadContext *tc, MVMDecodeStream *ds,
-                                         const MVMint32 *stopper_chars,
-                                         MVMDecodeStreamSeparators *seps, MVMString *replacement, MVMint64 config) {
-    return MVM_string_windows125X_decodestream(tc, ds, stopper_chars, seps, replacement, windows1251_codepoints, config);
+    return MVM_string_windows125X_decodestream(tc, ds, stopper_chars, seps, windows1251_codepoints);
 }
 
 /* Decodes the specified number of bytes of windows1252 into an NFG string,


### PR DESCRIPTION
We add the setting for strict/permissive and the replacement string to the
MVMDecodeStream object. Fixes bugs in the previous version which caused it
not to properly throw if strict was set and there was no replacement. Also
adds support for multiple character replacements.

Change arguments for windows1252/1 decodestream ops

We no longer need replacement and config to be arguments since they are
included in the MVMDecodeStream struct. Remove the variations which contain
this as the argument completely.