### PR TITLE
Implement a optimized memmem 32 bit search 4-15x faster

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -228,6 +228,7 @@ OBJECTS = src/core/callsite@obj@ \
           src/instrument/line_coverage@obj@ \
           src/platform/sys@obj@ \
           src/platform/random@obj@ \
+          src/platform/memmem32@obj@ \
           src/moar@obj@ \
           @platform@ \
           @jit_obj@
@@ -405,7 +406,8 @@ HEADERS = src/moar.h \
           src/gen/config.h \
           src/debug/debugserver.h \
           3rdparty/uthash.h \
-          3rdparty/cmp/cmp.h
+          3rdparty/cmp/cmp.h \
+          src/platform/memmem32.h
 
 UV_UNIX = 3rdparty/libuv/src/fs-poll@obj@ \
           3rdparty/libuv/src/inet@obj@ \

--- a/src/platform/memmem32.c
+++ b/src/platform/memmem32.c
@@ -1,0 +1,178 @@
+/*-
+ * Original FreeBSD code Copyright (c) 2005-2014 Rich Felker, et al.
+ * Modifications for 32 bit search Copyright (c) 2018 Samantha McVey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/*#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");*/
+
+#include <string.h>
+#include <stdint.h>
+/* This is a modification of the memmem used in FreeBSD to allow us to quickly
+ * search 32 bit strings. This is much more efficient than searching by byte
+ * since we can skip every 4 bytes instead of every 1 byte, as well as the fact
+ * that in a 32 bit integer, some of the bytes will be empty, making it even
+ * less efficient.
+ * The only caveats is the table uses a modulus so it can only jump to the next
+ * codepoint of the same modulus. */
+
+static uint32_t * memmem_one_uint32(const uint32_t *h0, const uint32_t n, const uint32_t *end_h) {
+	uint32_t *h = (uint32_t*)h0;
+	for (; h < end_h; h++) {
+		if (*h == n) return h;
+	}
+	return NULL;
+}
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+#define BITOP(a,b,op) \
+ ((a)[(size_t)(b)/(8*sizeof *(a))] op (size_t)1<<((size_t)(b)%(8*sizeof *(a))))
+
+/*
+ * Two Way string search algorithm, with a bad shift table applied to the last
+ * byte of the window. A bit array marks which entries in the shift table are
+ * initialized to avoid fully initializing a 1kb/2kb table.
+ *
+ * Reference: CROCHEMORE M., PERRIN D., 1991, Two-way string-matching,
+ * Journal of the ACM 38(3):651-675
+ */
+/* The modulus number is the length of the shift table. We use this to quickly
+ * lookup a codepoint and see how much we can shift forward. Caveat: if two numbers
+ * have the same modulus we can only shift as much forward as much as a codepoint
+ * with that modulus. */
+#define MODNUMBER 256
+#define MOD_OP(a) ((a) % MODNUMBER)
+static char *twoway_memmem_uint32(const uint32_t *h, const uint32_t *z, const uint32_t *n, size_t l)
+{
+	size_t i, ip, jp, k, p, ms, p0, mem, mem0;
+	size_t byteset[32 / sizeof(size_t)] = { 0 };
+	uint32_t shift[MODNUMBER];
+
+	/* Computing length of needle and fill shift table */
+	for (i=0; i<l; i++) {
+		BITOP(byteset, MOD_OP(n[i]), |=);
+		shift[MOD_OP(n[i])] = i+1;
+	}
+
+	/* Compute maximal suffix */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] > n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	ms = ip;
+	p0 = p;
+
+	/* And with the opposite comparison */
+	ip = -1; jp = 0; k = p = 1;
+	while (jp+k<l) {
+		if (n[ip+k] == n[jp+k]) {
+			if (k == p) {
+				jp += p;
+				k = 1;
+			} else k++;
+		} else if (n[ip+k] < n[jp+k]) {
+			jp += k;
+			k = 1;
+			p = jp - ip;
+		} else {
+			ip = jp++;
+			k = p = 1;
+		}
+	}
+	if (ip+1 > ms+1) ms = ip;
+	else p = p0;
+
+	/* Periodic needle? */
+	if (memcmp(n, n+p, ms+1)) {
+		mem0 = 0;
+		p = MAX(ms, l-ms-1) + 1;
+	} else mem0 = l-p;
+	mem = 0;
+
+	/* Search loop */
+	for (;;) {
+		/* If remainder of haystack is shorter than needle, done */
+		if (z-h < l) {
+			return 0;
+		}
+
+		/* Check last byte first; advance by shift on mismatch */
+		if (BITOP(byteset, MOD_OP(h[l-1]), &)) {
+			k = l-shift[MOD_OP(h[l-1])];
+			if (k) {
+				if (mem0 && mem && k < p) k = l-p;
+				h += k;
+				mem = 0;
+				continue;
+			}
+		} else {
+			h += l;
+			mem = 0;
+			continue;
+		}
+
+		/* Compare right half */
+		for (k=MAX(ms+1,mem); k<l && n[k] == h[k]; k++);
+		if (k < l) {
+			h += k-ms;
+			mem = 0;
+			continue;
+		}
+		/* Compare left half */
+		for (k=ms+1; k>mem && n[k-1] == h[k-1]; k--);
+		if (k <= mem) {
+			return (char *)h;
+		}
+		h += p;
+		mem = mem0;
+	}
+}
+void *memmem_uint32(const void *h0, size_t k, const void *n0, size_t l)
+{
+	const uint32_t *h = (uint32_t*)h0, *n = (uint32_t*)n0;
+
+	/* Return immediately on empty needle */
+	if (!l) return (void *)h;
+
+	/* Return immediately when needle is longer than haystack */
+	if (k<l) return 0;
+
+	/* Use faster algorithms for short needles */
+	h = memmem_one_uint32((uint32_t*)h, *n, h+k);
+	if (!h || l == 1) return (void *)h;
+	k -= h - (uint32_t*)h0;
+	if (k<l) return 0;
+
+	return twoway_memmem_uint32(h, h+k, n, l);
+}

--- a/src/platform/memmem32.h
+++ b/src/platform/memmem32.h
@@ -1,0 +1,1 @@
+void *memmem_uint32(const void *h0, size_t k, const void *n0, size_t l);

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -542,7 +542,42 @@ MVMint64 MVM_string_substrings_equal_nocheck(MVMThreadContext *tc, MVMString *a,
         return 1;
     }
 }
-
+static MVMint64 MVM_string_memmem_grapheme32 (MVMThreadContext *tc, MVMGrapheme32 *H_blob32, MVMGrapheme32 *n_blob32, MVMint64 H_start, MVMStringIndex H_graphs, MVMStringIndex n_graphs) {
+    void *start_ptr = H_blob32 + H_start;
+    void *mm_return_32 = NULL;
+    void *end_ptr = (char*)start_ptr + sizeof(MVMGrapheme32) * (H_graphs - H_start);
+    do {
+        /* Keep as void* to not lose precision */
+        mm_return_32 = MVM_memmem(
+            start_ptr, /* start position */
+            (char*)end_ptr - (char*)start_ptr, /* length of Haystack from start position to end */
+            n_blob32, /* needle start */
+            n_graphs * sizeof(MVMGrapheme32) /* needle length */
+        );
+        if (mm_return_32 == NULL)
+            return -1;
+    } /* If we aren't on a 32 bit boundary then continue from where we left off (unlikely but possible) */
+    while ( ( (char*)mm_return_32 - (char*)H_blob32) % sizeof(MVMGrapheme32)
+        && ( start_ptr = (char*)mm_return_32 + 1) /* Set the new start pointer right after where we left off */
+        && ( start_ptr < end_ptr ) /* Check we aren't past the end of the string just in case */
+    );
+    return (MVMGrapheme32*)mm_return_32 - H_blob32;
+}
+static MVMint64 MVM_string_memmem_grapheme32str (MVMThreadContext *tc, MVMString *Haystack, MVMString *needle, MVMint64 H_start, MVMStringIndex H_graphs, MVMStringIndex n_graphs) {
+    MVMGrapheme32 *needle_buf = NULL;
+    if (needle->body.storage_type != MVM_STRING_GRAPHEME_32) {
+        MVMStringIndex i;
+        MVMGraphemeIter n_gi;
+        needle_buf = MVM_malloc(needle->body.num_graphs * sizeof(MVMGrapheme32));
+        if (needle->body.storage_type != MVM_STRING_GRAPHEME_8) MVM_string_gi_init(tc, &n_gi, needle);
+        for (i = 0; i < needle->body.num_graphs; i++) {
+            needle_buf[i] = needle->body.storage_type == MVM_STRING_GRAPHEME_8 ? needle->body.storage.blob_8[i] : MVM_string_gi_get_grapheme(tc, &n_gi);
+        }
+    }
+    ssize_t rtrn = MVM_string_memmem_grapheme32(tc, Haystack->body.storage.blob_32, needle_buf ? needle_buf : needle->body.storage.blob_32, H_start, H_graphs, n_graphs);
+    if (needle_buf) MVM_free(needle_buf);
+    return rtrn;
+}
 /* Returns the location of one string in another or -1  */
 MVMint64 MVM_string_index(MVMThreadContext *tc, MVMString *Haystack, MVMString *needle, MVMint64 start) {
     size_t index           = (size_t)start;
@@ -569,40 +604,8 @@ MVMint64 MVM_string_index(MVMThreadContext *tc, MVMString *Haystack, MVMString *
      * Crochemore+Perrin two-way string matching */
     switch (Haystack->body.storage_type) {
         case MVM_STRING_GRAPHEME_32:
-            if (needle->body.storage_type == MVM_STRING_GRAPHEME_32 || needle->body.num_graphs < 100) {
-                void *start_ptr = Haystack->body.storage.blob_32 + start;
-                void *mm_return_32 = NULL;
-                void *end_ptr = (char*)start_ptr + sizeof(MVMGrapheme32) * (H_graphs - start);
-                MVMGrapheme32 *needle_buf = NULL;
-                if (needle->body.storage_type != MVM_STRING_GRAPHEME_32) {
-                    MVMStringIndex i;
-                    MVMGraphemeIter n_gi;
-                    needle_buf = MVM_malloc(needle->body.num_graphs * sizeof(MVMGrapheme32));
-                    if (needle->body.storage_type != MVM_STRING_GRAPHEME_8) MVM_string_gi_init(tc, &n_gi, needle);
-                    for (i = 0; i < needle->body.num_graphs; i++) {
-                        needle_buf[i] = needle->body.storage_type == MVM_STRING_GRAPHEME_8 ? needle->body.storage.blob_8[i] : MVM_string_gi_get_grapheme(tc, &n_gi);
-                    }
-                }
-                do {
-                    /* Keep as void* to not lose precision */
-                    mm_return_32 = MVM_memmem(
-                        start_ptr, /* start position */
-                        (char*)end_ptr - (char*)start_ptr, /* length of Haystack from start position to end */
-                        needle_buf ? needle_buf : needle->body.storage.blob_32, /* needle start */
-                        n_graphs * sizeof(MVMGrapheme32) /* needle length */
-                    );
-                    if (mm_return_32 == NULL) {
-                        if (needle_buf) MVM_free(needle_buf);
-                        return -1;
-                    }
-                } /* If we aren't on a 32 bit boundary then continue from where we left off (unlikely but possible) */
-                while ( ( (char*)mm_return_32 - (char*)Haystack->body.storage.blob_32) % sizeof(MVMGrapheme32)
-                    && ( start_ptr = (char*)mm_return_32 + 1) /* Set the new start pointer right after where we left off */
-                    && ( start_ptr < end_ptr ) /* Check we aren't past the end of the string just in case */
-                );
-                if (needle_buf) MVM_free(needle_buf);
-                return (MVMGrapheme32*)mm_return_32 - Haystack->body.storage.blob_32;
-            }
+            if (needle->body.storage_type == MVM_STRING_GRAPHEME_32 || needle->body.num_graphs < 100)
+                return MVM_string_memmem_grapheme32str(tc, Haystack, needle, start, H_graphs, n_graphs);
             break;
         case MVM_STRING_GRAPHEME_8:
             if (needle->body.storage_type == MVM_STRING_GRAPHEME_8 || needle->body.num_graphs < 100) {
@@ -2099,50 +2102,46 @@ MVMString * MVM_string_join(MVMThreadContext *tc, MVMString *separator, MVMObjec
     return concats_stable ? result : re_nfg(tc, result);
 }
 
-/* Returning nonzero means it found the char at the position specified in 'a' in 'b'.
+/* Returning nonzero means it found the char at the position specified in 'a' in 'Haystack'.
  * For character enumerations in regexes. */
-MVMint64 MVM_string_char_at_in_string(MVMThreadContext *tc, MVMString *a, MVMint64 offset, MVMString *b) {
-    MVMuint32     bgraphs;
+MVMint64 MVM_string_char_at_in_string(MVMThreadContext *tc, MVMString *a, MVMint64 offset, MVMString *Haystack) {
+    MVMuint32     H_graphs;
     MVMGrapheme32 search;
 
     MVM_string_check_arg(tc, a, "char_at_in_string");
-    MVM_string_check_arg(tc, b, "char_at_in_string");
+    MVM_string_check_arg(tc, Haystack, "char_at_in_string");
 
     /* We return -2 here only to be able to distinguish between "out of bounds" and "not in string". */
     if (offset < 0 || MVM_string_graphs_nocheck(tc, a) <= offset)
         return -2;
 
     search  = MVM_string_get_grapheme_at_nocheck(tc, a, offset);
-    bgraphs = MVM_string_graphs_nocheck(tc, b);
-    switch (b->body.storage_type) {
-    case MVM_STRING_GRAPHEME_32: {
-        MVMStringIndex i;
-        for (i = 0; i < bgraphs; i++)
-            if (b->body.storage.blob_32[i] == search)
-                return i;
-        break;
-    }
+    H_graphs = MVM_string_graphs_nocheck(tc, Haystack);
+    switch (Haystack->body.storage_type) {
+    case MVM_STRING_GRAPHEME_32:
+        return MVM_string_memmem_grapheme32(tc, Haystack->body.storage.blob_32, &search, 0, H_graphs, 1);
+
     case MVM_STRING_GRAPHEME_ASCII:
         if (can_fit_into_ascii(search)) {
             MVMStringIndex i;
-            for (i = 0; i < bgraphs; i++)
-                if (b->body.storage.blob_ascii[i] == search)
+            for (i = 0; i < H_graphs; i++)
+                if (Haystack->body.storage.blob_ascii[i] == search)
                     return i;
         }
         break;
     case MVM_STRING_GRAPHEME_8:
         if (can_fit_into_8bit(search)) {
             MVMStringIndex i;
-            for (i = 0; i < bgraphs; i++)
-                if (b->body.storage.blob_8[i] == search)
+            for (i = 0; i < H_graphs; i++)
+                if (Haystack->body.storage.blob_8[i] == search)
                     return i;
         }
         break;
     case MVM_STRING_STRAND: {
         MVMGraphemeIter gi;
         MVMStringIndex  i;
-        MVM_string_gi_init(tc, &gi, b);
-        for (i = 0; i < bgraphs; i++)
+        MVM_string_gi_init(tc, &gi, Haystack);
+        for (i = 0; i < H_graphs; i++)
             if (MVM_string_gi_get_grapheme(tc, &gi) == search)
                 return i;
     }


### PR DESCRIPTION
This is a modification of the memmem used in FreeBSD to allow us to quickly
search 32 bit strings. This is much more efficient than searching by byte
since we can skip every 4 bytes instead of every 1 byte, as well as the
fact that in a 32 bit integer, some of the bytes will be empty, making it
even less efficient.

The only caveat is the table uses a modulus so it can only jump to the next
codepoint of the same modulus. So it can only jump forward to the next
codepoint of the same modulus. This is generally not too much of a problem
and performs better than the previous 8 bit memmem for 32 bit strings in
all possible cases.

Factor out the memmem wrapper for searching Grapheme32 blobs