### PR TITLE
Moar JIT ops

### DIFF
--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -84,9 +84,6 @@ MVMJitCode * MVM_jit_compile_graph(MVMThreadContext *tc, MVMJitGraph *jg) {
         case MVM_JIT_NODE_DATA:
             MVM_jit_emit_data(tc, &cl, &node->u.data);
             break;
-        case MVM_JIT_NODE_SAVE_RV:
-            MVM_jit_emit_save_rv(tc, &cl, node->u.stack.slot);
-            break;
         }
         node = node->next;
     }

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1642,6 +1642,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_takedispatcher:
     case MVM_OP_setdispatcher:
     case MVM_OP_ctx:
+    case MVM_OP_ctxlexpad:
     case MVM_OP_curcode:
     case MVM_OP_getcode:
     case MVM_OP_callercode:

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1692,6 +1692,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_captureposelems:
     case MVM_OP_capturehasnameds:
     case MVM_OP_captureposarg:
+    case MVM_OP_captureexistsnamed:
     case MVM_OP_capturenamedshash:
         /* Exception handling */
     case MVM_OP_lastexpayload:

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1665,6 +1665,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_ishash:
     case MVM_OP_sp_boolify_iter_arr:
     case MVM_OP_sp_boolify_iter_hash:
+    case MVM_OP_lexprimspec:
     case MVM_OP_objprimspec:
     case MVM_OP_objprimbits:
     case MVM_OP_takehandlerresult:

--- a/src/jit/graph.h
+++ b/src/jit/graph.h
@@ -108,7 +108,6 @@ typedef enum {
        cur_op. */
     MVM_JIT_REG_DYNIDX,
     MVM_JIT_DATA_LABEL,
-    MVM_JIT_SAVED_RV,
     /* The MVM_JIT_ARG_* types are used when the offset into the WORK array is
        not known yet, i.e. for ahead of time compiled native calls. */
     MVM_JIT_ARG_I64,
@@ -127,6 +126,8 @@ typedef enum {
     MVM_JIT_PARAM_VMARRAY,
     /* spesh slot value */
     MVM_JIT_SPESH_SLOT_VALUE,
+    /* stack relative address */
+    MVM_JIT_STACK_VALUE,
 } MVMJitArgType;
 
 struct MVMJitCallArg {
@@ -162,6 +163,8 @@ typedef enum {
     MVM_JIT_RV_DYNIDX,
     /* store pointer or vmnull */
     MVM_JIT_RV_DEREF_OR_VMNULL,
+    /* store on stack with offset */
+    MVM_JIT_RV_TO_STACK,
 } MVMJitRVMode;
 
 
@@ -217,7 +220,6 @@ typedef enum {
     MVM_JIT_NODE_CONTROL,
     MVM_JIT_NODE_DATA,
     MVM_JIT_NODE_EXPR_TREE,
-    MVM_JIT_NODE_SAVE_RV,
 } MVMJitNodeType;
 
 struct MVMJitNode {

--- a/src/jit/internal.h
+++ b/src/jit/internal.h
@@ -48,7 +48,6 @@ void MVM_jit_emit_jumplist(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJi
 void MVM_jit_emit_control(MVMThreadContext *tc, MVMJitCompiler *compiler,
                           MVMJitControl *ctrl, MVMJitTile *tile);
 void MVM_jit_emit_data(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitData *data);
-void MVM_jit_emit_save_rv(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMint16 slot);
 
 void MVM_jit_emit_load(MVMThreadContext *tc, MVMJitCompiler *compiler,
                        MVMint32 reg_cls, MVMint8 reg_dst,

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1796,6 +1796,25 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov WORK[dest], TMP2;
         break;
     }
+    case MVM_OP_captureexistsnamed: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 obj = ins->operands[1].reg.orig;
+        MVMint16 name = ins->operands[2].reg.orig;
+        | mov TMP1, WORK[obj];
+        | is_type_object TMP1;
+        | jnz >1;
+        | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCallCapture;
+        | je >2;
+        |1:
+        | throw_adhoc "captureexistsnamed needs a MVMCallCapture";
+        |2:
+        | mov ARG2, CAPTURE:TMP1->body.apc;
+        | mov ARG3, WORK[name];
+        | mov ARG1, TC;
+        | callp MVM_args_has_named;
+        | mov WORK[dst], RV;
+        break;
+    }
     case MVM_OP_capturehasnameds: {
         MVMint16 dest    = ins->operands[0].reg.orig;
         MVMint16 capture = ins->operands[1].reg.orig;

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -264,7 +264,7 @@ const unsigned int MVM_jit_num_globals(void) {
 | mov reg, OBJECTPTR:reg[idx];
 |.endmacro
 
-|.macro is_type_object, reg
+|.macro test_type_object, reg
 | test word OBJECT:reg->header.flags, MVM_CF_TYPE_OBJECT
 |.endmacro
 
@@ -819,8 +819,8 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 src = ins->operands[1].reg.orig;
         MVMint16 dst = ins->operands[0].reg.orig;
         | mov TMP1, WORK[src];
-        | is_type_object TMP1;
-        | je >1;
+        | test_type_object TMP1;
+        | jnz >1;
         | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMContext;
         | je >2;
         |1:
@@ -890,7 +890,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 src = ins->operands[1].reg.orig;
         MVMint16 pos = ins->operands[2].reg.orig;
         | mov TMP5, qword WORK[src];
-        | is_type_object TMP5;
+        | test_type_object TMP5;
         | jnz >1;
         | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMCallCapture;
         | jne >1;
@@ -1525,7 +1525,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | test TMP5, TMP5;
         // obj is null
         | jz >1;
-        | is_type_object TMP5;
+        | test_type_object TMP5;
         // object is type object (not concrete)
         | jnz >1;
         | mov TMP6, OBJECT:TMP5->st;
@@ -1602,7 +1602,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov TMP1, WORK[obj];
         | test TMP1, TMP1;
         | jz >1;
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         | jnz >1;
         | mov qword WORK[dst], 1;
         | jmp >2;
@@ -1741,7 +1741,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 capture = ins->operands[2].reg.orig;
         | mov TMP1, aword WORK[capture];
         /* if (IS_CONCRETE(capture) && REPR(capture)->ID == MVM_REPR_ID_MVMCallCapture) */
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         | jnz >1;
         | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCallCapture;
         | je >2;
@@ -1783,7 +1783,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 capture = ins->operands[1].reg.orig;
         | mov TMP1, aword WORK[capture];
         /* if (IS_CONCRETE(capture) && REPR(capture)->ID == MVM_REPR_ID_MVMCallCapture) */
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         | jnz >1;
         | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCallCapture;
         | je >2;
@@ -1801,7 +1801,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 obj = ins->operands[1].reg.orig;
         MVMint16 name = ins->operands[2].reg.orig;
         | mov TMP1, WORK[obj];
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         | jnz >1;
         | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCallCapture;
         | je >2;
@@ -1820,7 +1820,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 capture = ins->operands[1].reg.orig;
         | mov TMP1, aword WORK[capture];
         /* if (IS_CONCRETE(capture) && REPR(capture)->ID == MVM_REPR_ID_MVMCallCapture) */
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         | jnz >1;
         | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCallCapture;
         | je >2;
@@ -1841,7 +1841,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 obj = ins->operands[1].reg.orig;
         | mov TMP1, WORK[obj];
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         | jnz >1;
         | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCallCapture;
         | je >2;
@@ -2430,7 +2430,7 @@ void MVM_jit_emit_block_branch(MVMThreadContext *tc, MVMJitCompiler *compiler, M
             | mov TMP1, WORK[ctx];
             | cmp_repr_id, TMP1, TMP2, MVM_REPR_ID_MVMContext;
             | jne >1;
-            | is_type_object TMP1;
+            | test_type_object TMP1;
             | jz >2;
             |1:
             | throw_adhoc "lexprimspec needs a context";
@@ -2518,7 +2518,7 @@ void MVM_jit_emit_guard(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGr
         | test TMP1, TMP1;
         | jz >1;
         /* check if type object (not concrete) */
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         /* if zero, this is a concrete object, and we should deopt */
         | jz >1;
         /* get stable and compare */
@@ -2530,7 +2530,7 @@ void MVM_jit_emit_guard(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGr
         | test TMP1, TMP1;
         | jz >1;
         /* shouldn't be type object */
-        | is_type_object TMP1;
+        | test_type_object TMP1;
         | jnz >1;
         /* should have our stable */
         | cmp TMP2, OBJECT:TMP1->st;

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -97,6 +97,7 @@
 |.type REPR, MVMREPROps
 |.type STRING, MVMString
 |.type OBJECTPTR, MVMObject*
+|.type CONTEXT, MVMContext
 |.type CONTAINERSPEC, MVMContainerSpec
 |.type STORAGESPEC, MVMStorageSpec
 |.type HLLCONFIG, MVMHLLConfig;
@@ -2401,6 +2402,25 @@ void MVM_jit_emit_block_branch(MVMThreadContext *tc, MVMJitCompiler *compiler, M
 
                 | jne =>(name);
             }
+            break;
+        }
+        case MVM_OP_lexprimspec: {
+            MVMint16 dst = ins->operands[0].reg.orig;
+            MVMint16 ctx = ins->operands[1].reg.orig;
+            MVMint16 name = ins->operands[2].reg.orig;
+            | mov TMP1, WORK[ctx];
+            | cmp_repr_id, TMP1, TMP2, MVM_REPR_ID_MVMContext;
+            | jne >1;
+            | is_type_object TMP1;
+            | jz >2;
+            |1:
+            | throw_adhoc "lexprimspec needs a context";
+            |2:
+            | mov ARG2, CONTEXT:TMP1->body.context;
+            | mov ARG3, WORK[name];
+            | mov ARG1, TC;
+            | callp MVM_frame_lexical_primspec;
+            | mov WORK[dst], RV;
             break;
         }
         default:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2039,9 +2039,6 @@ static void load_call_arg(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJit
     case MVM_JIT_DATA_LABEL:
         | lea TMP6, [=>(arg.v.lit_i64)];
         break;
-    case MVM_JIT_SAVED_RV:
-        | mov TMP6, [rbp-(0x28+arg.v.lit_i64*8)];
-        break;
     case MVM_JIT_ARG_I64:
         | mov TMP6, TC->cur_frame;
         | mov TMP6, FRAME:TMP6->args;
@@ -2080,6 +2077,9 @@ static void load_call_arg(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJit
         break;
     case MVM_JIT_SPESH_SLOT_VALUE:
         | get_spesh_slot TMP6, arg.v.lit_i64;
+        break;
+    case MVM_JIT_STACK_VALUE:
+        | mov TMP6, [rbp-(0x28+arg.v.lit_i64*8)];
         break;
     default:
         MVM_oops(tc, "JIT: Unknown JIT argument type %d", arg.type);
@@ -2197,7 +2197,6 @@ static void emit_posix_callargs(MVMThreadContext *tc, MVMJitCompiler *compiler, 
         case MVM_JIT_LITERAL_64:
         case MVM_JIT_LITERAL_PTR:
         case MVM_JIT_DATA_LABEL:
-        case MVM_JIT_SAVED_RV:
         case MVM_JIT_ARG_I64:
         case MVM_JIT_ARG_I64_RW:
         case MVM_JIT_ARG_PTR:
@@ -2207,6 +2206,7 @@ static void emit_posix_callargs(MVMThreadContext *tc, MVMJitCompiler *compiler, 
         case MVM_JIT_PARAM_PTR:
         case MVM_JIT_PARAM_VMARRAY:
         case MVM_JIT_SPESH_SLOT_VALUE:
+        case MVM_JIT_STACK_VALUE:
             if (num_gpr < 6) {
                 in_gpr[num_gpr++] = args[i];
             } else {
@@ -2314,6 +2314,9 @@ void MVM_jit_emit_call_c(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitG
         | get_vmnull TMP1;
         |5:
         | mov WORK[call_spec->rv_idx], TMP1;
+        break;
+    case MVM_JIT_RV_TO_STACK:
+        | mov [rbp-(0x28+call_spec->rv_idx*8)], RV;
         break;
     }
 }
@@ -2844,10 +2847,6 @@ void MVM_jit_emit_data(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitDat
         |.byte bytes[i];
     }
     |.code
-}
-
-void MVM_jit_emit_save_rv(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMint16 slot) {
-    | mov [rbp-(0x28+slot*8)], RV;
 }
 
 /* import tiles */


### PR DESCRIPTION
Now with a fixed `ctxlexpad`.
And I removed the `SAVE_RV` node, folding that into the call node itself.