### PR TITLE
Change getsignals output from hash to array 

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -352,8 +352,8 @@ struct MVMInstance {
     /* Cache the environment hash */
     MVMObject      *env_hash;
 
-    /* Cache the signal hash */
-    MVMObject      *sig_hash;
+    /* Cache the signal array */
+    MVMObject      *sig_arr;
 
     /* Flags indicating the signals available on the host system */
     MVMuint64       valid_sigs;

--- a/src/gc/roots.c
+++ b/src/gc/roots.c
@@ -120,8 +120,8 @@ void MVM_gc_root_add_instance_roots_to_worklist(MVMThreadContext *tc, MVMGCWorkl
     add_collectable(tc, worklist, snapshot, tc->instance->env_hash,
         "Cached environment variable hash");
 
-    add_collectable(tc, worklist, snapshot, tc->instance->sig_hash,
-        "Cached signal mapping hash");
+    add_collectable(tc, worklist, snapshot, tc->instance->sig_arr,
+        "Cached signal mapping array");
 
     MVM_debugserver_mark_handles(tc, worklist, snapshot);
 }

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -818,6 +818,11 @@
       (carg $3 ptr)
       (carg $5 int_sz)) ptr_sz))
 
+(template: getsignals
+  (call (^func &MVM_io_get_signals)
+    (arglist
+      (carg (tc) ptr)) ptr_sz))
+
 (template: slice!
   (let: (
     ($dest (call (^getf (^repr $1) MVMREPROps allocate)

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -324,6 +324,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_decont_s: return MVM_6model_container_decont_s;
     case MVM_OP_getrusage: return MVM_proc_getrusage;
     case MVM_OP_cpucores: return MVM_platform_cpu_count;
+    case MVM_OP_getsignals: return MVM_io_get_signals;
     case MVM_OP_sleep: return MVM_platform_sleep;
     case MVM_OP_getlexref_i32: case MVM_OP_getlexref_i16: case MVM_OP_getlexref_i8: case MVM_OP_getlexref_i: return MVM_nativeref_lex_i;
     case MVM_OP_getlexref_n32: case MVM_OP_getlexref_n: return MVM_nativeref_lex_n;
@@ -3102,6 +3103,12 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_cpucores: {
         MVMint16 dst = ins->operands[0].reg.orig;
         jg_append_call_c(tc, jg, op_to_func(tc, op), 0, NULL, MVM_JIT_RV_INT, dst);
+        break;
+    }
+    case MVM_OP_getsignals: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMJitCallArg args[] =  { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } } };
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 1, args, MVM_JIT_RV_PTR, dst);
         break;
     }
     case MVM_OP_sleep: {


### PR DESCRIPTION
This is the MoarVM component of a whole spanning the MoarVM, NQP,
and Rakudo repos.
[NQP](https://github.com/perl6/nqp/pull/457)
[Rakudo](https://github.com/rakudo/rakudo/pull/1897)

Changed the output of getsignals from a hash to an array with signal
names interleaved with signal values.

The purpose of this is to allow for a more consistent ordering of
signals when exposed to the HLL.

Also, although this probably isn't likely to be part of any hot code path,
adding JIT support for the getsignals op.