### PR TITLE
Use correct types in find_deopt_target_and_index

### DIFF
--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1313,7 +1313,7 @@ MVMuint32 find_invoke_offset(MVMThreadContext *tc, MVMSpeshIns *ins) {
 /* Given an instruction, finds the deopt target on it. Panics if there is not
  * one there. */
 void find_deopt_target_and_index(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns *ins,
-                                 MVMint32 *deopt_target_out, MVMint32 *deopt_index_out) {
+                                 MVMuint32 *deopt_target_out, MVMuint32 *deopt_index_out) {
     MVMSpeshAnn *deopt_ann = ins->annotations;
     while (deopt_ann) {
         if (deopt_ann->type == MVM_SPESH_ANN_DEOPT_ONE_INS) {


### PR DESCRIPTION
The signature had MVMint32 for the deopt_target_out and deopt_index_out
parameters, but they were only ever passed MVMuint32s.

Silences clang warnings.