### PR TITLE
Display build/commit info on config/make

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -15,6 +15,7 @@ RM_F   = $(PERL) -MExtUtils::Command -e rm_f
 
 MINGW_UNICODE = @mingw_unicode@
 
+VERSION_DISPLAY = @version@
 
 CONFIG    = @config@
 ADDCONFIG =
@@ -549,7 +550,7 @@ reconfig: realclean
 clangcheck gcccheck:
 	@$(MAKE) --no-print-directory -f tools/check.mk $@
 
-moar@exe@: $(MAIN_OBJECTS) @moar@
+moar@exe@: .showversion $(MAIN_OBJECTS) @moar@
 	$(MSG) linking $@
 	$(CMD)$(LD) @ldout@$@ $(LDFLAGS) $(MINGW_UNICODE) $(MAIN_OBJECTS) $(MAIN_LIBS)
 
@@ -702,6 +703,8 @@ release:
 	bash -c 'if [[ $$(git status --untracked=no --porcelain) ]]; then echo "Dirty work trees will make broken releases; maybe git stash?"; exit 1; fi'
 	./tools/release.sh $(VERSION)
 
+.showversion:
+	@echo Building MoarVM version $(VERSION_DISPLAY)...
 
 sandwich:
 	@echo What? Make it yourself.


### PR DESCRIPTION
This will be most helpful using '--gen-moar=master' when configuring
NQP or Rakudo in an environment like Travis or AppVeyor.

This PR does up the required Perl 5 version to 5.10 (due to the named
captures). I'm not sure if that is an issue or not.