### PR TITLE
Speedup zero_slots by using memset...

### DIFF
--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -259,52 +259,40 @@ static MVMuint64 zero_slots(MVMThreadContext *tc, MVMArrayBody *body,
         MVMuint64 elems, MVMuint64 ssize, MVMuint8 slot_type) {
     switch (slot_type) {
         case MVM_ARRAY_OBJ:
-            while (elems < ssize)
-                body->slots.o[elems++] = NULL;
+            memset(&(body->slots.o[elems]), 0, (ssize - elems) * sizeof(MVMObject *));
             break;
         case MVM_ARRAY_STR:
-            while (elems < ssize)
-                body->slots.s[elems++] = NULL;
+            memset(&(body->slots.s[elems]), 0, (ssize - elems) * sizeof(MVMString *));
             break;
         case MVM_ARRAY_I64:
-            while (elems < ssize)
-                body->slots.i64[elems++] = 0;
+            memset(&(body->slots.i64[elems]), 0, (ssize - elems) * sizeof(MVMint64));
             break;
         case MVM_ARRAY_I32:
-            while (elems < ssize)
-                body->slots.i32[elems++] = 0;
+            memset(&(body->slots.i32[elems]), 0, (ssize - elems) * sizeof(MVMint32));
             break;
         case MVM_ARRAY_I16:
-            while (elems < ssize)
-                body->slots.i16[elems++] = 0;
+            memset(&(body->slots.i16[elems]), 0, (ssize - elems) * sizeof(MVMint16));
             break;
         case MVM_ARRAY_I8:
-            while (elems < ssize)
-                body->slots.i8[elems++] = 0;
+            memset(&(body->slots.i8[elems]), 0, (ssize - elems) * sizeof(MVMint8));
             break;
         case MVM_ARRAY_N64:
-            while (elems < ssize)
-                body->slots.n64[elems++] = 0.0;
+            memset(&(body->slots.n64[elems]), 0, (ssize - elems) * sizeof(MVMnum64));
             break;
         case MVM_ARRAY_N32:
-            while (elems < ssize)
-                body->slots.n32[elems++] = 0.0;
+            memset(&(body->slots.n32[elems]), 0, (ssize - elems) * sizeof(MVMnum32));
             break;
         case MVM_ARRAY_U64:
-            while (elems < ssize)
-                body->slots.u64[elems++] = 0;
+            memset(&(body->slots.u64[elems]), 0, (ssize - elems) * sizeof(MVMuint64));
             break;
         case MVM_ARRAY_U32:
-            while (elems < ssize)
-                body->slots.u32[elems++] = 0;
+            memset(&(body->slots.u32[elems]), 0, (ssize - elems) * sizeof(MVMuint32));
             break;
         case MVM_ARRAY_U16:
-            while (elems < ssize)
-                body->slots.u16[elems++] = 0;
+            memset(&(body->slots.u16[elems]), 0, (ssize - elems) * sizeof(MVMuint16));
             break;
         case MVM_ARRAY_U8:
-            while (elems < ssize)
-                body->slots.u8[elems++] = 0;
+            memset(&(body->slots.u8[elems]), 0, (ssize - elems) * sizeof(MVMuint8));
             break;
         default:
             MVM_exception_throw_adhoc(tc, "MVMArray: Unhandled slot type");


### PR DESCRIPTION
instead of looping over the array and setting each element.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

This test case `use Compress::Zlib; my $a = gzslurp("100k.txt.gz"); say $a.lines.elems; say now - INIT now` (where `100k.txt.gz` is 2mb and decompresses to 6.8mb) used to take ~10.2s and now takes ~9.7s. Additionally, `zero_slots` used to be 2nd most expensive in a perf report, but now it's not even in the top 30.