### PR TITLE
Ensure `make realclean` cleans cmp and libatomic_ops

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -670,6 +670,7 @@ realclean: clean
 	-$(CMD)@shaclean@ $(NOOUT) $(NOERR)
 	-$(CMD)@mtclean@ $(NOOUT) $(NOERR)
 	-$(CMD)@dcclean@ $(NOOUT) $(NOERR)
+	-$(CMD)@cmpclean@ $(NOOUT) $(NOERR)
 
 distclean: realclean
 	$(MSG) remove executable and libraries

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -11,7 +11,7 @@ our %TP_LAO = (
     name  => 'atomic_ops',
     path  => '3rdparty/libatomic_ops/src',
     rule  => 'cd 3rdparty/libatomic_ops && CC=\'$(CC)\' CFLAGS=\'$(CFLAGS)\' ./configure @crossconf@ && cd src && $(MAKE) && cd ..',
-    clean => 'cd 3rdparty/libatomic_ops/src && $(MAKE) distclean',
+    clean => 'cd 3rdparty/libatomic_ops/src && $(RM) libatomic_ops.a && $(MAKE) distclean',
 );
 
 our %TP_SHA = (
@@ -55,6 +55,7 @@ our %TP_CMP = (
     name => 'cmp',
     path => '3rdparty/cmp',
     src  => [ '3rdparty/cmp' ],
+    clean => 'cd 3rdparty/cmp && $(RM) libcmp.a && $(MAKE) clean'
 );
 
 our %TP_UVDUMMY = (


### PR DESCRIPTION
The `cmp` lib had not been added to Makefile.in and setup.pm yet.
`libatomic_ops` was already running `make distclean` in
3rdparty/libatomic_ops/src, but this didn't remove libatomic_ops.a, so
remove it manually.