### PR TITLE
JIT neg_I and abs_I

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3301,17 +3301,13 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             }
             OP(neg_I): {
                 MVMObject *   const type = GET_REG(cur_op, 4).o;
-                MVMObject * const result = MVM_repr_alloc_init(tc, type);
-                MVM_bigint_neg(tc, result, GET_REG(cur_op, 2).o);
-                GET_REG(cur_op, 0).o = result;
+                GET_REG(cur_op, 0).o = MVM_bigint_neg(tc, type, GET_REG(cur_op, 2).o);
                 cur_op += 6;
                 goto NEXT;
             }
             OP(abs_I): {
                 MVMObject *   const type = GET_REG(cur_op, 4).o;
-                MVMObject * const result = MVM_repr_alloc_init(tc, type);
-                MVM_bigint_abs(tc, result, GET_REG(cur_op, 2).o);
-                GET_REG(cur_op, 0).o = result;
+                GET_REG(cur_op, 0).o = MVM_bigint_abs(tc, type, GET_REG(cur_op, 2).o);
                 cur_op += 6;
                 goto NEXT;
             }

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -1441,14 +1441,14 @@
     (arglist
       (carg (tc) ptr)
       (carg $2   ptr)
-      (carg $1   ptr)) int_sz))
+      (carg $1   ptr)) ptr_sz))
 
 (template: abs_I
   (call (^func &MVM_bigint_abs)
     (arglist
       (carg (tc) ptr)
       (carg $2   ptr)
-      (carg $1   ptr)) int_sz))
+      (carg $1   ptr)) ptr_sz))
 
 (template: cmp_I
   (call (^func &MVM_bigint_cmp)

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -1436,6 +1436,20 @@
       (carg $1   ptr)
       (carg $2   ptr)) ptr_sz))
 
+(template: neg_I
+  (call (^func &MVM_bigint_neg)
+    (arglist
+      (carg (tc) ptr)
+      (carg $2   ptr)
+      (carg $1   ptr)) int_sz))
+
+(template: abs_I
+  (call (^func &MVM_bigint_abs)
+    (arglist
+      (carg (tc) ptr)
+      (carg $2   ptr)
+      (carg $1   ptr)) int_sz))
+
 (template: cmp_I
   (call (^func &MVM_bigint_cmp)
     (arglist

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -276,6 +276,8 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_sub_I: return MVM_bigint_sub;
     case MVM_OP_mul_I: return MVM_bigint_mul;
     case MVM_OP_div_I: return MVM_bigint_div;
+    case MVM_OP_neg_I: return MVM_bigint_neg;
+    case MVM_OP_abs_I: return MVM_bigint_abs;
     case MVM_OP_bor_I: return MVM_bigint_or;
     case MVM_OP_band_I: return MVM_bigint_and;
     case MVM_OP_bxor_I: return MVM_bigint_xor;
@@ -2826,6 +2828,18 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
                                  { MVM_JIT_REG_VAL, { src_a } },
                                  { MVM_JIT_REG_VAL, { src_b } } };
         jg_append_call_c(tc, jg, op_to_func(tc, op), 4, args,
+                          MVM_JIT_RV_PTR, dst);
+        break;
+    }
+    case MVM_OP_neg_I:
+    case MVM_OP_abs_I: {
+        MVMint16 src  = ins->operands[1].reg.orig;
+        MVMint16 type = ins->operands[2].reg.orig;
+        MVMint16 dst  = ins->operands[0].reg.orig;
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { type } },
+                                 { MVM_JIT_REG_VAL, { src } } };
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 3, args,
                           MVM_JIT_RV_PTR, dst);
         break;
     }

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -323,8 +323,13 @@ static void two_complement_shl(mp_int *result, mp_int *value, MVMint64 count) {
 }
 
 #define MVM_BIGINT_UNARY_OP(opname, SMALLINT_OP) \
-void MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result, MVMObject *source) { \
-    MVMP6bigintBody *bb = get_bigint_body(tc, result); \
+MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MVMObject *source) { \
+    MVMP6bigintBody *bb; \
+    MVMObject *result; \
+    MVMROOT(tc, source, { \
+        result = MVM_repr_alloc_init(tc, result_type);\
+    }); \
+    bb = get_bigint_body(tc, result); \
     if (!IS_CONCRETE(source)) { \
         store_int64_result(bb, 0); \
     } \
@@ -345,6 +350,7 @@ void MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result, MVMObject *sou
             store_int64_result(bb, sb); \
         } \
     } \
+    return result; \
 }
 
 #define MVM_BIGINT_BINARY_OP(opname) \

--- a/src/math/bigintops.h
+++ b/src/math/bigintops.h
@@ -1,8 +1,8 @@
 int MVM_bigint_mp_set_uint64(mp_int * a, MVMuint64 b);
 
-MVMObject * MVM_bigint_abs(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
-MVMObject * MVM_bigint_neg(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
-MVMObject * MVM_bigint_not(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
+MVMObject * MVM_bigint_abs(MVMThreadContext *tc, MVMObject *result_type, MVMObject *a);
+MVMObject * MVM_bigint_neg(MVMThreadContext *tc, MVMObject *result_type, MVMObject *a);
+MVMObject * MVM_bigint_not(MVMThreadContext *tc, MVMObject *result_type, MVMObject *a);
 /* unused */
 /* void MVM_bigint_sqrt(MVMObject *b, MVMObject *a); */
 

--- a/src/math/bigintops.h
+++ b/src/math/bigintops.h
@@ -1,7 +1,7 @@
 int MVM_bigint_mp_set_uint64(mp_int * a, MVMuint64 b);
 
-void MVM_bigint_abs(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
-void MVM_bigint_neg(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
+MVMObject * MVM_bigint_abs(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
+MVMObject * MVM_bigint_neg(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
 MVMObject * MVM_bigint_not(MVMThreadContext *tc, MVMObject *result, MVMObject *a);
 /* unused */
 /* void MVM_bigint_sqrt(MVMObject *b, MVMObject *a); */


### PR DESCRIPTION
Rewrite the MVM_BIGINT_UNARY_OP macro the same way as was done for the
MVM_BIGINT_BINARY_OP macro so it can be JITted.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.