### PR TITLE
Add missing write barrier enforcement in CPPStruct

### DIFF
--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -7,7 +7,8 @@ static const MVMREPROps CPPStruct_this_repr;
  * list of attributes (populating the passed flat_list). Also builds
  * the index mapping for doing named lookups. Note index is not related
  * to the storage position. */
-static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *mro, MVMCPPStructREPRData *repr_data) {
+static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *mro,
+         MVMCPPStructREPRData *repr_data, MVMSTable *st) {
     MVMInstance *instance  = tc->instance;
     MVMObject *flat_list, *class_list, *attr_map_list;
     MVMint32  num_classes, i, current_slot = 0;
@@ -15,6 +16,7 @@ static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *
 
     MVMint32 mro_idx = MVM_repr_elems(tc, mro);
 
+    MVM_gc_root_temp_push(tc, (MVMCollectable **)&st);
     MVM_gc_root_temp_push(tc, (MVMCollectable **)&mro);
 
     flat_list = MVM_repr_alloc_init(tc, MVM_hll_current(tc)->slurpy_array_type);
@@ -84,15 +86,17 @@ static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *
         }
     }
 
-    MVM_gc_root_temp_pop_n(tc, 4);
+    MVM_gc_root_temp_pop_n(tc, 5);
 
     /* We can now form the name map. */
     num_classes = MVM_repr_elems(tc, class_list);
     result = (MVMCPPStructNameMap *) MVM_malloc(sizeof(MVMCPPStructNameMap) * (1 + num_classes));
 
     for (i = 0; i < num_classes; i++) {
-        result[i].class_key = MVM_repr_at_pos_o(tc, class_list, i);
-        result[i].name_map  = MVM_repr_at_pos_o(tc, attr_map_list, i);
+        MVM_ASSIGN_REF(tc, &(st->header), result[i].class_key,
+            MVM_repr_at_pos_o(tc, class_list, i));
+        MVM_ASSIGN_REF(tc, &(st->header), result[i].name_map,
+            MVM_repr_at_pos_o(tc, attr_map_list, i));
     }
 
     /* set the end to be NULL, it's useful for iteration. */
@@ -115,7 +119,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMSTable *st,
     /* Compute index mapping table and get flat list of attributes. */
     MVMObject *flat_list;
     MVMROOT(tc, st, {
-        flat_list = index_mapping_and_flat_list(tc, repr_info, repr_data);
+        flat_list = index_mapping_and_flat_list(tc, repr_info, repr_data, st);
     });
 
     /* If we have no attributes in the index mapping, then just the header. */


### PR DESCRIPTION
This was done earlier for CStruct, by jnthn++, in commit 85fc758ce976.
Stress testing of t/04-nativecall/11-cpp.t showed that the same fix
had to be applied to CPPStruct as well.