### PR TITLE
Define SIGBREAK on WIN32

### DIFF
--- a/src/io/signals.c
+++ b/src/io/signals.c
@@ -2,8 +2,10 @@
 
 #include <signal.h>
 #ifdef _WIN32
+/* Add signals used by libuv but not defined in the Windows signal.h */
 #define SIGHUP      1
 #define SIGKILL     9
+#define SIGBREAK    21
 #define SIGWINCH    28
 #endif
 


### PR DESCRIPTION
SIGBREAK is another signal emulated by libuv on Windows, but is not
defined in the platform's signal.h file. Using the same signum provided
to it in NodeJS's os.constants.signals object.