### PR TITLE
Fix installs having an outdated version

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -129,7 +129,7 @@ if (open(my $fh, '<', 'VERSION')) {
     close($fh);
 }
 # .git is a file and not a directory in submodule
-if (-e '.git' && open(my $GIT, '-|', "git describe")) {
+if (-e '.git' && open(my $GIT, '-|', "git describe --tags --match='20*'")) {
     $VERSION = <$GIT>;
     close($GIT);
 }


### PR DESCRIPTION
This was breaking configuring nqp and Rakudo when I was building all three manually