### PR TITLE
Restrict spesh debug logging to selected frames

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -343,7 +343,7 @@ HEADERS = src/moar.h \
           src/mast/driver.h \
           src/mast/nodes.h \
           src/spesh/dump.h \
-	  src/spesh/debug.h \
+          src/spesh/debug.h \
           src/spesh/graph.h \
           src/spesh/codegen.h \
           src/spesh/candidate.h \

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -200,6 +200,7 @@ OBJECTS = src/core/callsite@obj@ \
           src/spesh/lookup@obj@ \
           src/spesh/iterator@obj@ \
           src/spesh/worker@obj@ \
+	  src/spesh/debug@obj@ \
           src/spesh/stats@obj@ \
           src/spesh/plan@obj@ \
           src/spesh/arg_guard@obj@ \
@@ -342,6 +343,7 @@ HEADERS = src/moar.h \
           src/mast/driver.h \
           src/mast/nodes.h \
           src/spesh/dump.h \
+	  src/spesh/debug.h \
           src/spesh/graph.h \
           src/spesh/codegen.h \
           src/spesh/candidate.h \

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -200,7 +200,7 @@ OBJECTS = src/core/callsite@obj@ \
           src/spesh/lookup@obj@ \
           src/spesh/iterator@obj@ \
           src/spesh/worker@obj@ \
-	  src/spesh/debug@obj@ \
+          src/spesh/debug@obj@ \
           src/spesh/stats@obj@ \
           src/spesh/plan@obj@ \
           src/spesh/arg_guard@obj@ \
@@ -256,7 +256,7 @@ HEADERS = src/moar.h \
           src/core/loadbytecode.h \
           src/core/bitmap.h \
           src/math/num.h \
-		  src/math/grisu.h \
+          src/math/grisu.h \
           src/core/coerce.h \
           src/core/dll.h \
           src/core/ext.h \

--- a/src/moar.h
+++ b/src/moar.h
@@ -141,6 +141,7 @@ MVM_PUBLIC const MVMint32 MVM_jit_support(void);
 #include "gc/finalize.h"
 #include "core/regionalloc.h"
 #include "spesh/dump.h"
+#include "spesh/debug.h"
 #include "spesh/graph.h"
 #include "spesh/codegen.h"
 #include "spesh/candidate.h"

--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -39,16 +39,16 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
 #if MVM_GC_DEBUG
     tc->in_spesh = 1;
 #endif
-    if (tc->instance->spesh_log_fh)
+    if (MVM_spesh_debug_enabled(tc))
         start_time = uv_hrtime();
     sg = MVM_spesh_graph_create(tc, p->sf, 0, 1);
-    if (tc->instance->spesh_log_fh) {
+    if (MVM_spesh_debug_enabled(tc)) {
         char *c_name = MVM_string_utf8_encode_C_string(tc, p->sf->body.name);
         char *c_cuid = MVM_string_utf8_encode_C_string(tc, p->sf->body.cuuid);
         char *before = MVM_spesh_dump(tc, sg);
-        fprintf(tc->instance->spesh_log_fh,
+        MVM_spesh_debug_printf(tc,
             "Specialization of '%s' (cuid: %s)\n\n", c_name, c_cuid);
-        fprintf(tc->instance->spesh_log_fh, "Before:\n%s", before);
+        MVM_spesh_debug_printf(tc, "Before:\n%s", before);
         MVM_free(c_name);
         MVM_free(c_cuid);
         MVM_free(before);
@@ -61,10 +61,11 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
     MVM_spesh_facts_discover(tc, sg, p);
     MVM_spesh_optimize(tc, sg, p);
 
-    if (tc->instance->spesh_log_fh) {
+
+    if (MVM_spesh_debug_enabled(tc)) {
         char *after = MVM_spesh_dump(tc, sg);
-        fprintf(tc->instance->spesh_log_fh, "After:\n%s", after);
-        fprintf(tc->instance->spesh_log_fh, "Specialization took %dus\n\n========\n\n",
+        MVM_spesh_debug_printf(tc, "After:\n%s", after);
+        MVM_spesh_debug_printf(tc, "Specialization took %dus\n\n========\n\n",
             (int)((uv_hrtime() - start_time) / 1000));
         MVM_free(after);
         fflush(tc->instance->spesh_log_fh);
@@ -100,10 +101,10 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
             candidate->jitcode = MVM_jit_compile_graph(tc, jg);
             MVM_jit_graph_destroy(tc, jg);
         }
-        if (tc->instance->spesh_log_fh) {
-            fprintf(tc->instance->spesh_log_fh, "JIT was %s and compilation took %" PRIu64 "us\n",
-                    candidate->jitcode ? "successful" : "not successful",
-                    (uv_hrtime() - start_time) / 1000);
+        if (MVM_spesh_debug_enabled(tc)) {
+            MVM_spesh_debug_printf(tc, "JIT was %s and compilation took %" PRIu64 "us\n",
+                                   candidate->jitcode ? "successful" : "not successful",
+                                   (uv_hrtime() - start_time) / 1000);
         }
     }
 
@@ -156,10 +157,10 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
     MVM_barrier();
     spesh->body.num_spesh_candidates++;
 
-    /* If we're logging, dump the updated arg guards also. */
-    if (tc->instance->spesh_log_fh) {
+    /* If we're logging, dump the upadated arg guards also. */
+    if (MVM_spesh_debug_enabled(tc)) {
         char *guard_dump = MVM_spesh_dump_arg_guard(tc, p->sf);
-        fprintf(tc->instance->spesh_log_fh, "%s========\n\n", guard_dump);
+        MVM_spesh_debug_printf(tc, "%s========\n\n", guard_dump);
         fflush(tc->instance->spesh_log_fh);
         MVM_free(guard_dump);
     }

--- a/src/spesh/debug.c
+++ b/src/spesh/debug.c
@@ -1,0 +1,13 @@
+#include "moar.h"
+#include <stdarg.h>
+
+void MVM_spesh_debug_printf(MVMThreadContext *tc, const char *format, ...) {
+    va_list list;
+    va_start(list, format);
+    vfprintf(tc->instance->spesh_log_fh, format, list);
+    va_end(list);
+}
+
+void MVM_spesh_debug_flush(MVMThreadContext *tc) {
+    fflush(tc->instance->spesh_log_fh);
+}

--- a/src/spesh/debug.h
+++ b/src/spesh/debug.h
@@ -1,0 +1,8 @@
+void MVM_spesh_debug_printf(MVMThreadContext *tc, const char *format, ...);
+void MVM_spesh_debug_flush(MVMThreadContext *tc);
+
+MVM_STATIC_INLINE MVMint32 MVM_spesh_debug_enabled(MVMThreadContext *tc) {
+    return tc->instance->spesh_log_fh != NULL &&
+        (tc->instance->spesh_limit == 0 ||
+         tc->instance->spesh_produced == tc->instance->spesh_limit);
+}

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1707,6 +1707,11 @@ static void optimize_call(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb
             MVMSpeshGraph *inline_graph = MVM_spesh_inline_try_get_graph(tc, g,
                 target_sf, target_sf->body.spesh->body.spesh_candidates[spesh_cand],
                 ins, &no_inline_reason);
+            if (inline_graph != NULL && MVM_spesh_debug_enabled(tc)) {
+                char *dump = MVM_spesh_dump(tc, inline_graph);
+                MVM_spesh_debug_printf(tc, "Inlining graph\n%s\n", dump);
+                MVM_free(dump);
+            }
 #if MVM_LOG_INLINES
             {
                 char *c_name_i = MVM_string_utf8_encode_C_string(tc, target_sf->body.name);

--- a/src/spesh/worker.c
+++ b/src/spesh/worker.c
@@ -18,11 +18,11 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
             MVMObject *log_obj;
             MVMuint64 start_time;
             unsigned int interval_id;
-            if (tc->instance->spesh_log_fh)
+            if (MVM_spesh_debug_enabled(tc))
                 start_time = uv_hrtime();
             log_obj = MVM_repr_shift_o(tc, tc->instance->spesh_queue);
-            if (tc->instance->spesh_log_fh) {
-                fprintf(tc->instance->spesh_log_fh,
+            if (MVM_spesh_debug_enabled(tc)) {
+                MVM_spesh_debug_printf(tc,
                     "Received Logs\n"
                     "=============\n\n"
                     "Was waiting %dus for logs on the log queue.\n\n",
@@ -49,12 +49,12 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
 
                     /* Update stats, and if we're logging dump each of them. */
                     tc->instance->spesh_stats_version++;
-                    if (tc->instance->spesh_log_fh)
+                    if (MVM_spesh_debug_enabled(tc))
                         start_time = uv_hrtime();
                     MVM_spesh_stats_update(tc, sl, updated_static_frames);
                     n = MVM_repr_elems(tc, updated_static_frames);
-                    if (tc->instance->spesh_log_fh) {
-                        fprintf(tc->instance->spesh_log_fh,
+                    if (MVM_spesh_debug_enabled(tc)) {
+                        MVM_spesh_debug_printf(tc,
                             "Statistics Updated\n"
                             "==================\n"
                             "%d frames had their statistics updated in %dus.\n\n",
@@ -62,7 +62,7 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
                         for (i = 0; i < n; i++) {
                             char *dump = MVM_spesh_dump_stats(tc, (MVMStaticFrame* )
                                 MVM_repr_at_pos_o(tc, updated_static_frames, i));
-                            fprintf(tc->instance->spesh_log_fh, "%s==========\n\n", dump);
+                            MVM_spesh_debug_printf(tc, "%s==========\n\n", dump);
                             MVM_free(dump);
                         }
                     }
@@ -70,12 +70,12 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
                     GC_SYNC_POINT(tc);
 
                     /* Form a specialization plan. */
-                    if (tc->instance->spesh_log_fh)
+                    if (MVM_spesh_debug_enabled(tc))
                         start_time = uv_hrtime();
                     tc->instance->spesh_plan = MVM_spesh_plan(tc, updated_static_frames);
-                    if (tc->instance->spesh_log_fh) {
+                    if (MVM_spesh_debug_enabled(tc)) {
                         n = tc->instance->spesh_plan->num_planned;
-                        fprintf(tc->instance->spesh_log_fh,
+                        MVM_spesh_debug_printf(tc,
                             "Specialization Plan\n"
                             "===================\n"
                             "%u specialization(s) will be produced (planned in %dus).\n\n",
@@ -83,7 +83,7 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
                         for (i = 0; i < n; i++) {
                             char *dump = MVM_spesh_dump_planned(tc,
                                 &(tc->instance->spesh_plan->planned[i]));
-                            fprintf(tc->instance->spesh_log_fh, "%s==========\n\n", dump);
+                            MVM_spesh_debug_printf(tc, "%s==========\n\n", dump);
                             MVM_free(dump);
                         }
                     }


### PR DESCRIPTION
This is simple enough change, but anyway; I want spesh debugging to be more useful, by being more silent. I'm repurposing MVM_SPESH_LIMIT to achieve this; not necessarily the nicest thing, but otherwise we don't even maintain a count of the frames, so we can't identify them at all.