### PR TITLE
Fix Spesh Memory Leaks

### DIFF
--- a/src/core/regionalloc.c
+++ b/src/core/regionalloc.c
@@ -43,3 +43,15 @@ void MVM_region_destroy(MVMThreadContext *tc, MVMRegionAlloc *alloc) {
     }
     alloc->block = NULL;
 }
+
+/* Link source region into target region, so they can be cleaned up as one */
+void MVM_region_merge(MVMThreadContext *tc, MVMRegionAlloc *target, MVMRegionAlloc *source) {
+    MVMRegionBlock *block = source->block;
+    while (block != NULL) {
+        MVMRegionBlock *prev = block->prev;
+        block->prev = target->block->prev;
+        target->block->prev = block;
+        block = prev;
+    }
+    source->block = NULL;
+}

--- a/src/core/regionalloc.h
+++ b/src/core/regionalloc.h
@@ -24,3 +24,4 @@ struct MVMRegionAlloc {
 
 void * MVM_region_alloc(MVMThreadContext *tc, MVMRegionAlloc *alloc, size_t s);
 void MVM_region_destroy(MVMThreadContext *tc, MVMRegionAlloc *alloc);
+void MVM_region_merge(MVMThreadContext *tc,  MVMRegionAlloc *target, MVMRegionAlloc *source);

--- a/src/moar.c
+++ b/src/moar.c
@@ -591,8 +591,6 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     uv_mutex_destroy(&instance->nfg->update_mutex);
     MVM_nfg_destroy(instance->main_thread);
 
-    /* Clean up fixed size allocator */
-    MVM_fixed_size_destroy(instance->fsa);
 
     /* Clean up integer constant and string cache. */
     uv_mutex_destroy(&instance->mutex_int_const_cache);
@@ -605,6 +603,9 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     /* Destroy main thread contexts and thread list mutex. */
     MVM_tc_destroy(instance->main_thread);
     uv_mutex_destroy(&instance->mutex_threads);
+
+    /* Clean up fixed size allocator */
+    MVM_fixed_size_destroy(instance->fsa);
 
     /* Clear up VM instance memory. */
     MVM_free(instance);

--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -137,7 +137,7 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
     candidate->num_spesh_slots = sg->num_spesh_slots;
     candidate->spesh_slots     = sg->spesh_slots;
 
-    /* Claim ownership of allocated memory by candidate */
+    /* Claim ownership of allocated memory assigned to the candidate */
     sg->cand = candidate;
     MVM_spesh_graph_destroy(tc, sg);
 
@@ -196,4 +196,5 @@ void MVM_spesh_candidate_destroy(MVMThreadContext *tc, MVMSpeshCandidate *candid
     MVM_free(candidate->lexical_types);
     if (candidate->jitcode)
         MVM_jit_code_destroy(tc, candidate->jitcode);
+    MVM_free(candidate);
 }

--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -137,15 +137,8 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
     candidate->num_spesh_slots = sg->num_spesh_slots;
     candidate->spesh_slots     = sg->spesh_slots;
 
-    /* Clean up after specialization work. */
-    if (candidate->num_inlines) {
-        MVMint32 i;
-        for (i = 0; i < candidate->num_inlines; i++)
-            if (candidate->inlines[i].g) {
-                MVM_spesh_graph_destroy(tc, candidate->inlines[i].g);
-                candidate->inlines[i].g = NULL;
-            }
-    }
+    /* Claim ownership of allocated memory by candidate */
+    sg->cand = candidate;
     MVM_spesh_graph_destroy(tc, sg);
 
     /* Create a new candidate list and copy any existing ones. Free memory

--- a/src/spesh/codegen.c
+++ b/src/spesh/codegen.c
@@ -316,9 +316,8 @@ MVMSpeshCode * MVM_spesh_codegen(MVMThreadContext *tc, MVMSpeshGraph *g) {
         }
         else {
             if (g->inlines[i].start == -1 || g->inlines[i].end == -1)
-                MVM_oops(tc, "Spesh: failed to fix up inline %d %p (%s) %d %d",
+                MVM_oops(tc, "Spesh: failed to fix up inline %d (%s) %d %d",
                     i,
-                    g->inlines[i].g,
                     MVM_string_utf8_maybe_encode_C_string(tc, g->inlines[i].sf->body.name),
                     g->inlines[i].start,
                     g->inlines[i].end

--- a/src/spesh/inline.h
+++ b/src/spesh/inline.h
@@ -39,9 +39,6 @@ struct MVMSpeshInline {
     /* Bit field of named args used to put in place during deopt, since we
      * typically don't update the array in specialized code. */
     MVMuint64 deopt_named_used_bit_field;
-
-    /* Inlinee's spesh graph, so we can free it up after code-gen. */
-    MVMSpeshGraph *g;
 };
 
 MVMSpeshGraph * MVM_spesh_inline_try_get_graph(MVMThreadContext *tc,

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1805,7 +1805,6 @@ static void optimize_call(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb
                 MVM_spesh_usages_add_unconditional_deopt_usage_by_reg(tc, g, code_ref_reg);
                 MVM_spesh_inline(tc, g, arg_info, bb, ins, inline_graph, target_sf,
                         code_ref_reg, prepargs_deopt_idx);
-                MVM_free(inline_graph->spesh_slots);
             }
             else {
                 /* Can't inline, so just identify candidate. */
@@ -1856,7 +1855,6 @@ static void optimize_call(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb
                 MVM_spesh_usages_add_unconditional_deopt_usage_by_reg(tc, g, code_ref_reg);
                 MVM_spesh_inline(tc, g, arg_info, bb, ins, inline_graph, target_sf,
                         code_ref_reg, prepargs_deopt_idx);
-                MVM_free(inline_graph->spesh_slots);
             }
         }
 


### PR DESCRIPTION
Spesh memory management is mostly simple except for the cases where it isn't.
We create spesh graphs in three ways:

- From a spesh plan (i.e. the original bytecode)
- From a spesh candidate, when inlining
- From a known invocant, when we do not have a pre-existing specialization, when inlining.

When we generate a spesh candidate, we transfer ownership of allocated memory (e.g. for inlines, handlers, local type maps, spesh slots) to that candidate.

I found that we had a number of leaks coming from the third case, and that they were not straightforward to fix. The code assumed that inlinees came from spesh candidates and that the spesh candidate would therefore own the allocated memory, and not free it. But in the third case there is no spesh candidate, so those fields would leak.

I fixed this in two ways:
- I made sure the inlinee graph was destroyed directly after inlining. The memory allocated by the region allocator (for the graph nodes that are merged into the inliner) is merged into the inliner region allocator.
- I made sure we free all allocated fields, if and only if they are different from the ones allocated for the spesh candidate, so that we don't free those that are still in use.

Further, there is a fix for the FSA, so that the per-thread FSA freelist is cleaned up before freeing the memory of the FSA allocator as a whole.