### PR TITLE
Allow NativeCall support for wchar_t

### DIFF
--- a/src/6model/reprs/P6int.c
+++ b/src/6model/reprs/P6int.c
@@ -145,6 +145,7 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
                 case MVM_P6INT_C_TYPE_BOOL:     repr_data->bits = 8 * sizeof(char);      break;
 #endif
                 case MVM_P6INT_C_TYPE_ATOMIC:   repr_data->bits = 8 * sizeof(AO_t);      break;
+                case MVM_P6INT_C_TYPE_WCHAR_T:  repr_data->bits = 8 * sizeof(wchar_t);   break;
             }
 
             if (repr_data->bits !=  1 && repr_data->bits !=  2 && repr_data->bits !=  4 && repr_data->bits != 8

--- a/src/6model/reprs/P6int.h
+++ b/src/6model/reprs/P6int.h
@@ -6,6 +6,7 @@
 #define MVM_P6INT_C_TYPE_SIZE_T    -6
 #define MVM_P6INT_C_TYPE_BOOL      -7
 #define MVM_P6INT_C_TYPE_ATOMIC    -8
+#define MVM_P6INT_C_TYPE_WCHAR_T   -9
 
 /* Representation used by P6 native ints. */
 struct MVMP6intBody {


### PR DESCRIPTION
A library I'm writing bindings for uses `wchar_t` in some places, so I thought it'd be useful to be able to use it as a type. NQP and Rakudo pullreqs will come later