### PR TITLE
Fix Multiple Statevar Initialization Bugs

### DIFF
--- a/src/6model/reprs/MVMCode.c
+++ b/src/6model/reprs/MVMCode.c
@@ -69,6 +69,7 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMCode *code_obj = (MVMCode *)obj;
     MVM_free(code_obj->body.state_vars);
+    MVM_free(code_obj->body.state_vars_is_hll_init);
 }
 
 static const MVMStorageSpec storage_spec = {

--- a/src/6model/reprs/MVMCode.h
+++ b/src/6model/reprs/MVMCode.h
@@ -6,6 +6,7 @@ struct MVMCodeBody {
     MVMObject      *code_object;
     MVMString      *name;
     MVMRegister    *state_vars;
+    MVMuint8       *state_vars_is_hll_init;
     MVMuint16       is_static;
     MVMuint16       is_compiler_stub;
 };

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1650,15 +1650,14 @@ void MVM_frame_binddynlex(MVMThreadContext *tc, MVMString *name, MVMObject *valu
     }
 }
 
-/* Returns the storage unit for the lexical in the specified frame. Does not
- * try to vivify anything - gets exactly what is there. */
-MVMRegister * MVM_frame_lexical(MVMThreadContext *tc, MVMFrame *f, MVMString *name) {
+/* Returns the index in the env array for the lexical in the specified frame. */
+MVMint64 MVM_frame_lexical_idx(MVMThreadContext *tc, MVMFrame *f, MVMString *name) {
     MVMLexicalRegistry *lexical_names = f->static_info->body.lexical_names;
     if (MVM_LIKELY(lexical_names != NULL)) {
         MVMLexicalRegistry *entry;
         MVM_HASH_GET(tc, lexical_names, name, entry)
         if (entry)
-            return &f->env[entry->value];
+            return entry->value;
     }
     {
         char *c_name = MVM_string_utf8_encode_C_string(tc, name);
@@ -1666,6 +1665,12 @@ MVMRegister * MVM_frame_lexical(MVMThreadContext *tc, MVMFrame *f, MVMString *na
         MVM_exception_throw_adhoc_free(tc, waste, "Frame has no lexical with name '%s'",
             c_name);
     }
+}
+
+/* Returns the storage unit for the lexical in the specified frame. Does not
+ * try to vivify anything - gets exactly what is there. */
+MVMRegister * MVM_frame_lexical(MVMThreadContext *tc, MVMFrame *f, MVMString *name) {
+    return &f->env[ MVM_frame_lexical_idx(tc, f, name) ];
 }
 
 /* Returns the storage unit for the lexical in the specified frame. */

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -594,8 +594,11 @@ void MVM_frame_invoke(MVMThreadContext *tc, MVMStaticFrame *static_frame,
                         }
                         else {
                             /* Allocate storage for state vars. */
+                            MVMCode *cref = (MVMCode *)frame->code_ref;
+
                             state = (MVMRegister *)MVM_calloc(1, frame->static_info->body.env_size);
-                            ((MVMCode *)frame->code_ref)->body.state_vars = state;
+                            cref->body.state_vars = state;
+                            cref->body.state_vars_is_hll_init = (MVMuint8 *)MVM_calloc(1, numlex);
                             state_act = 1;
 
                             /* Note that this frame should run state init code. */

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -598,7 +598,8 @@ void MVM_frame_invoke(MVMThreadContext *tc, MVMStaticFrame *static_frame,
 
                             state = (MVMRegister *)MVM_calloc(1, frame->static_info->body.env_size);
                             cref->body.state_vars = state;
-                            cref->body.state_vars_is_hll_init = (MVMuint8 *)MVM_calloc(1, numlex);
+                            cref->body.state_vars_is_hll_init
+                                = (MVMuint8 *)MVM_calloc(1, MVM_BITARR8_BYTES_NEEDED(numlex));
                             state_act = 1;
 
                             /* Note that this frame should run state init code. */

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -246,6 +246,7 @@ MVMObject * MVM_frame_getdynlex_with_frame_walker(MVMThreadContext *tc, MVMSpesh
         MVMString *name);
 MVMObject * MVM_frame_getdynlex(MVMThreadContext *tc, MVMString *name, MVMFrame *cur_frame);
 void MVM_frame_binddynlex(MVMThreadContext *tc, MVMString *name, MVMObject *value, MVMFrame *cur_frame);
+MVMint64 MVM_frame_lexical_idx(MVMThreadContext *tc, MVMFrame *f, MVMString *name);
 MVMRegister * MVM_frame_lexical(MVMThreadContext *tc, MVMFrame *f, MVMString *name);
 MVM_PUBLIC MVMRegister * MVM_frame_try_get_lexical(MVMThreadContext *tc, MVMFrame *f, MVMString *name, MVMuint16 type);
 MVMuint16 MVM_frame_translate_to_primspec(MVMThreadContext *tc, MVMuint16 kind);

--- a/src/moar.h
+++ b/src/moar.h
@@ -253,3 +253,8 @@ AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t
  * which the other atomic operation macros are used... */
 #define MVM_store(addr, new) AO_store_full((volatile AO_t *)(addr), (AO_t)(new))
 #define MVM_load(addr) AO_load_full((volatile AO_t *)(addr))
+
+/* Set and check bit flags in variable byte bit array by number */
+#define MVM_BITARR8_BYTES_NEEDED(n) ((n) / 8 + ((n) % 8 ? 1 : 0))
+#define MVM_BITARR8_CHECK(var, n)   ((var)[(n) / 8] &  1 << (n) % 8)
+#define MVM_BITARR8_SET(var, n)     ((var)[(n) / 8] |= 1 << (n) % 8)


### PR DESCRIPTION
This PR is one part of a series spanning the MoarVM, NQP, and Rakudo repositories.
[NQP]
[Rakudo]

This series of PRs modifies the state init check to instead keep a record of the statevars that have been 'HLL init-ed' and have that value determine whether to perform the assignment or not. If the statevar is not assigned to on the first invocation, it is shown as needing assignment the next time it is encountered despite what the MVM_FRAME_FLAG_STATE_INIT value is. If the statevar has been assigned to already and is encountered again within the same frame invocation (as the C-style loop example below), it is aware the that assignment has occurred and does not repeat it.

I had submitted a PR similar to this in the past, but this one has been rebased to a much newer HEAD and changed enough to the point that it feels appropriate to open a new PR.

### Specific modifications made are:

* Modified the ```p6stateinit``` extop to take a symbol as an argument. Within the function, lookup that symbol within the frame's lexical registry and determine whether the 'HLL assignment' has taken place. If so, do not assign again.

  * The value that persists whether an 'HLL assignment' has taken place is stored in the CodeRef object (alongside the statevar values themselves), which is unique to each closure. This 'isHllInit' value is a variable-length bit array, with each lexical represented by one bit.

* Added a new extop, ```p6stateinitbulk```, that will take a list of symbols and check multiple in one extop execution (for use in destructuring state assignments)

* Implemented for both the MoarVM and JVM backends.

### Issue being addressed:

In the past, we have determined whether to perform an assignment to a state variable by determining whether or not it was the first invocation of a closure (or clone of a frame). In MoarVM, an MVM_FRAME_FLAG_STATE_INIT value is set on the first frame of a given closure.

This works most of the time, but there are some instances where this is producing undesired results (see [RT #102994](https://rt.perl.org/Public/Bug/Display.html?id=102994))

```perl6
sub f($x) {
    return if $x;
    state $y = 5;
    $y;
} 

f(1);
say f(0);
# OUTPUT:   (Any)
# EXPECTED: 5
```

Since during the first invocation of this closure (when MVM_FRAME_FLAG_STATE_INIT is set) the statevar is not assigned to, on the next invocation the assignment is skipped and the unassigned value (Any) is returned.

In the case of 'once' with a C-style loop conditional (see [GH issue 1684](https://github.com/rakudo/rakudo/issues/1684)), this method also produces some unexpected results.

```perl6
loop (my $i = 0; $i < once { print $i; 10 }; ++$i ) { }
# OUTPUT:   012345678910
# EXPECTED: 0
```

In this case, the 'once' appears in the e2 expression in the C-style loop. The statevar init check occurs within the loop conditional and is executed multiple times within the same initial closure invocation. Because of this, MVM_FRAME_FLAG_STATE_INIT is set and the code within the block (containing print) is executed for each iteration.
