### PR TITLE
Fix Configure.pl version detection

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -134,7 +134,7 @@ if (open(my $fh, '<', 'VERSION')) {
     close($fh);
 }
 # .git is a file and not a directory in submodule
-if (-e '.git' && open(my $GIT, '-|', "git describe")) {
+if (-e '.git' && open(my $GIT, '-|', 'git describe --tags "--match=20*"')) {
     $VERSION = <$GIT>;
     close($GIT);
 }


### PR DESCRIPTION
`Configure.pl` was sometimes giving versions based off past tags instead
of the current one.