### PR TITLE
Workaround version failure on Travis CI (MacOS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ before_script:
   - MVM_debug="--debug"; MVM_optimize="--optimize"
   - if [ "$COVERAGE" ] || [ "$MOCK_COVERAGE" ]; then MVM_debug="--debug=3"; MVM_optimize="--optimize=0"; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then sudo apt-get update -qq || sudo apt-get update -qq ; fi
-  - git fetch --unshallow
   - git clone --depth 1 git://github.com/perl6/nqp
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os:
   - osx
 perl:
   - "5.10"
+# Do a full clone to be sure we get the tags and can properly retrieve version
+git:
+  depth: false
 before_install:
   |-
     echo "Begin ‘before_install’ section of .travis.yml"


### PR DESCRIPTION
Travis doesn't fetch the full history (only 50 commits by default) and
we use `git fetch --unshallow` to retrieve the rest. This is necessary
to retrieve the tags used in versioning MoarVM. That process does not
appear to be working on MacOS currently.

Explicitly fetch the full history in order to work around this defect.

See [this thread](https://github.com/travis-ci/travis-ci/issues/4942)
for more information.

I don't really know if this works or not without submitting the PR and
letting Travis do it's thing :P