### PR TITLE
[JIT] Use reference counting for maintaining multiple code copies

### DIFF
--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -25,6 +25,8 @@ struct MVMJitCode {
 
     MVMint32       spill_size;
     MVMint32       seq_nr;
+
+    AO_t ref_cnt;
 };
 
 MVMJitCode* MVM_jit_compile_graph(MVMThreadContext *tc, MVMJitGraph *graph);


### PR DESCRIPTION
We take some care to make executable memory read/executable, so they are
mmap()'d. The copied' frames would have malloc()'d memory. It is
probably better to treat them as shared resources and use reference
counting to decide when to actually destroy them.

This may be the fix to some bugs, and it may not (JIT code copy and destruction both ought to be rare).