### PR TITLE
JIT decoder(empty|takebytes)

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -235,6 +235,8 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_encode: return MVM_string_encode_to_buf;
     case MVM_OP_decoderaddbytes: return MVM_decoder_add_bytes;
     case MVM_OP_decodertakeline: return MVM_decoder_take_line;
+    case MVM_OP_decodertakebytes: return MVM_decoder_take_bytes;
+    case MVM_OP_decoderempty: return MVM_decoder_empty;
 
     case MVM_OP_elems: return MVM_repr_elems;
     case MVM_OP_concat_s: return MVM_string_concatenate;
@@ -2769,6 +2771,22 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         jg_append_call_c(tc, jg, op_to_func(tc, op), 3, args, MVM_JIT_RV_VOID, -1);
         break;
     }
+    case MVM_OP_decodertakebytes: {
+        MVMint16 dst     = ins->operands[0].reg.orig;
+        MVMint16 decoder = ins->operands[1].reg.orig;
+        MVMint16 chomp   = ins->operands[2].reg.orig;
+        MVMint16 inc     = ins->operands[3].reg.orig;
+        MVMJitCallArg argc[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { decoder } },
+                                 { MVM_JIT_LITERAL_PTR, { (MVMint64)"decodertakebytes" } } };
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { decoder } },
+                                 { MVM_JIT_REG_VAL, { chomp } },
+                                 { MVM_JIT_REG_VAL, { inc } } };
+        jg_append_call_c(tc, jg, &MVM_decoder_ensure_decoder, 3, argc, MVM_JIT_RV_VOID, -1);
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 4, args, MVM_JIT_RV_PTR, dst);
+        break;
+    }
     case MVM_OP_decodertakeline: {
         MVMint16 dst     = ins->operands[0].reg.orig;
         MVMint16 decoder = ins->operands[1].reg.orig;
@@ -2783,6 +2801,18 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
                                  { MVM_JIT_REG_VAL, { inc } } };
         jg_append_call_c(tc, jg, &MVM_decoder_ensure_decoder, 3, argc, MVM_JIT_RV_VOID, -1);
         jg_append_call_c(tc, jg, op_to_func(tc, op), 4, args, MVM_JIT_RV_PTR, dst);
+        break;
+    }
+    case MVM_OP_decoderempty: {
+        MVMint16 dst     = ins->operands[0].reg.orig;
+        MVMint16 decoder = ins->operands[1].reg.orig;
+        MVMJitCallArg argc[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { decoder } },
+                                 { MVM_JIT_LITERAL_PTR, { (MVMint64)"decodertakeline" } } };
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { decoder } } };
+        jg_append_call_c(tc, jg, &MVM_decoder_ensure_decoder, 3, argc, MVM_JIT_RV_VOID, -1);
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 2, args, MVM_JIT_RV_PTR, dst);
         break;
     }
         /* bigint ops */

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -2763,7 +2763,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         MVMint16 bytes   = ins->operands[1].reg.orig;
         MVMJitCallArg argc[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } },
-                                 { MVM_JIT_LITERAL_PTR, { (MVMint64)"decoderaddbytes" } } };
+                                 { MVM_JIT_LITERAL_PTR, { (uintptr_t)"decoderaddbytes" } } };
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } },
                                  { MVM_JIT_REG_VAL, { bytes } } };
@@ -2778,7 +2778,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         MVMint16 inc     = ins->operands[3].reg.orig;
         MVMJitCallArg argc[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } },
-                                 { MVM_JIT_LITERAL_PTR, { (MVMint64)"decodertakebytes" } } };
+                                 { MVM_JIT_LITERAL_PTR, { (uintptr_t)"decodertakebytes" } } };
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } },
                                  { MVM_JIT_REG_VAL, { chomp } },
@@ -2794,7 +2794,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         MVMint16 inc     = ins->operands[3].reg.orig;
         MVMJitCallArg argc[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } },
-                                 { MVM_JIT_LITERAL_PTR, { (MVMint64)"decodertakeline" } } };
+                                 { MVM_JIT_LITERAL_PTR, { (uintptr_t)"decodertakeline" } } };
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } },
                                  { MVM_JIT_REG_VAL, { chomp } },
@@ -2808,7 +2808,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         MVMint16 decoder = ins->operands[1].reg.orig;
         MVMJitCallArg argc[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } },
-                                 { MVM_JIT_LITERAL_PTR, { (MVMint64)"decodertakeline" } } };
+                                 { MVM_JIT_LITERAL_PTR, { (uintptr_t)"decodertakeline" } } };
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { decoder } } };
         jg_append_call_c(tc, jg, &MVM_decoder_ensure_decoder, 3, argc, MVM_JIT_RV_VOID, -1);


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

This gets rid of some BAILs I saw when using Compress::Zlib. However, it seemed to actually make it slightly slower (roughly from 6.4s before to 6.6s after when `gzslurp`ing a 975k file). @bdw any idea why?