### PR TITLE
Rotate hash value randomly for each hash and on hash table expansion

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -393,6 +393,7 @@ HEADERS = src/moar.h \
           src/platform/setjmp.h \
           src/platform/memmem.h \
           src/platform/random.h \
+          src/platform/rotate.h \
           src/jit/graph.h \
           src/jit/label.h \
           src/jit/expr.h \

--- a/src/core/threadcontext.h
+++ b/src/core/threadcontext.h
@@ -309,6 +309,7 @@ struct MVMThreadContext {
 
     MVMuint32 cur_file_idx;
     MVMuint32 cur_line_no;
+    MVMHashBucketRand hashbucket_rand;
 };
 
 MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance);

--- a/src/moar.h
+++ b/src/moar.h
@@ -16,7 +16,7 @@
 /* stuff for uthash */
 #define uthash_fatal(msg) MVM_exception_throw_adhoc(tc, "internal hash error: " msg)
 typedef uint32_t MVMhashv;
-
+#include "platform/rotate.h"
 #include "strings/uthash.h"
 
 /* libuv

--- a/src/moar.h
+++ b/src/moar.h
@@ -16,8 +16,25 @@
 /* stuff for uthash */
 #define uthash_fatal(msg) MVM_exception_throw_adhoc(tc, "internal hash error: " msg)
 typedef uint32_t MVMhashv;
-#include "platform/rotate.h"
-#include "strings/uthash.h"
+struct MVMHashBucketRand {
+    uint64_t data;
+    uint8_t location;
+};
+typedef struct MVMHashBucketRand MVMHashBucketRand;
+/* forward declarations */
+#include "types.h"
+
+/* Sized types. */
+typedef int8_t   MVMint8;
+typedef uint8_t  MVMuint8;
+typedef int16_t  MVMint16;
+typedef uint16_t MVMuint16;
+typedef int32_t  MVMint32;
+typedef uint32_t MVMuint32;
+typedef int64_t  MVMint64;
+typedef uint64_t MVMuint64;
+typedef float    MVMnum32;
+typedef double   MVMnum64;
 
 /* libuv
  * must precede atomic_ops.h so we get the ordering of Winapi headers right
@@ -36,21 +53,6 @@ typedef uint32_t MVMhashv;
 #include <dyncall.h>
 #include <dyncall_callback.h>
 #endif
-
-/* forward declarations */
-#include "types.h"
-
-/* Sized types. */
-typedef int8_t   MVMint8;
-typedef uint8_t  MVMuint8;
-typedef int16_t  MVMint16;
-typedef uint16_t MVMuint16;
-typedef int32_t  MVMint32;
-typedef uint32_t MVMuint32;
-typedef int64_t  MVMint64;
-typedef uint64_t MVMuint64;
-typedef float    MVMnum32;
-typedef double   MVMnum64;
 
 /* Alignment. */
 #if HAVE_ALIGNOF
@@ -97,6 +99,10 @@ MVM_PUBLIC const MVMint32 MVM_jit_support(void);
 #include "gc/wb.h"
 #include "core/vector.h"
 #include "core/threadcontext.h"
+#include "platform/rotate.h"
+
+#include "strings/uthash.h"
+
 #include "core/instance.h"
 #include "core/interp.h"
 #include "core/callsite.h"

--- a/src/platform/rotate.h
+++ b/src/platform/rotate.h
@@ -6,3 +6,42 @@ MVM_STATIC_INLINE uint32_t rotl32 (uint32_t value, unsigned int shift) {
     count &= mask;
     return (value << count) | (value >> (-count & mask));*/
 }
+MVMint64 MVM_proc_rand_i(MVMThreadContext *tc);
+static void printBits(size_t const size, void const * const ptr)
+{
+    unsigned char *b = (unsigned char*) ptr;
+    unsigned char byte;
+    int i, j;
+
+    for (i=size-1;i>=0;i--)
+    {
+        for (j=7;j>=0;j--)
+        {
+            byte = (b[i] >> j) & 1;
+            printf("%u", byte);
+        }
+    }
+    puts("");
+}
+static uint64_t extract_bits (uint64_t data, unsigned startBit) {
+    uint64_t mask;
+    #define MVM_EXTRACT_NUM_BITS 5
+    mask = ((1 << MVM_EXTRACT_NUM_BITS) - 1) << startBit;
+    uint64_t isolatedXbits = data & mask;
+    return isolatedXbits >> startBit;
+}
+static uint64_t get_0_to_31 (MVMThreadContext *tc) {
+    MVMHashBucketRand *t = &(tc->hashbucket_rand);
+    if ((sizeof(uint64_t) * 8) <= t->location + MVM_EXTRACT_NUM_BITS) {
+        //printf("here\n");
+        t->data = MVM_proc_rand_i(tc);
+        //getrandom(&(t->data), sizeof(uint64_t), 0);
+        t->location = 0;
+    }
+    fprintf(stderr, "location %i..%i. size %li\n", t->location, t->location + MVM_EXTRACT_NUM_BITS, sizeof(uint64_t) * 8);
+
+    uint64_t blah = extract_bits(t->data, t->location);
+    t->location += MVM_EXTRACT_NUM_BITS;
+    fprintf(stderr, "returning %lu\n", blah);
+    return blah;
+}

--- a/src/platform/rotate.h
+++ b/src/platform/rotate.h
@@ -1,0 +1,8 @@
+#include <stdint.h>  // for uint32_t, to get 32bit-wide rotates, regardless of the size of int.
+
+MVM_STATIC_INLINE uint32_t rotl32 (uint32_t value, unsigned int shift) {
+    return ((shift &= 31) == 0) ? value : (value << shift) | (value >> (32 - shift));
+    /*const unsigned int mask = CHAR_BIT*sizeof(value) - 1;
+    count &= mask;
+    return (value << count) | (value >> (-count & mask));*/
+}

--- a/src/strings/uthash.h
+++ b/src/strings/uthash.h
@@ -441,8 +441,9 @@ do {                                                                            
  *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
  *
  */
-#define GET_NEW_OFFSET(tc) \
-    (tinymt64_generate_double((tc)->rand_state) * sizeof(MVMhashv))
+#define GET_NEW_OFFSET(tc, offset) \
+    get_0_to_31(tc)
+    //(tinymt64_generate_double((tc)->rand_state) * sizeof(MVMhashv) * 8)
 #define HASH_EXPAND_BUCKETS(tbl)                                                 \
 do {                                                                             \
     unsigned _he_bkt;                                                            \


### PR DESCRIPTION
This is another improvement to prevent DOS as well as to improve our
conflict resolution. Currently a conflict of the lower `x` bits of the
hash value will cause conflicts every time we expand the table. It is
much smarter to attempt to use the full bit width of our hash value.

We define an offset for each hash table which is randomized. The hash
values are then rotated that number of bits to determine which bucket
the hash key goes into. On hash table expansion the offset is generated
randomly again.