### PR TITLE
Make a faster HASH_ITER macro and make other hash optimizations

### DIFF
--- a/src/6model/reprs/HashAttrStore.c
+++ b/src/6model/reprs/HashAttrStore.c
@@ -21,27 +21,25 @@ static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
 static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *dest_root, void *dest) {
     MVMHashAttrStoreBody *src_body  = (MVMHashAttrStoreBody *)src;
     MVMHashAttrStoreBody *dest_body = (MVMHashAttrStoreBody *)dest;
-    MVMHashEntry *current, *tmp;
-    unsigned bucket_tmp;
+    MVMHashEntry *current;
 
     /* NOTE: if we really wanted to, we could avoid rehashing... */
-    HASH_ITER(tc, hash_handle, src_body->hash_head, current, tmp, bucket_tmp) {
+    HASH_ITER_FAST(tc, hash_handle, src_body->hash_head, current, {
         MVMHashEntry *new_entry = MVM_malloc(sizeof(MVMHashEntry));
         MVM_ASSIGN_REF(tc, &(dest_root->header), new_entry->value, current->value);
         MVM_HASH_BIND(tc, dest_body->hash_head, MVM_HASH_KEY(current), new_entry);
-    }
+    });
 }
 
 /* Adds held objects to the GC worklist. */
 static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorklist *worklist) {
     MVMHashAttrStoreBody *body = (MVMHashAttrStoreBody *)data;
-    MVMHashEntry *current, *tmp;
-    unsigned bucket_tmp;
+    MVMHashEntry *current;
 
-    HASH_ITER(tc, hash_handle, body->hash_head, current, tmp, bucket_tmp) {
+    HASH_ITER_FAST(tc, hash_handle, body->hash_head, current, {
         MVM_gc_worklist_add(tc, worklist, &current->hash_handle.key);
         MVM_gc_worklist_add(tc, worklist, &current->value);
-    }
+    });
 }
 
 /* Called by the VM in order to free memory associated with this object. */

--- a/src/6model/reprs/MVMHash.h
+++ b/src/6model/reprs/MVMHash.h
@@ -47,10 +47,10 @@ const MVMREPROps * MVMHash_initialize(MVMThreadContext *tc);
 #define MVM_HASH_DESTROY(tc, hash_handle, hashentry_type, head_node) do { \
     hashentry_type *current, *tmp; \
     unsigned bucket_tmp; \
-    HASH_ITER(tc, hash_handle, head_node, current, tmp, bucket_tmp) { \
+    HASH_ITER_FAST(tc, hash_handle, head_node, current, { \
         if (current != head_node) \
             MVM_free(current); \
-    } \
+    }); \
     tmp = head_node; \
     HASH_CLEAR(tc, hash_handle, head_node); \
     MVM_free(tmp); \

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -21,7 +21,7 @@ void MVM_args_marked_named_used(MVMThreadContext *tc, MVMuint32 idx) {
 static void init_named_used(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint16 num) {
     ctx->named_used_size = num;
     if (num > 64)
-        ctx->named_used.byte_array = MVM_fixed_size_alloc_zeroed(tc, tc->instance->fsa, num); 
+        ctx->named_used.byte_array = MVM_fixed_size_alloc_zeroed(tc, tc->instance->fsa, num);
     else
         ctx->named_used.bit_field = 0;
 }
@@ -803,10 +803,9 @@ static void flatten_args(MVMThreadContext *tc, MVMArgProcContext *ctx) {
 
             if (arg_info.arg.o && REPR(arg_info.arg.o)->ID == MVM_REPR_ID_MVMHash) {
                 MVMHashBody *body = &((MVMHash *)arg_info.arg.o)->body;
-                MVMHashEntry *current, *tmp;
-                unsigned bucket_tmp;
+                MVMHashEntry *current;
 
-                HASH_ITER(tc, hash_handle, body->hash_head, current, tmp, bucket_tmp) {
+                HASH_ITER_FAST(tc, hash_handle, body->hash_head, current, {
                     MVMString *arg_name = MVM_HASH_KEY(current);
                     if (!seen_name(tc, arg_name, new_args, new_num_pos, new_arg_pos)) {
                         if (new_arg_pos + 1 >= new_args_size) {
@@ -820,7 +819,7 @@ static void flatten_args(MVMThreadContext *tc, MVMArgProcContext *ctx) {
                         (new_args + new_arg_pos++)->o = current->value;
                         new_arg_flags[new_flag_pos++] = MVM_CALLSITE_ARG_NAMED | MVM_CALLSITE_ARG_OBJ;
                     }
-                }
+                });
             }
             else if (arg_info.arg.o) {
                 MVM_exception_throw_adhoc(tc, "flattening of other hash reprs NYI.");

--- a/src/core/bytecodedump.c
+++ b/src/core/bytecodedump.c
@@ -404,8 +404,7 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
 
     for (k = 0; k < cu->body.num_frames; k++) {
         MVMStaticFrame *frame = get_frame(tc, cu, k);
-        MVMLexicalRegistry *current, *tmp;
-        unsigned bucket_tmp;
+        MVMLexicalRegistry *current;
         char **lexicals;
 
         if (!frame->body.fully_deserialized) {
@@ -415,11 +414,11 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
         lexicals = (char **)MVM_malloc(sizeof(char *) * frame->body.num_lexicals);
         frame_lexicals[k] = lexicals;
 
-        HASH_ITER(tc, hash_handle, frame->body.lexical_names, current, tmp, bucket_tmp) {
+        HASH_ITER(tc, hash_handle, frame->body.lexical_names, current, {
             name->body.storage.blob_32 = (MVMint32 *)current->hash_handle.key;
             name->body.num_graphs      = (MVMuint32)current->hash_handle.keylen / sizeof(MVMGrapheme32);
             lexicals[current->value]   = MVM_string_utf8_encode_C_string(tc, name);
-        }
+        });
     }
     for (k = 0; k < cu->body.num_frames; k++) {
         MVMStaticFrame *frame = get_frame(tc, cu, k);

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1357,8 +1357,7 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
     static_info = frame->static_info;
     lexical_names = static_info->body.lexical_names;
     if (lexical_names) {
-        MVMLexicalRegistry *entry, *tmp;
-        unsigned bucket_tmp;
+        MVMLexicalRegistry *entry;
         MVMuint64 lexcount = HASH_CNT(hash_handle, lexical_names);
         MVMuint64 lexical_index = 0;
 
@@ -1374,7 +1373,7 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
         if (dtc->instance->debugserver->debugspam_protocol)
             fprintf(stderr, "will write %lu lexicals\n", lexcount);
 
-        HASH_ITER(dtc, hash_handle, lexical_names, entry, tmp, bucket_tmp) {
+        HASH_ITER(dtc, hash_handle, lexical_names, entry, {
             MVMuint16 lextype = static_info->body.lexical_types[entry->value];
             MVMRegister *result = &frame->env[entry->value];
             char *c_key_name;
@@ -1448,7 +1447,7 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
             if (dtc->instance->debugserver->debugspam_protocol)
                 fprintf(stderr, "wrote a lexical\n");
             lexical_index++;
-        }
+        });
     } else {
         cmp_write_map(ctx, 3);
         cmp_write_str(ctx, "id", 2);
@@ -1900,7 +1899,7 @@ static MVMint32 request_object_metadata(MVMThreadContext *dtc, cmp_ctx_t *ctx, r
                 cmp_write_str(ctx, "nothing", 7);
         }
 
-        
+
 
         MVM_free(name);
         MVM_free(cuuid);
@@ -2119,8 +2118,6 @@ static MVMint32 request_object_associatives(MVMThreadContext *dtc, cmp_ctx_t *ct
         MVMuint64 count = HASH_CNT(hash_handle, body->hash_head);
 
         MVMHashEntry *entry = NULL;
-        MVMHashEntry *tmp = NULL;
-        unsigned bucket_tmp;
 
         cmp_write_map(ctx, 4);
         cmp_write_str(ctx, "id", 2);
@@ -2134,7 +2131,7 @@ static MVMint32 request_object_associatives(MVMThreadContext *dtc, cmp_ctx_t *ct
         cmp_write_str(ctx, "contents", 8);
         cmp_write_map(ctx, count);
 
-        HASH_ITER(dtc, hash_handle, body->hash_head, entry, tmp, bucket_tmp) {
+        HASH_ITER(dtc, hash_handle, body->hash_head, entry, {
             char *key = MVM_string_utf8_encode_C_string(dtc, entry->hash_handle.key);
             MVMObject *value = entry->value;
             char *value_debug_name = value ? MVM_6model_get_debug_name(dtc, value) : "VMNull";
@@ -2159,7 +2156,7 @@ static MVMint32 request_object_associatives(MVMThreadContext *dtc, cmp_ctx_t *ct
                 cmp_write_bool(ctx, STABLE(value)->container_spec == NULL ? 0 : 1);
 
             MVM_free(key);
-        }
+        });
     }
 }
 

--- a/src/mast/compiler.c
+++ b/src/mast/compiler.c
@@ -264,8 +264,7 @@ static void cleanup_frame(VM, FrameState *fs) {
 
 /* Cleans up all allocated memory related to this compilation. */
 static void cleanup_all(VM, WriterState *ws) {
-    CallsiteReuseEntry *current, *tmp;
-    unsigned bucket_tmp;
+    CallsiteReuseEntry *current;
     if (ws->cur_frame)
         cleanup_frame(vm, ws->cur_frame);
     if (ws->scdep_seg)
@@ -280,9 +279,9 @@ static void cleanup_all(VM, WriterState *ws) {
         MVM_free(ws->bytecode_seg);
     if (ws->annotation_seg)
         MVM_free(ws->annotation_seg);
-    HASH_ITER(tc, hash_handle, ws->callsite_reuse_head, current, tmp, bucket_tmp) {
+    HASH_ITER_FAST(tc, hash_handle, ws->callsite_reuse_head, current, {
         MVM_free(current->identifier);
-    }
+    });
     MVM_HASH_DESTROY(tc, hash_handle, CallsiteReuseEntry, ws->callsite_reuse_head);
     MVM_free(ws);
 }

--- a/src/moar.h
+++ b/src/moar.h
@@ -46,6 +46,15 @@ typedef uint64_t MVMuint64;
 typedef float    MVMnum32;
 typedef double   MVMnum64;
 
+/* MSVC Wants i64 and ui64 suffixes instead of LL and ULL */
+#if _MSC_VER
+    #define MVM_C_CONSTANT_I64(number) number ## i64
+    #define MVM_C_CONSTANT_U64(number) number ## ui64
+#else
+    #define MVM_C_CONSTANT_I64(number) number ## LL
+    #define MVM_C_CONSTANT_U64(number) number ## ULL
+#endif
+
 /* Alignment. */
 #if HAVE_ALIGNOF
 /* A GCC extension. */

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -1050,8 +1050,6 @@ void MVM_unicode_release(MVMThreadContext *tc)
 
         for (i = 0; i < MVM_NUM_PROPERTY_CODES; i++) {
             MVMUnicodeNameRegistry *entry = NULL;
-            MVMUnicodeNameRegistry *tmp   = NULL;
-            unsigned bucket_tmp;
             int j;
 
             if (!unicode_property_values_hashes[i]) {
@@ -1064,10 +1062,10 @@ void MVM_unicode_release(MVMThreadContext *tc)
                 }
             }
 
-            HASH_ITER(tc, hash_handle, unicode_property_values_hashes[i], entry, tmp, bucket_tmp) {
+            HASH_ITER_FAST(tc, hash_handle, unicode_property_values_hashes[i], entry, {
                 HASH_DELETE(hash_handle, unicode_property_values_hashes[i], entry);
                 MVM_free(entry);
-            }
+            });
             assert(!unicode_property_values_hashes[i]);
         }
 

--- a/src/strings/uthash_types.h
+++ b/src/strings/uthash_types.h
@@ -1,6 +1,10 @@
 #ifndef UTHASH_TYPES
 #define UTHASH_TYPES
+/* If set to 1, will throw if you add a key to the hash during iteration. */
 #define MVM_HASH_THROW_ON_ITER_AFTER_ADD_KEY 0
+/* If set to 1, will randomize bucket iteration order and bucket insertion order.
+ * HASH_ITER_FAST is not affected by iteration order randomization. */
+#define MVM_HASH_RANDOMIZE 1
 typedef struct UT_hash_bucket {
    struct UT_hash_handle *hh_head;
    unsigned count;
@@ -19,6 +23,12 @@ typedef struct UT_hash_bucket {
     */
    unsigned expand_mult;
 } UT_hash_bucket;
+
+#if 8 <= MVM_PTR_SIZE
+   typedef MVMuint64 MVM_UT_bucket_rand;
+#else
+   typedef MVMuint32 MVM_UT_bucket_rand;
+#endif
 
 typedef struct UT_hash_table {
    UT_hash_bucket *buckets;
@@ -42,15 +52,10 @@ typedef struct UT_hash_table {
     * function isn't a good fit for the key domain. When expansion is inhibited
     * the hash will still work, albeit no longer in constant time. */
    unsigned ineff_expands, noexpand;
-#if 8 <= MVM_PTR_SIZE
-   MVMuint64 bucket_rand;
+#if MVM_HASH_RANDOMIZE
+   MVM_UT_bucket_rand bucket_rand;
 #  if MVM_HASH_THROW_ON_ITER_AFTER_ADD_KEY
    MVMuint64 bucket_rand_last;
-#  endif
-#else
-   MVMuint32 bucket_rand;
-#  if MVM_HASH_THROW_ON_ITER_AFTER_ADD_KEY
-   MVMuint32 bucket_rand_last;
 #  endif
 #endif
 } UT_hash_table;


### PR DESCRIPTION
HASH_ITER_FAST is faster and it doesn't randomize bucket order (though
it's faster regardless of that).

Makes the biggest difference when we are iterating a hash with a LOT of
keys in it, such as adding a million keys to a hash then deleting and
adding back again. Got about 40% speed improvement on this nqp script:
https://gist.github.com/9a65a586ea21b20def8efe4aaaab55de

Also optimize GET_X_BITS by making a switch out of it. It doesn't seem
like this would be faster, but it is due to compiler optimizations.