### PR TITLE
Speed up collapse_strands 4x by full rewrite targeting SIMD optims

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -142,6 +142,7 @@ $config{dllimport}                = '' unless defined $config{dllimport};
 $config{dllexport}                = '' unless defined $config{dllexport};
 $config{dlllocal}                 = '' unless defined $config{dlllocal};
 $config{translate_newline_output} = 0  unless defined $config{translate_newline_output};
+$config{vectorizerspecifier}      = '' unless defined $config{vectorizerspecifier};
 
 # assume the compiler can be used as linker frontend
 $config{ld}           = $config{cc} unless defined $config{ld};

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -60,3 +60,5 @@
 
 #define MVM_JIT_ARCH @jit_arch@
 #define MVM_JIT_PLATFORM @jit_platform@
+
+#define MVM_VECTORIZE_LOOP @vectorizerspecifier@

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -60,4 +60,3 @@
 
 #define MVM_JIT_ARCH @jit_arch@
 #define MVM_JIT_PLATFORM @jit_platform@
-

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -310,6 +310,7 @@ our %COMPILERS = (
         noreturnspecifier => '',
         noreturnattribute => '__attribute__((noreturn))',
         formatattribute   => '__attribute__((format(X, Y, Z)))',
+        vectorizerspecifier => '_Pragma ("clang loop vectorize(enable)")'
     },
 
     cl => {

--- a/src/strings/iter.h
+++ b/src/strings/iter.h
@@ -53,6 +53,24 @@ MVM_STATIC_INLINE void MVM_string_gi_init(MVMThreadContext *tc, MVMGraphemeIter 
     (gi->end - gi->pos + gi->repetitions * (gi->end - gi->start))
 /* graphs left in strand + graphs left in repetitions of current strand */
 
+static void MVM_string_gi_next_strand (MVMThreadContext *tc, MVMGraphemeIter *gi) {
+    MVMStringStrand *next = NULL;
+    if (gi->repetitions) {
+        gi->pos = gi->start;
+        gi->repetitions--;
+        return;
+    }
+    if (gi->strands_remaining <= 0)
+        MVM_exception_throw_adhoc(tc, "Iteration past end of grapheme iterator\n");
+
+    next = (gi->next_strand)++;
+    gi->pos = gi->start = next->start;
+    gi->end             = next->end;
+    gi->repetitions     = next->repetitions;
+    gi->blob_type       = next->blob_string->body.storage_type;
+    gi->active_blob.any = next->blob_string->body.storage.any;
+    gi->strands_remaining--;
+}
 /* Sets the position of the iterator. (Can be optimized in many ways in the
  * repetitions and strands branches.) */
 MVM_STATIC_INLINE void MVM_string_gi_move_to(MVMThreadContext *tc, MVMGraphemeIter *gi, MVMuint32 pos) {

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -24,11 +24,6 @@ static void check_strand_sanity(MVMThreadContext *tc, MVMString *s) {
 #else
 #define STRAND_CHECK(tc, s)
 #endif
-#if __clang__
-#define MVM_VECTORIZE_LOOP _Pragma ("clang loop vectorize(enable)")
-#else
-#define MVM_VECTORIZE_LOOP _Pragma ("GCC ivdep")
-#endif
 
 static MVMString * re_nfg(MVMThreadContext *tc, MVMString *in);
 #if MVM_DEBUG_NFG

--- a/src/strings/ops.h
+++ b/src/strings/ops.h
@@ -119,11 +119,11 @@ MVMString * MVM_string_chr(MVMThreadContext *tc, MVMint64 cp);
 void MVM_string_compute_hash_code(MVMThreadContext *tc, MVMString *s);
 /* If MVM_DEBUG_NFG is 1, calls to NFG_CHECK will re_nfg the given string
  * and compare num_graphs before and after the normalization.
- * If it is different debug information will be printed out.
-#define MVM_DEBUG_NFG 1 */
+ * If it is different debug information will be printed out.*/
+#define MVM_DEBUG_NFG 0
 /* MVM_DEBUG_NFG_STRICT does as above but does not only rely on num_graphs. It
- * always checks every grapheme manually. Slower. (requires MVM_DEBUG_NFG)
-#define MVM_DEBUG_NFG_STRICT 0 */
+ * always checks every grapheme manually. Slower. (requires MVM_DEBUG_NFG)*/
+#define MVM_DEBUG_NFG_STRICT 0
 #if MVM_DEBUG_NFG
 void NFG_check (MVMThreadContext *tc, MVMString *orig, char *varname);
 void NFG_check_concat (MVMThreadContext *tc, MVMString *result, MVMString *a, MVMString *b, char *varname);


### PR DESCRIPTION
collapse_strands and certain conditions of substr rely on
iterate_gi_into_string() for flattening a specified section of a string.
This has been a performance issue since forever, and though I made
changes to make it faster, it still had issues. These new changes are a
full rewrite of that function and a new function which checks if a
string for the specified length can fit into 8 or 32 bits.

Both these functions have been rewritten to take advantage of compiler
vectorization which will utilize instructions such as SSE* or AVX*.

In string_can_be_8bit() we use multiple bitwise AND operations to check
the 32 bit integers while ORing the result with `val`.
Care must be taken so that any variables altered by the loop are not used
outside of the loop. Even more critical, there cannot be  any branching or
function calls. For example: `i` is not used outside the loop, while `val`
is allowed as biwise OR works with vectorization well.

To support both of these changes a new grapheme iterator function has
been added called MVM_string_gi_next_strand() which moves to the next
strand. This allows us to process each strand at a time without having
to process each grapheme at a time. This was needed to either memcpy()
or use vectorizable loops to copy the graphemes based on strand bit
type.