### PR TITLE
Use the pointer dereference instead of the pointer.

### DIFF
--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -553,7 +553,7 @@ static void async_read(uv_stream_t *handle, ssize_t nread, const uv_buf_t *buf, 
             si->last_read = nread;
 
             /* Update permit count, stop reading if we run out. */
-            if (permit > 0) {
+            if (*permit > 0) {
                 (*permit)--;
                 if (*permit == 0) {
                     uv_read_stop(handle);


### PR DESCRIPTION
This fixes an obvious typo, since using a pointer comparison in the
condition does not make sense.