### PR TITLE
Remove previous hash handle pointers in hash implementation

### DIFF
--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -127,10 +127,9 @@ static MVMint64 exists_key(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
 static void delete_key(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMObject *key_obj) {
     MVMHashBody *body = (MVMHashBody *)data;
     MVMString *key = get_string_key(tc, key_obj);
-    MVMHashEntry *old_entry = NULL;
-    MVM_HASH_GET(tc, body->hash_head, key, old_entry);
+    MVMHashEntry *old_entry = NULL, *prev_entry = NULL;
+    HASH_FIND_VM_STR_AND_DELETE(tc, hash_handle, body->hash_head, key, old_entry, prev_entry);
     if (old_entry) {
-        HASH_DELETE(hash_handle, body->hash_head, old_entry);
         MVM_fixed_size_free(tc, tc->instance->fsa,
             sizeof(MVMHashEntry), old_entry);
     }

--- a/src/6model/reprs/SCRef.c
+++ b/src/6model/reprs/SCRef.c
@@ -107,13 +107,14 @@ static void SCRef_gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGC
 /* Called by the VM in order to free memory associated with this object. */
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMSerializationContext *sc = (MVMSerializationContext *)obj;
+    MVMSerializationContextBody  *entry, *prev;
 
     if (sc->body == NULL)
         return;
 
     /* Remove from weakref lookup hash (which doesn't count as a root). */
     uv_mutex_lock(&tc->instance->mutex_sc_registry);
-    HASH_DELETE(hash_handle, tc->instance->sc_weakhash, sc->body);
+    HASH_FIND_AND_DELETE(hash_handle, tc->instance->sc_weakhash, sc->body, sizeof(*(sc->body)), entry, prev);
     tc->instance->all_scs[sc->body->sc_idx] = NULL;
     uv_mutex_unlock(&tc->instance->mutex_sc_registry);
 

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -1061,11 +1061,7 @@ void MVM_unicode_release(MVMThreadContext *tc)
                     unicode_property_values_hashes[j] = NULL;
                 }
             }
-
-            HASH_ITER_FAST(tc, hash_handle, unicode_property_values_hashes[i], entry, {
-                HASH_DELETE(hash_handle, unicode_property_values_hashes[i], entry);
-                MVM_free(entry);
-            });
+            MVM_HASH_DESTROY(tc, hash_handle, MVMUnicodeNameRegistry, unicode_property_values_hashes[i]);
             assert(!unicode_property_values_hashes[i]);
         }
 

--- a/src/strings/uthash_types.h
+++ b/src/strings/uthash_types.h
@@ -61,8 +61,7 @@ typedef struct UT_hash_table {
 } UT_hash_table;
 
 typedef struct UT_hash_handle {
-   struct UT_hash_table *tbl;
-   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
+   struct UT_hash_table  *tbl;
    struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
    void *key;                        /* ptr to enclosing struct's key (char * for
                                       * low-level hashes, MVMString * for high level


### PR DESCRIPTION
This makes each hash handle 8 bytes (on 64-bit) smaller. It results in a
speedup on my hash speed test by ~1% as well (likely due to more entries
fitting in the cache) and reduces memory by 8MB with a million hash
entries. The test wastes about half cpu on GC so likely the speed
increase is at least 3% or more if just taking the hash impl. code into
account.

Main changes to the code is adding additional functions that don't just
find the hash pointer, but its previous entry (since we don't store it
in the pointer itself anymore).

A convenience HASH_FIND_AND_DELETE has been added which acts just like
the old HASH_DELETE performed while also letting us use HASH_FIND_prev
in places where we want to access the found object before then calling
HASH_DELETE on it.