### PR TITLE
Implement JIT templates for 12 ops (27/06/18)

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -455,6 +455,11 @@
   (let: (($who (^getf (^stable $1) MVMSTable WHO)))
   (if (nz $who) $who (^vmnull))))
 
+(template: setwho
+  (do
+    (^store_write_barrier! (^stable $1) (^getf (^stable $1) MVMSTable WHO) $2)
+    $2))
+
 (template: eqaddr (flagval (eq $1 $2)))
 
 (template: box_i!

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -457,8 +457,8 @@
 
 (template: setwho
   (do
-    (^store_write_barrier! (^stable $1) (^getf (^stable $1) MVMSTable WHO) $2)
-    $2))
+    (^store_write_barrier! (^stable $1) (^addrf (^stable $1) MVMSTable WHO) $2)
+    $1))
 
 (template: eqaddr (flagval (eq $1 $2)))
 

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1563,6 +1563,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         /* comparison (objects) */
     case MVM_OP_eqaddr:
     case MVM_OP_isconcrete:
+    case MVM_OP_isinvokable:
         /* comparison (big integer) */
     case MVM_OP_eq_I:
     case MVM_OP_ne_I:
@@ -1618,6 +1619,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_sp_getlex_ins:
     case MVM_OP_sp_getlexvia_o:
     case MVM_OP_sp_getlexvia_ins:
+    case MVM_OP_getlexreldyn:
     case MVM_OP_getlex_no:
     case MVM_OP_sp_getlex_no:
     case MVM_OP_bindlex:
@@ -1655,8 +1657,12 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_lexprimspec:
     case MVM_OP_objprimspec:
     case MVM_OP_objprimbits:
+    case MVM_OP_objprimunsigned:
     case MVM_OP_takehandlerresult:
     case MVM_OP_exception:
+    case MVM_OP_scgethandle:
+    case MVM_OP_scobjcount:
+    case MVM_OP_setobjsc:
     case MVM_OP_scwbdisable:
     case MVM_OP_scwbenable:
     case MVM_OP_assign:
@@ -1671,6 +1677,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_getstdin:
     case MVM_OP_ordat:
     case MVM_OP_ordfirst:
+    case MVM_OP_getcodename:
     case MVM_OP_setcodeobj:
         /* Profiling */
     case MVM_OP_prof_enterspesh:
@@ -1679,6 +1686,9 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_captureposelems:
     case MVM_OP_capturehasnameds:
     case MVM_OP_captureposarg:
+    case MVM_OP_captureposarg_i:
+    case MVM_OP_captureposarg_n:
+    case MVM_OP_captureposarg_s:
     case MVM_OP_captureexistsnamed:
     case MVM_OP_capturenamedshash:
         /* Exception handling */

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1631,6 +1631,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_setdispatcher:
     case MVM_OP_ctx:
     case MVM_OP_ctxlexpad:
+    case MVM_OP_ctxcallerskipthunks:
     case MVM_OP_curcode:
     case MVM_OP_getcode:
     case MVM_OP_callercode:

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -1,5 +1,7 @@
 # -*-whitespace-*-
 
+(macro: ^addrf (,object ,type ,field)
+    (addr ,object (&offsetof ,type ,field)))
 (macro: ^getf (,object ,type ,field)
    (load (addr ,object (&offsetof ,type ,field)) (&SIZEOF_MEMBER ,type ,field)))
 (macro: ^setf (,object ,type ,field ,value)

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -873,6 +873,37 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov WORK[dst], TMP1;
         break;
     }
+    case MVM_OP_ctxcallerskipthunks: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 ctx = ins->operands[1].reg.orig;
+        | mov TMP5, aword WORK[ctx];
+        | test_type_object TMP5;
+        | jz >1;
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMContext;
+        | je >1;
+        | throw_adhoc "ctxcallerskipthunks needs an MVMContext";
+        |1:
+        | mov ARG1, TC;
+        | mov ARG2, CONTEXT:TMP5->body.context->caller;
+        |2:
+        | test ARG2, ARG2;
+        | jz >4;
+        | mov TMP6, FRAME:ARG2->static_info->body.is_thunk;
+        | test TMP6, TMP6;
+        | jz >3;
+        | mov ARG2, FRAME:ARG2->caller;
+        | jmp >2;
+        |3:
+        | callp &MVM_frame_context_wrapper;
+        | mov TMP6, RV;
+        | test TMP6, TMP6;
+        | jnz >5;
+        |4:
+        | get_vmnull TMP6;
+        |5:
+        | mov WORK[dst], TMP6;
+        break;
+    }
     case MVM_OP_curcode: {
         MVMint16 dst = ins->operands[0].reg.orig;
         | mov TMP1, TC->cur_frame;

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -103,6 +103,7 @@
 |.type CONTAINERSPEC, MVMContainerSpec
 |.type STORAGESPEC, MVMStorageSpec
 |.type HLLCONFIG, MVMHLLConfig;
+|.type SCREF, MVMSerializationContext
 |.type SCREFBODY, MVMSerializationContextBody
 |.type NFGSYNTH, MVMNFGSynthetic
 |.type CODE, MVMCode
@@ -535,6 +536,25 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov WORK[dst], TMP5;
         break;
     }
+    case MVM_OP_getlexreldyn: {
+        MVMint16 dst  = ins->operands[0].reg.orig;
+        MVMint16 ctx  = ins->operands[1].reg.orig;
+        MVMint16 name = ins->operands[2].reg.orig;
+        | mov TMP5, aword WORK[ctx];
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMContext;
+        | je >1;
+        | test_type_object TMP5;
+        | jz >1;
+        | throw_adhoc "getlexreldyn needs a context"
+        |1:
+        | mov TMP6, CONTEXT:TMP5->body.context;
+        | mov ARG1, TC
+        | mov ARG2, aword WORK[name];
+        | mov ARG3, TMP6;
+        | callp &MVM_frame_getdynlex;
+        | mov WORK[dst], RV;
+        break;
+    }
     case MVM_OP_getlex_no:
     case MVM_OP_sp_getlex_no: {
         MVMint16  dst = ins->operands[0].reg.orig;
@@ -595,7 +615,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov ARG2, CONTEXT:TMP1->body.context;
         | mov ARG3, WORK[name];
         | mov ARG1, TC;
-        | callp MVM_frame_lexical_primspec;
+        | callp &MVM_frame_lexical_primspec;
         | mov WORK[dst], RV;
         break;
     }
@@ -921,11 +941,71 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov ARG1, TC;
         | mov ARG2, aword CAPTURE:TMP5->body.apc;
         | mov ARG3, WORK[pos];
-        | callp MVM_args_get_required_pos_obj;
+        | callp &MVM_args_get_required_pos_obj;
         | mov WORK[dst], RV;
         | jmp >2;
         |1:
         | throw_adhoc "captureposarg needs a MVMCallCapture";
+        |2:
+        break;
+    }
+    case MVM_OP_captureposarg_i: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 src = ins->operands[1].reg.orig;
+        MVMint16 pos = ins->operands[2].reg.orig;
+        | mov TMP5, qword WORK[src];
+        | test_type_object TMP5;
+        | jnz >1;
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMCallCapture;
+        | jne >1;
+        | mov ARG1, TC;
+        | mov ARG2, aword CAPTURE:TMP5->body.apc;
+        | mov ARG3, qword WORK[pos];
+        | callp &MVM_args_get_required_pos_int;
+        | mov WORK[dst], RV;
+        | jmp >2;
+        |1:
+        | throw_adhoc "captureposarg_i needs a MVMCallCapture";
+        |2:
+        break;
+    }
+    case MVM_OP_captureposarg_n: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 src = ins->operands[1].reg.orig;
+        MVMint16 pos = ins->operands[2].reg.orig;
+        | mov TMP5, qword WORK[src];
+        | test_type_object TMP5;
+        | jnz >1;
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMCallCapture;
+        | jne >1;
+        | mov ARG1, TC;
+        | mov ARG2, aword CAPTURE:TMP5->body.apc;
+        | mov ARG3, qword WORK[pos];
+        | callp &MVM_args_get_pos_num;
+        | mov WORK[dst], RV;
+        | jmp >2;
+        |1:
+        | throw_adhoc "captureposarg_n needs a MVMCallCapture";
+        |2:
+        break;
+    }
+    case MVM_OP_captureposarg_s: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 src = ins->operands[1].reg.orig;
+        MVMint16 pos = ins->operands[2].reg.orig;
+        | mov TMP5, qword WORK[src];
+        | test_type_object TMP5;
+        | jnz >1;
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMCallCapture;
+        | jne >1;
+        | mov ARG1, TC;
+        | mov ARG2, aword CAPTURE:TMP5->body.apc;
+        | mov ARG3, aword WORK[pos];
+        | callp MVM_args_get_required_pos_str;
+        | mov WORK[dst], RV;
+        | jmp >2;
+        |1:
+        | throw_adhoc "captureposarg_s needs a MVMCallCapture";
         |2:
         break;
     }
@@ -1491,10 +1571,10 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov TMP6, aword WORK[type];
         | test TMP6, TMP6;
         | jz >1;
+        | mov ARG1, TC;
         | mov ARG2, OBJECT:TMP6->st;
         | mov FUNCTION, STABLE:ARG2->REPR;
         | mov FUNCTION, REPR:FUNCTION->get_storage_spec;
-        | mov ARG1, TC;
         | call FUNCTION;
         | movzx TMP6, word STORAGESPEC:RV->boxed_primitive;
         |1:
@@ -1520,6 +1600,28 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov aword WORK[dst], TMP6;
         break;
     }
+    case MVM_OP_objprimunsigned: {
+        MVMint16 dst  = ins->operands[0].reg.orig;
+        MVMint16 type = ins->operands[1].reg.orig;
+        | mov TMP5, aword WORK[type];
+        | test TMP5, TMP5;
+        | jz >1;
+        | mov ARG1, TC;
+        | mov ARG2, OBJECT:TMP5->st;
+        | mov FUNCTION, STABLE:ARG2->REPR;
+        | mov FUNCTION, REPR:FUNCTION->get_storage_spec;
+        | call FUNCTION;
+        | mov TMP6, STORAGESPEC:RV->boxed_primitive;
+        | cmp TMP6, 1;
+        | jne >1;
+        | mov TMP6, STORAGESPEC:RV->is_unsigned;
+        | mov WORK[dst], TMP6;
+        | jmp >2;
+        |1:
+        | mov aword WORK[dst], 0;
+        |2:
+        break;
+    }
     case MVM_OP_isnonnull: {
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 obj = ins->operands[1].reg.orig;
@@ -1532,6 +1634,48 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | and TMP2b, TMP3b;
         | movzx TMP2, TMP2b;
         | mov WORK[dst], TMP2;
+        break;
+    }
+    case MVM_OP_scgethandle: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 sc  = ins->operands[1].reg.orig;
+        | mov TMP5, aword WORK[sc];
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_SCRef;
+        | je >1;
+        | throw_adhoc "Must provide an SCRef operand to scgethandle"
+        |1:
+        | mov ARG1, TC;
+        | mov ARG2, SCREF:TMP5;
+        | callp &MVM_sc_get_handle;
+        | mov WORK[dst], RV;
+        break;
+    }
+    case MVM_OP_scobjcount: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 sc  = ins->operands[1].reg.orig;
+        | mov TMP5, aword WORK[dst];
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_SCRef;
+        | je >1;
+        | throw_adhoc "Must provide an SCRef operand to scobjcount"
+        |1:
+        | mov ARG1, TC;
+        | mov ARG2, SCREF:TMP5;
+        | callp &MVM_sc_get_object_count;
+        | mov WORK[dst], RV;
+        break;
+    }
+    case MVM_OP_setobjsc: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 sc  = ins->operands[1].reg.orig;
+        | mov TMP5, WORK[sc];
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_SCRef;
+        | je >1;
+        | throw_adhoc "Must provide an SCRef operand to setobjsc"
+        |1:
+        | mov ARG1, TC;
+        | mov ARG2, aword WORK[dst];
+        | mov ARG3, SCREF:TMP5;
+        | callp &MVM_sc_set_obj_sc;
         break;
     }
     case MVM_OP_isnull: {
@@ -1648,6 +1792,23 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         |1:
         | mov qword WORK[dst], 0;
         |2:
+        break;
+    }
+    case MVM_OP_isinvokable: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 src = ins->operands[1].reg.orig;
+        | mov TMP1, aword WORK[src];
+        | mov TMP1, OBJECT:TMP1->st;
+        | mov TMP2, 1;
+        | mov64 TMP3, ((uintptr_t)(MVM_6model_invoke_default));
+        | cmp TMP3, STABLE:TMP1->invoke;
+        | jne >1;
+        | mov TMP4, STABLE:TMP1->invocation_spec;
+        | test TMP4, TMP4;
+        | jnz >1;
+        | and TMP2, TMP4;
+        |1:
+        | mov aword WORK[dst], TMP2;
         break;
     }
     case MVM_OP_takehandlerresult: {
@@ -1922,6 +2083,20 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         }
         | callp &MVM_string_ord_at;
         | mov qword WORK[dst], RV;
+        break;
+    }
+    case MVM_OP_getcodename: {
+        MVMint16 obj  = ins->operands[0].reg.orig;
+        MVMint16 code = ins->operands[1].reg.orig;
+        | mov TMP1, aword WORK[code];
+        | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCode;
+        | je >1;
+        | test_type_object TMP1;
+        | jnz >1;
+        | throw_adhoc "getcodename requires a concrete object";
+        |1:
+        | mov TMP2, CODE:TMP1->body.name;
+        | mov WORK[obj], TMP2;
         break;
     }
     case MVM_OP_setcodeobj: {

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -541,18 +541,20 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 ctx  = ins->operands[1].reg.orig;
         MVMint16 name = ins->operands[2].reg.orig;
         | mov TMP5, aword WORK[ctx];
-        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMContext;
-        | je >1;
         | test_type_object TMP5;
-        | jz >1;
-        | throw_adhoc "getlexreldyn needs a context"
-        |1:
+        | jnz >1;
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMContext;
+        | jne >1;
         | mov TMP6, CONTEXT:TMP5->body.context;
-        | mov ARG1, TC
+        | mov ARG1, TC;
         | mov ARG2, aword WORK[name];
         | mov ARG3, TMP6;
         | callp &MVM_frame_getdynlex;
         | mov WORK[dst], RV;
+        | jmp >2;
+        |1:
+        | throw_adhoc "getlexreldyn needs a context";
+        |2:
         break;
     }
     case MVM_OP_getlex_no:
@@ -878,22 +880,20 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 ctx = ins->operands[1].reg.orig;
         | mov TMP5, aword WORK[ctx];
         | test_type_object TMP5;
-        | jz >1;
+        | jnz >6;
         | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMContext;
-        | je >1;
-        | throw_adhoc "ctxcallerskipthunks needs an MVMContext";
-        |1:
+        | jne >6;
         | mov ARG1, TC;
         | mov ARG2, CONTEXT:TMP5->body.context->caller;
-        |2:
+        |1:
         | test ARG2, ARG2;
-        | jz >4;
+        | jz >3;
         | mov TMP6, FRAME:ARG2->static_info->body.is_thunk;
         | test TMP6, TMP6;
-        | jz >3;
+        | jz >2;
         | mov ARG2, FRAME:ARG2->caller;
-        | jmp >2;
-        |3:
+        | jmp >1;
+        |2:
         | callp &MVM_frame_context_wrapper;
         | mov TMP6, RV;
         | test TMP6, TMP6;
@@ -902,6 +902,10 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | get_vmnull TMP6;
         |5:
         | mov WORK[dst], TMP6;
+        | jmp >7;
+        |6:
+        | throw_adhoc "ctxcallerskipthunks needs an MVMContext";
+        |7:
         break;
     }
     case MVM_OP_curcode: {
@@ -2120,14 +2124,16 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 obj  = ins->operands[0].reg.orig;
         MVMint16 code = ins->operands[1].reg.orig;
         | mov TMP1, aword WORK[code];
-        | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCode;
-        | je >1;
         | test_type_object TMP1;
         | jnz >1;
-        | throw_adhoc "getcodename requires a concrete object";
-        |1:
+        | cmp_repr_id TMP1, TMP2, MVM_REPR_ID_MVMCode;
+        | jne >1;
         | mov TMP2, CODE:TMP1->body.name;
         | mov WORK[obj], TMP2;
+        | jmp >2;
+        |1:
+        | throw_adhoc "getcodename requires a concrete object";
+        |2:
         break;
     }
     case MVM_OP_setcodeobj: {


### PR DESCRIPTION
Adds JIT support for the following ops:
- isinvokable
- getlexreldyn
- objprimunsigned
- scgethandle
- scobjcount
- setobjsc
- getcodename
- captureposarg_i
- captureposarg_n
- captureposarg_s
- ctxcallerskipthunks
- setwho