### PR TITLE
Rm 'unsafe' templates already in core_templates

### DIFF
--- a/src/jit/unsafe.expr
+++ b/src/jit/unsafe.expr
@@ -10,45 +10,12 @@
               (arglist 1 (carg (tc) ptr)))
        (^exit)))
 
-(template: return_o
-  (do 3
-     (call (^func &MVM_args_set_result_obj)
-           (arglist
-              (carg (tc) ptr)
-              (carg $0 ptr)
-              (carg (const 0 int_sz) int))
-           void)
-     (call (^func &MVM_frame_try_return)
-           (arglist 1 (carg (tc) ptr))
-           void)
-     (^exit)))
-
-(template: setdispatcher
-  (^setf (tc) MVMThreadContext cur_dispatcher $0))
-
-(template: takedispatcher
-  (let: (($cur (^getf (tc) MVMThreadContext cur_dispatcher)))
-        (do
-           (^setf (tc) MVMThreadContext cur_dispatcher (const 0 ptr_sz))
-           (copy $cur))))
-
-
-(template: getcode
-  (let: (($arr (^getf (cu) MVMCompUnit body.coderefs)))
-        (load (idx $arr $1 ptr_sz) ptr_sz)))
-
-(template: callercode
-  (let: (($caller (^getf (frame) MVMFrame caller)))
-        (if (nz $caller)
-            (^getf $caller MVMFrame code_ref)
-            (const 0 ptr_sz))))
-
 
 (macro: ^throw_adhoc (,msg)
    (die (^func &MVM_exception_throw_adhoc)
         (arglist 2 (carg (tc) ptr)
                     (carg (const ,msg ptr_sz) ptr))))
-       
+
 # These properly yield a flag, not a register value.
 # I maybe want to add a flag-to-register op
 


### PR DESCRIPTION
These templates have working versions in src/jit/core_templates.expr