### PR TITLE
[JIT] New template compiler

### DIFF
--- a/docs/jit/how-to-add-an-missing-expression-operator.org
+++ b/docs/jit/how-to-add-an-missing-expression-operator.org
@@ -13,7 +13,7 @@ The file =src/jit/expr_ops.h= contains a macro-list of all defined operators.
 Each operator is defined as such:
 
 #+BEGIN_EXAMPLE
-_(ADD, 2, 0, REG, UNSIGNED), \
+_(ADD, 2, 0), \
 #+END_EXAMPLE
 
 + First item is the name, which must be *uppercase*. Choose something
@@ -24,18 +24,51 @@ _(ADD, 2, 0, REG, UNSIGNED), \
 + Third item is the number of *parameters* (or options). Parameters
   are constants to use for the operator. E.g. for the =CONST= operator
   the value of the constant is a parameter.
-+ Fourth item is the 'result value'. I'm reasonably sure this has no
-  use anymore and could be cleaned up.
-+ Fifth item is the 'cast behaviour'. The expression compiler
-  automatically inserts size extension operators (=CAST=) so that both
-  arguments are equal in size. There's three options:
+
+Mind the comma and the backslash to escape the newline.
+
+* Add to operator type tables
+
+The template precompiler uses type tables to check the consistency of
+templates while compiling. You may need to edit these tables when
+adding a new operator.
+
+- =%OPERATOR_TYPES= contains the result type of the operator. E.g. an
+  operator like =store= does not yield any value, and its
+  =%OPERAND_TYPE= is =void=.
+- =%OPERAND_TYPES= maps operators to their expected operand types as
+  comma-separated values. If the number of types does not match up
+  with the number of operands, the first type is repeated to match,
+  and the last type is treated as an exception. E.g. =do= maps to
+  =void,reg= - meaning that it accepts any number of =void= operands
+  and a final =reg= operand.
+- =%OP_SIZE_ARG= records the argument offset (if any) that represents
+  the 'size' applicable to the operator, allowing the template
+  compiler to check if that argument makes any sense. (As defined by -
+  a parameter that ends with =_sz=, or a macro expression).
+
+The default type is =reg= (an integer or pointer value that can be
+stored in a *register*) and it is not necessary to specify this
+explicitly.
+
+* Add to autocasting in the analyzer
+
+Templates are generally written without concern for the exact sizes
+and offsets at runtime. (Those depend on the C compiler).  As a
+result, an operator may get differently-sized operands. The expression
+JIT resolves such size conflicts by insertings size casts
+automatically. Operand casting can be in three forms, and you'll need
+to decide which it is:
+
   - =NO_CAST= - don't insert casts
   - =UNSIGNED= - extend with zeros
   - =SIGNED= - extend with sign bit (two's complement)
-  Autocasting is a questionable design decision and may be removed in
-  the future.
 
-Mind the comma and the backslash to escape the newline.
+Typically, =SIGNED= is only suitable for arithmetic operators,
+=UNSIGNED= is more suitable for binary operators like =AND= and =OR=,
+and anything else should probably use =NO_CAST=. There's a long switch
+statement in =expr.c= (=analyze_node=) that sets this up, and thats
+where you add your edits.
 
 * Add tiles to implement the new operator
 

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -19,9 +19,9 @@
 
 (template: set (copy $1))
 
-(template: trunc_i8!  (store $0 $1 1))
-(template: trunc_i16! (store $0 $1 2))
-(template: trunc_i32! (store $0 $1 4))
+(template: trunc_i8!  (store \$0 $1 1))
+(template: trunc_i16! (store \$0 $1 2))
+(template: trunc_i32! (store \$0 $1 4))
 
 (template: goto (branch $0))
 
@@ -34,7 +34,7 @@
     (branch $1)))
 
 (template: getlex (copy $1))
-(template: bindlex! (store $0 $1 reg_sz))
+(template: bindlex! (store \$0 $1 reg_sz))
 
 (template: getlex_ni
   (load
@@ -119,16 +119,16 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: smrt_strify!
   (callv (^func &MVM_coerce_smart_stringify)
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
-(template: checkarity!
+(template: checkarity
   (callv (^func &MVM_args_checkarity)
     (arglist
       (carg (tc) ptr)
@@ -199,7 +199,7 @@
       (carg $0 ptr)
       (carg $1 ptr))))
 
-(template: bindexcategory!
+(template: bindexcategory
   (callv (^func &MVM_bind_exception_category)
     (arglist
       (carg (tc) ptr)
@@ -223,7 +223,7 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: backtracestrings
   (call (^func &MVM_exception_backtrace_strings)
@@ -513,7 +513,7 @@
       (carg (tc) ptr)
       (carg $1 ptr)) ptr_sz))
 
-(template: setbuffersize_fh!
+(template: setbuffersize_fh
   (callv (^func &MVM_io_set_buffer_size)
     (arglist
       (carg (tc) ptr)
@@ -561,7 +561,7 @@
       (carg $2 ptr)
       (carg $3 int)) ptr_sz))
 
-(template: nfarunalt!
+(template: nfarunalt
   (callv (^func &MVM_nfa_run_alt)
     (arglist
       (carg (tc) ptr)
@@ -630,7 +630,7 @@
       (carg (tc) ptr)
       (carg $1   ptr)
       (carg (^cu_string $2) ptr)
-      (carg $0   ptr)
+      (carg \$0  ptr)
       (carg (const 1 int_sz) int))))
 
 (template: findmeth_s!
@@ -639,7 +639,7 @@
       (carg (tc) ptr)
       (carg $1   ptr)
       (carg $2   ptr)
-      (carg $0   ptr)
+      (carg \$0  ptr)
       (carg (const 1 int_sz) int))))
 
 (template: can!
@@ -648,7 +648,7 @@
       (carg (tc) ptr)
       (carg $1 ptr)
       (carg (^cu_string $2) ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: can_s!
   (callv (^func &MVM_6model_can_method)
@@ -656,7 +656,7 @@
       (carg (tc) ptr)
       (carg $1   ptr)
       (carg $2   ptr)
-      (carg $0   ptr))))
+      (carg \$0  ptr))))
 
 (template: create!
   (let: (($obj (call (^getf (^repr $1) MVMREPROps allocate)
@@ -672,7 +672,7 @@
             (carg (^stable $obj) ptr)
             (carg $obj ptr)
             (carg (^body $obj) ptr))))
-      (store $0 $obj ptr_sz))))
+      (store \$0 $obj ptr_sz))))
 
 (template: isconcrete
   (if (all
@@ -687,7 +687,7 @@
       (carg (tc) ptr)
       (carg $1 ptr)
       (carg $2 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: gethow
   (let: (($how (^getf (^stable $1) MVMSTable HOW)))
@@ -718,7 +718,7 @@
       (carg (tc) ptr)
       (carg $1 int)
       (carg $2 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: box_s!
   (callv (^func &MVM_box_str)
@@ -726,7 +726,7 @@
       (carg (tc) ptr)
       (carg $1 ptr)
       (carg $2 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: unbox_s
   (call (^func &MVM_unbox_str)
@@ -742,7 +742,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg $2 int)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
 
 (template: atpos_n!
@@ -753,7 +753,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg $2 int)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
 
 (template: atpos_s!
@@ -764,7 +764,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg $2 int)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
 
 #  REPR(obj)->pos_funcs.at_pos(tc, STABLE(obj), obj,
@@ -772,7 +772,7 @@
 #       &GET_REG(cur_op, 0), MVM_reg_obj);
 (template: atpos_o!
   (ifv (^is_type_obj $1)
-    (store $0 (^vmnull) ptr_sz)
+    (store \$0 (^vmnull) ptr_sz)
     (callv (^getf (^repr $1) MVMREPROps pos_funcs.at_pos)
       (arglist
         (carg (tc) ptr)
@@ -780,10 +780,10 @@
         (carg $1 ptr)
         (carg (^body $1) ptr)
         (carg $2 int)
-        (carg $0 ptr)
+        (carg \$0 ptr)
         (carg (const (&QUOTE MVM_reg_obj) int_sz) int)))))
 
-(template: bindpos_i!
+(template: bindpos_i
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.bind_pos)
       (arglist
@@ -799,13 +799,13 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: bindpos_n!
+(template: bindpos_n
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.bind_pos)
       (arglist
         (carg (tc) ptr)
         (carg (^stable $0) ptr)
-        (carg $0 ptr)
+        (carg \$0 ptr)
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
@@ -815,7 +815,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: bindpos_s!
+(template: bindpos_s
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.bind_pos)
       (arglist
@@ -831,7 +831,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: bindpos_o!
+(template: bindpos_o
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.bind_pos)
       (arglist
@@ -847,7 +847,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: push_i!
+(template: push_i
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.push)
       (arglist
@@ -862,7 +862,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: push_n!
+(template: push_n
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.push)
       (arglist
@@ -877,7 +877,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: push_s!
+(template: push_s
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.push)
       (arglist
@@ -892,7 +892,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: push_o!
+(template: push_o
   (dov
     (callv (^getf (^repr $0) MVMREPROps pos_funcs.push)
       (arglist
@@ -914,7 +914,7 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
 
 (template: pop_n!
@@ -924,7 +924,7 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
 
 (template: pop_s!
@@ -934,7 +934,7 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
 
 (template: pop_o!
@@ -944,7 +944,7 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_obj) int_sz) int))))
 
 (template: shift_i!
@@ -954,7 +954,7 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
 
 (template: shift_n!
@@ -964,7 +964,7 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
 
 (template: shift_s!
@@ -974,7 +974,7 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
 
 (template: shift_o!
@@ -984,21 +984,21 @@
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_obj) int_sz) int))))
 
-(template: splice!
+(template: splice
   (callv (^getf (^repr $0) MVMREPROps pos_funcs.splice)
     (arglist
       (carg (tc) ptr)
       (carg (^stable $0) ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (^body $0) ptr)
       (carg $1 ptr)
       (carg $2 int)
       (carg $3 int))))
 
-(template: setelemspos!
+(template: setelemspos
   (callv (^getf (^repr $0) MVMREPROps pos_funcs.set_elems)
     (arglist
       (carg (tc) ptr)
@@ -1008,43 +1008,44 @@
       (carg $1 int))))
 
 (template: atkey_i!
-  (callv (^getf (^repr $0) MVMREPROps ass_funcs.at_key)
+  (callv (^getf (^repr $1) MVMREPROps ass_funcs.at_key)
     (arglist
       (carg (tc) ptr)
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg $2 ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
 
+
 (template: atkey_n!
-  (callv (^getf (^repr $0) MVMREPROps ass_funcs.at_key)
+  (callv (^getf (^repr $1) MVMREPROps ass_funcs.at_key)
     (arglist
       (carg (tc) ptr)
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg $2 ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
 
 (template: atkey_s!
-  (callv (^getf (^repr $0) MVMREPROps ass_funcs.at_key)
+  (callv (^getf (^repr $1) MVMREPROps ass_funcs.at_key)
     (arglist
       (carg (tc) ptr)
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg $2 ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
 
 #  REPR(obj)->ass_funcs.at_key(tc, STABLE(obj), obj, OBJECT_BODY(obj),
 #       (MVMObject *)GET_REG(cur_op, 4).s, &GET_REG(cur_op, 0), MVM_reg_obj);
 (template: atkey_o!
   (ifv (^is_type_obj $1)
-    (store $0 (^vmnull) ptr_sz)
+    (store \$0 (^vmnull) ptr_sz)
     (callv (^getf (^repr $1) MVMREPROps ass_funcs.at_key)
       (arglist
         (carg (tc) ptr)
@@ -1052,10 +1053,10 @@
         (carg $1 ptr)
         (carg (^body $1) ptr)
         (carg $2 ptr)
-        (carg $0 ptr)
+        (carg \$0 ptr)
         (carg (const (&QUOTE MVM_reg_obj) int_sz) int)))))
 
-(template: bindkey_i!
+(template: bindkey_i
   (dov
     (callv (^getf (^repr $0) MVMREPROps ass_funcs.bind_key)
       (arglist
@@ -1071,7 +1072,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: bindkey_n!
+(template: bindkey_n
   (dov
     (callv (^getf (^repr $0) MVMREPROps ass_funcs.bind_key)
       (arglist
@@ -1087,7 +1088,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: bindkey_s!
+(template: bindkey_s
   (dov
     (callv (^getf (^repr $0) MVMREPROps ass_funcs.bind_key)
       (arglist
@@ -1103,7 +1104,7 @@
         (carg (tc) ptr)
         (carg $0 ptr)))))
 
-(template: bindkey_o!
+(template: bindkey_o
   (dov
     (callv (^getf (^repr $0) MVMREPROps ass_funcs.bind_key)
       (arglist
@@ -1164,7 +1165,7 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (^nullptr) ptr)
       (carg (^nullptr) ptr)
       (carg (const 0 int_sz) int))))
@@ -1174,7 +1175,7 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (^nullptr) ptr)
       (carg (^nullptr) ptr)
       (carg (const 1 int_sz) int))))
@@ -1253,14 +1254,14 @@
       (carg $1   ptr)
       (carg $2   ptr)) ptr_sz))
 
-(template: settypehll!
+(template: settypehll
   (^setf (^stable $0) MVMSTable hll_owner
     (call (^func &MVM_hll_get_config_for)
       (arglist
         (carg (tc) ptr)
         (carg $1 ptr)) ptr_sz)))
 
-(template: settypehllrole!
+(template: settypehllrole
   (^setf (^stable $0) MVMSTable hll_role $1))
 
 (template: hllize!
@@ -1271,7 +1272,7 @@
       (carg (call (^func &MVM_hll_current)
               (arglist
                 (carg (tc) ptr)) ptr_sz) ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: hllizefor!
   (callv (^func &MVM_hll_map)
@@ -1282,7 +1283,7 @@
               (arglist
                 (carg (tc) ptr)
                 (carg $2   ptr)) ptr_sz) ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: iter
   (call (^func &MVM_iter)
@@ -1322,7 +1323,7 @@
     (flagval (nz (^getf (^stable $1) MVMSTable invocation_spec)))
     (const 1 int_sz)))
 
-(template: setdispatcher!
+(template: setdispatcher
   (dov
     (^setf (tc) MVMThreadContext cur_dispatcher $0)
     (^setf (tc) MVMThreadContext cur_dispatcher_for (^nullptr))))
@@ -1352,12 +1353,12 @@
          (zr $1)
          (^is_type_obj $1)
          (zr (^getf (^stable $1) MVMSTable container_spec)))
-    (store $0 $1 ptr_sz)
+    (store \$0 $1 ptr_sz)
     (callv (^stable_cont_func $1 fetch)
       (arglist
         (carg (tc) ptr)
         (carg $1 ptr)
-        (carg $0 ptr)))))
+        (carg \$0 ptr)))))
 
 (template: sha1
   (call (^func &MVM_sha1)
@@ -1596,11 +1597,11 @@
                    (carg (tc) ptr)
                    (carg $4   ptr)) ptr_sz)))
     (dov
-      (store $0 $res ptr_sz)
+      (store \$0 $res ptr_sz)
       (callv (^func &MVM_bigint_expmod)
         (arglist
           (carg (tc) ptr)
-          (carg $0   ptr)
+          (carg $res ptr)
           (carg $1   ptr)
           (carg $2   ptr)
           (carg $3   ptr))))))
@@ -1649,9 +1650,9 @@
   (callv (^func &MVM_io_connect)
     (arglist
       (carg (tc) ptr)
+      (carg $0   ptr)
       (carg $1   ptr)
-      (carg $2   ptr)
-      (carg $3   int))))
+      (carg $2   int))))
 
 (template: socket
   (call (^func &MVM_io_socket_create)
@@ -1706,7 +1707,7 @@
       (carg (tc) ptr)
       (carg $1   ptr)
       (carg (^cu_string $2) ptr)
-      (carg $0   ptr)
+      (carg \$0  ptr)
       (carg (const 0 int_sz) int))))
 
 (template: tryfindmeth_s!
@@ -1715,7 +1716,7 @@
       (carg (tc) ptr)
       (carg $1   ptr)
       (carg $2   ptr)
-      (carg $0   ptr)
+      (carg \$0  ptr)
       (carg (const 0 int_sz) int))))
 
 (template: rand_i
@@ -1770,7 +1771,7 @@
       (carg $1   ptr)
       (carg $2   ptr)) ptr_sz))
 
-(template: assertparamcheck!
+(template: assertparamcheck
   (when (zr $0)
     (callv (^func &MVM_args_bind_failed)
       (arglist
@@ -1882,7 +1883,7 @@
       (carg $4 int)
       (carg $5 ptr)) ptr_sz))
 
-(template: cancel!
+(template: cancel
   (callv (^func &MVM_io_eventloop_cancel_work)
     (arglist
       (carg (tc) ptr)
@@ -2009,7 +2010,7 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
 
 (template: getrusage
   (callv (^func &MVM_proc_getrusage)
@@ -2081,7 +2082,8 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg $0 ptr))))
+      (carg \$0 ptr))))
+
 (template: lastexpayload
   (^getf (tc) MVMThreadContext last_payload))
 
@@ -2095,7 +2097,7 @@
       (carg $4 int)
       (carg $5 int)) int_sz))
 
-(template: setdispatcherfor!
+(template: setdispatcherfor
   (dov
     (^setf (tc) MVMThreadContext cur_dispatcher $0)
     (^setf (tc) MVMThreadContext cur_dispatcher_for
@@ -2203,7 +2205,7 @@
       ptr_sz))
     ($initialize (^getf (^repr $1) MVMREPROps initialize)))
     (dov
-      (store $0 $dest ptr_sz)
+      (store \$0 $dest ptr_sz)
       (when (nz $initialize)
         (callv $initialize
           (arglist
@@ -2222,14 +2224,14 @@
           (carg $3           int))))))
 
 (template: atkey_u!
-  (callv (^getf (^repr $0) MVMREPROps ass_funcs.at_key)
+  (callv (^getf (^repr $1) MVMREPROps ass_funcs.at_key)
     (arglist
       (carg (tc) ptr)
       (carg (^stable $1) ptr)
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg $2 ptr)
-      (carg $0 ptr)
+      (carg \$0 ptr)
       (carg (const (&QUOTE MVM_reg_uint64) int_sz) int))))
 
 (template: sp_resolvecode
@@ -2247,8 +2249,8 @@
       (arglist
         (carg (tc) ptr)
         (carg $1 ptr)
-        (carg $0 ptr)))
-    (store $0 $1 ptr_sz)))
+        (carg \$0 ptr)))
+    (store \$0 $1 ptr_sz)))
 
 (template: sp_getarg_o (load (^parg $1) ptr_sz))
 (template: sp_getarg_i (load (^parg $1) int_sz))
@@ -2265,7 +2267,7 @@
     (^setf $block MVMObject st (^spesh_slot_value $2))
     (^setf $block MVMObject header.size $1)
     (^setf $block MVMObject header.owner (^getf (tc) MVMThreadContext thread_id))
-    (store $0 $block ptr_sz)))
+    (store \$0 $block ptr_sz)))
 
 (template: sp_p6oget_o
   (let: (($val (load (add (^p6obody $1) $2) ptr_sz)))

--- a/tools/expr-template-compiler.pl
+++ b/tools/expr-template-compiler.pl
@@ -1,10 +1,11 @@
 #!/usr/bin/env perl
+package template_compiler;
 use strict;
 use warnings FATAL => 'all';
 
 use Getopt::Long;
 use File::Spec;
-use Scalar::Util qw(looks_like_number refaddr);
+use Scalar::Util qw(looks_like_number refaddr reftype);
 
 # use my libs
 use FindBin;
@@ -36,22 +37,17 @@ if ($OPTIONS{output}) {
     close( STDOUT ) or die $!;
     open( STDOUT, '>', $OPTIONS{output} ) or die $!;
 }
+
 if ($OPTIONS{input} //= shift @ARGV) {
     close( STDIN );
     open( STDIN, '<', $OPTIONS{input} ) or die $!;
 }
 
-# Wrapper for the recursive write_template
-sub compile_template {
-    my $tree = shift;
-    my ($templ, $desc, $env) = ([], [], {});
-    my ($root, $mode) = write_template($tree, $templ, $desc, $env);
-    die "Invalid template!" unless $mode eq 'l'; # top should be a simple expression
-    return {
-        root => $root,
-        template => $templ,
-        desc => join('', @$desc)
-    };
+END {
+    close STDOUT;
+    if ($? && $OPTIONS{output}) {
+        unlink $OPTIONS{output};
+    }
 }
 
 # Template check tables
@@ -82,7 +78,7 @@ my %OPERAND_TYPES = (
 );
 
 # which list item is the size
-my %OP_SIZE_ARG = (
+my %OP_SIZE_PARAM = (
     load => 2,
     store => 3,
     call => 3,
@@ -90,109 +86,65 @@ my %OP_SIZE_ARG = (
     cast => 2,
 );
 
-my %VARIADIC_OPERATORS = map { $_ => 1 } grep $EXPR_OPS{$_}{num_childs} < 0, keys %EXPR_OPS;
+my %VARIADIC = map { $_ => 1 } grep $EXPR_OPS{$_}{num_operands} < 0, keys %EXPR_OPS;
 
-sub validate_template {
-    my ($template, $context) = @_;
+# first read the correct order of opcodes
+my %OPNAMES = map { $OPLIST[$_][0] => $_ } 0..$#OPLIST;
 
-    # Because we destructively modify (some) nodes, make sure we never
-    # visit the same node twice. NB - autovivifies $context if not
-    # passed
-    return if $context->{refaddr($template)}++;
+# cache operand direction
+sub opcode_operand_direction {
+    $_[0] =~ m/^([rw])l?\(/ ? $1 : '';
+}
 
-    my $node = $template->[0];
-    if ($node eq 'let:') {
-        my $defs = $template->[1];
-        my @expr = @$template[2..$#$template];
-        for my $def (@$defs) {
-            validate_template($def->[1], $context);
-        }
-        validate_template($_, $context) for grep ref($_) eq 'ARRAY', @expr;
-        return;
-    }
+# Pre compute exptected operand type and direction
+my %MOAR_OPERAND_DIRECTION;
+for my $opcode (@OPLIST) {
+    my ($opname, undef, $operands) = @$opcode;
+    $MOAR_OPERAND_DIRECTION{$opname} = [
+        map opcode_operand_direction($_), @$operands
+    ];
+}
 
-    die "Unknown node type $node" unless exists $EXPR_OPS{$node};
+# Need a global constant table
+my %CONSTANTS;
 
-    # NB - this inserts the template length parameter into the list,
-    # which is necessary for the template builder (runtime)
-    my ($nchild, $narg) = @{$EXPR_OPS{$node}}{qw(num_childs num_args)};;
+sub compile_template {
+    my ($expr, $opcode) = @_;
+    my $compiler = +{
+        types => {},
+        env   => {},
+        expr  => {},
+        tmpl  => [],
+        desc  => [],
+        opcode => $opcode,
+        constants => \%CONSTANTS,
+    };
+    my ($mode, $root) = compile_expression($compiler, $expr);
+    die "Invalid template!" unless $mode eq 'l'; # top should be a simple expression
+    return {
+        root => $root,
+        template => $compiler->{tmpl},
+        desc => join('', @{$compiler->{desc}}),
+    };
+}
 
-    unless ($nchild < 0 or (my $expected = 1+$nchild+$narg) == @$template) {
-        my $txt = sexpr::encode($template);
-        die "Node $txt should be $expected long";
-    }
-
-    my @types = split /,/, ($OPERAND_TYPES{$node} // 'reg');
-    if (@types < $nchild) {
-        if (@types == 1) {
-            @types = (@types) x $nchild;
-        } elsif (@types == 2) {
-            @types = (($types[0]) x ($nchild-1), $types[1]);
-        } else {
-            die "Can't match up types";
-        }
-    }
-
-
-    for (my $i = 0; $i < $nchild; $i++) {
-        my $child = $template->[1+$i];
-        if (ref($child) eq 'ARRAY' and substr($child->[0], 0, 1) ne '&') {
-            unless ((my $op = $child->[0]) eq 'let:') {
-
-                my $type = ($OPERATOR_TYPES{$op} // 'reg');
-                die sprintf('Expected %s but got %s in template %s child %d (op %s)', $types[$i],
-                            $type, sexpr::encode($template), $i, $op)
-                    unless $types[$i] eq $type;
-            }
-            validate_template($child, $context);
-        } elsif (substr($child, 0, 1) eq '$') {
-            # OK!
-            die sprintf('Expected type %s but got %s', $types[$i], $child)
-                unless $types[$i] eq 'reg';
-        } else {
-            my $txt = sexpr::encode($template);
-            die "Child $i of $txt is not a expression";
-        }
-    }
-    for (my  $i = 0; $i < $narg; $i++) {
-        my $child = $template->[1+$nchild+$i];
-        if (ref($child) eq 'ARRAY' and substr($child->[0], 0, 1) eq '&') {
-            # OK
-        } elsif (substr($child, 0, 1) ne '$') {
-            # Also OK
-        } else {
-            my $txt = sexpr::encode($template);
-            die "Child $i of $txt is not an argument";
-        }
-    }
-
-    if (exists $OP_SIZE_ARG{$node}) {
-        # does this look like a size argument?
-        my $size_arg = $template->[$OP_SIZE_ARG{$node}];
-        if (ref($size_arg)) {
-            warn sprintf("size argument '%s' for node '%s' is not a macro",
-                         sexpr::encode($size_arg), $node)
-                if $size_arg->[0] !~ m/\A&\w+/
-        } elsif (!looks_like_number($size_arg) && $size_arg !~ m/_sz\z/) {
-            warn sprintf("size argument '%s' for node '%s' may not be a size",
-                         $size_arg, $node);
-        }
-    }
-
+sub is_arrayref {
+    defined(reftype($_[0])) && reftype($_[0]) eq 'ARRAY';
 }
 
 sub apply_macros {
-    my ($tree, $macros) = @_;
-    return unless ref($tree) eq 'ARRAY';
+    my ($expr, $macros) = @_;
+    return unless is_arrayref($expr);
 
     my @result;
-    for my $node (@$tree) {
-        if (ref($node) eq 'ARRAY') {
-            push @result, apply_macros($node, $macros);
+    for my $element (@$expr) {
+        if (is_arrayref($element)) {
+            push @result, apply_macros($element, $macros);
         } else {
-            push @result, $node;
+            push @result, $element;
         }
     }
+
     # empty lists can occur for instance with macros without arguments
     if (@result and $result[0] =~ m/^\^/) {
         # looks like a macro
@@ -213,132 +165,219 @@ sub apply_macros {
 sub fill_macro {
     my ($macro, $bind) = @_;
     my $result = [];
-    for (my $i = 0; $i < @$macro; $i++) {
-        if (ref($macro->[$i]) eq 'ARRAY') {
-            push @$result, fill_macro($macro->[$i], $bind);
-        } elsif (substr($macro->[$i], 0, 1) eq ',') {
-            if (defined $bind->{$macro->[$i]}) {
-                push @$result, $bind->{$macro->[$i]};
+    for my $element (@$macro) {
+        if (is_arrayref($element)) {
+            push @$result, fill_macro($element, $bind);
+        } elsif ($element =~ m/^,/) {
+            if (defined $bind->{$element}) {
+                push @$result, $bind->{$element};
             } else {
-                die "Unmatched macro substitution: $macro->[$i]";
+                die "Unmatched macro substitution: $element";
             }
         } else {
-            push @$result, $macro->[$i];
+            push @$result, $element;
         }
     }
     return $result;
 }
 
-# lets add a global instead of replacing the entire thing with a class
-my %CONSTANTS;
-
-sub write_template {
-    my ($tree, $tmpl, $desc, $env) = @_;
-
-    # Macro application can potentially introduce multiple references
-    # to a node. Instead of duplicating the template, we reuse the
-    # calculated offset. Because we're using reference identity as key
-    # this never conflict with named variable references.
-    return $env->{refaddr($tree)}, 'l' if exists $env->{refaddr($tree)};
-
-    die "Can't deal with an empty tree" unless @$tree; # we need at least some nodes
-    my ($node, @edges) = @$tree;
-    die "First parameter must be a bareword or macro" unless $node =~ m/^&?[a-z]\w*:?$/i;
-
-
-    if ($node eq 'let:') {
-        # rewrite (let: (($name ($code))) ($code..)+)
-        # into (do(v)?: $ndec + $ncode $decl+ $code+)
-        my $env  = { %$env }; # copy env and shadow it
-        my ($decl, @expr) = @edges;
-
-        # depening on last node result, start with DO or DOV (void)
-        my $type = ($OPERATOR_TYPES{$expr[-1][0]} // 'reg');
-        my $list = [ $type eq 'void' ? 'dov' : 'do' ];
-        # add declarations to template and to DO list
-        for my $stmt (@$decl) {
-            my ($name, $expr) = @$stmt;
-            die "Let statement should hold 2 expressions, holds ".@$stmt unless @$stmt == 2;
-            die "Variable name $name is invalid" unless $name =~ m/\$[a-z]\w*/i;
-            die "Let statement expects an expression" unless ref($expr) eq 'ARRAY';
-            die "Redeclaration of '$name'" if exists($env->{$name});
-            my ($child, $mode) = write_template($expr, $tmpl, $desc, $env);
-            die "Let can only be used with simple expresions" unless $mode eq 'l';
-            $env->{$name} = $child;
-            # ensure the DO is compiled as I expect.
-            push @$list, ['discard', $name];
-        }
-        push @$list, @expr;
-        return write_template($list, $tmpl, $desc, $env);
-    } elsif (substr($node, 0, 1) eq '&') {
-        # C-macro expressions are opaque to the template compiler but
-        # should reduce to a constant expression when the generated
-        # header is compiled. Used for sizeof/offsetof expressions
-        # mostly. Returns a 'dot' mode to be treated as a constant
-        return (sprintf('%s(%s)', substr($node, 1),
-                        join(', ', @edges)), '.');
-    } elsif ($node =~ m/const_ptr|const_large/) {
-        # intern this constant
-        my ($value, $size) = @edges;
-        my $const_nr = $CONSTANTS{$value} = exists $CONSTANTS{$value} ?
-            $CONSTANTS{$value} : scalar keys %CONSTANTS;
-        my $root  = @$tmpl;
-        push @$tmpl, $PREFIX . uc($node), 0, $const_nr;
-        push @$desc, qw(n s c);
-        if ($node eq 'const_large') {
-            # const_large needs a size
-            push @$tmpl, $size;
-            push @$desc, '.';
-        }
-        $env->{refaddr($tree)} = $root;
-        return ($root, 'l');
-    }
-
-    # deal with a simple expression
-    my (@tmpl, @desc); # for this node
-    my $nchild = $VARIADIC_OPERATORS{$node} ? @edges : $EXPR_OPS{$node}{num_childs};
-    push @tmpl, $PREFIX . uc($node), $nchild;
-    push @desc, qw(n s); # n = node, s = size
-
-
-    for my $item (@edges) {
-        if (ref($item) eq 'ARRAY') {
-            # subexpression: get offset and template mode for this root
-            my ($child, $mode) = write_template($item, $tmpl, $desc, $env);
-            push @tmpl, $child;
-            push @desc, $mode;
-        } elsif ($item =~ m/^\$\d+$/) {
-            # numeric variable (an operand parameter)
-            push @tmpl, substr($item, 1)+0; # pass the operand nummer
-            push @desc, 'i'; # run-time *input* operand
-        } elsif ($item =~ m/^\$\w+$/) {
-            # named variable (declared in let)
-            die "Undefined variable '$item' used" unless exists $env->{$item};
-            push @tmpl, $env->{$item};
-            push @desc, 'l'; # also needs to be linked in properly
-        } elsif ($item =~ m/^\d+$/) {
-            # integer numerics are passed literally
-            push @tmpl, $item;
-            push @desc, '.';
+sub check_type {
+    my ($compiler, $expr) = @_;
+    if (is_arrayref($expr)) {
+        my ($operator) = @$expr;
+        die "Expected operator but got macro" if $operator =~ m/^&/;
+        return check_type($compiler, $expr->[$#$expr]) if $operator eq 'let:';
+        return $OPERATOR_TYPES{$operator} || 'reg';
+    } elsif ($expr =~ m/^\\?\$(\w+)$/) {
+        my $name = $1;
+        if (looks_like_number($name)) {
+            # TODO - we can do much better, but it is not easy,
+            # because there are a number of opcodes like 'bindlex'
+            # which introduce wildcards, and a number of operators
+            # (like COPY and STORE) which are generic.
+            return 'reg';
         } else {
-            # barewords are passed as uppercased prefixed strings
-            push @tmpl, $PREFIX . uc($item);
-            push @desc, '.';
+            die "$name is not declared" unless exists $compiler->{types}{$expr};
+            return $compiler->{types}{$expr};
         }
+    } else {
+        die "Expected operator or type, got " . sexpr::encode($expr);
     }
-    my $root = @$tmpl; # current position is where we'll be writing the root template.
-    # add to output array
-    push @$tmpl, @tmpl;
-    push @$desc, @desc;
-
-    $env->{refaddr($tree)} = $root;
-    # a simple expression should be linked in at runtime
-    return ($root, 'l');
 }
 
 
-# first read the correct order of opcodes
-my %OPNAMES = map { $OPLIST[$_][0] => $_ } 0..$#OPLIST;
+
+sub compile_expression {
+    my ($compiler, $expr) = @_;
+
+    return 'l' => $compiler->{expr}{refaddr($expr)}
+        if exists $compiler->{expr}{refaddr($expr)};
+
+    my ($operator, @operands) = @$expr;
+
+    return compile_declarations($compiler, @operands)
+        if $operator eq 'let:';
+
+    die "Expected expression but got macro" if $operator =~ m/^&/;
+    die "Unknown operator $operator" unless my $info = $EXPR_OPS{$operator};
+
+    my $num_operands = $VARIADIC{$operator} ? @operands : $info->{num_operands};
+    my $num_params = $info->{num_params};
+
+    die "Expected $num_operands operands and $num_params params, got " . 0+@operands
+        if $num_operands + $num_params != @operands;
+
+    # large constants are treated specially
+    if ($operator =~ m/^const_(ptr|large)$/) {
+        my ($value, $size) = @operands;
+        return 'l' => emit($compiler,
+                           compile_operator($compiler, $operator, 0),
+                           compile_constant($compiler, $value),
+                           defined $size ? ('.' => $size) : ());
+    }
+
+    # match up types
+    my @types = split /,/, ($OPERAND_TYPES{$operator} // 'reg');
+    if (@types < $num_operands) {
+        if (@types == 1) {
+            @types = (@types) x $num_operands;
+        } elsif (@types == 2) {
+            @types = (($types[0]) x ($num_operands-1), $types[1]);
+        } else {
+            die "Can't match up types";
+        }
+    }
+
+    my @code = compile_operator($compiler, $operator, $num_operands);
+
+    my $i = 0;
+    for (; $i < $num_operands; $i++) {
+        my $type = check_type($compiler, $operands[$i]);
+        die "Mismatched type, got $type expected $types[$i]" .
+            "for $operator ($compiler->{opcode} $operands[$i])"
+            unless $type eq $types[$i];
+        push @code, compile_operand($compiler, $operands[$i]);
+    }
+
+    # check size parameter if any
+    if (my $param = $OP_SIZE_PARAM{$operator}) {
+        my $size = $operands[$param - 1];
+        die "Expected size parameter" unless
+            # macro, number or bareword-ending-with-size
+            ((is_arrayref($size) && $size->[0] =~ m/^&/) ||
+             looks_like_number($size) || $size =~ m/_sz$/);
+    }
+    for (; $i < $num_operands + $num_params; $i++) {
+        push @code, compile_parameter($compiler, $operands[$i]);
+    }
+    my $node = emit($compiler, @code);
+    $compiler->{expr}{refaddr($expr)} = $node;
+    return 'l' => $node;
+}
+
+sub compile_declarations {
+    my ($compiler, $declarations, @rest) = @_;
+    # rewrite (let: (($name ($code))) ($code..)+)
+    # into (do(v)?: $ndec + $ncode $decl+ $code+)
+    my $type = check_type($compiler, $rest[$#rest]);
+    my @list = ($type eq 'void' ? 'dov' : 'do');
+    for my $declaration (@$declarations) {
+        die "Need name and expression" unless @$declaration == 2;
+        my ($name, $expr) = @$declaration;
+        die "Variable name $name is invalid" unless $name =~ m/\$[a-z]\w*/i;
+
+        my $type = check_type($compiler, $expr);
+        die "Let declaration needs a register value got $type" unless $type eq 'reg';
+
+        (undef, my $node) = compile_expression($compiler, $expr);
+        $compiler->{types}{$name} = $type;
+        $compiler->{env}{$name} = $node;
+        push @list, ['discard', $name];
+    }
+    push @list, @rest;
+    return compile_expression($compiler, \@list);
+}
+
+sub compile_constant {
+    my ($compiler, $value, $size) = @_;
+    my $constants = $compiler->{constants};
+    my $const_nr = ($constants->{$value} = exists $constants->{$value} ?
+                        $constants->{$value} : scalar keys %$constants);
+    return 'c' => $const_nr;
+}
+
+sub compile_operand {
+    my ($compiler, $expr) = @_;
+    if (is_arrayref($expr)) {
+        compile_expression($compiler, $expr);
+    } else {
+        compile_reference($compiler, $expr);
+    }
+}
+
+sub compile_reference {
+    my ($compiler, $expr) = @_;
+    die "Expected reference got $expr" unless
+        my ($ref, $name) = $expr =~ m/^(\\?)\$(\w+)/;
+    if (looks_like_number($name)) {
+        my $opcode = $compiler->{opcode};
+        # special case for dec_i/inc_i
+        return 'i' => $name if $opcode =~ m/^(dec|inc)_i$/ and $name <= 1;
+        my $direction = $MOAR_OPERAND_DIRECTION{$opcode};
+        die "Invalid operand reference $expr for $opcode"
+            unless $name >= 0 && $name < @$direction;
+        die "Expected reference for write operand ($opcode)"
+            if $direction->[$name] eq 'w' && !$ref;
+        return 'i' => $name;
+    } else {
+        die "Undefined named reference $expr"
+            unless defined (my $ref = $compiler->{env}{$expr});
+        return 'l' => $ref;
+    }
+}
+
+sub compile_parameter {
+    my ($compiler, $expr) = @_;
+    if (is_arrayref($expr)) {
+        return compile_macro($compiler, $expr);
+    } elsif (looks_like_number($expr)) {
+        return '.' => $expr;
+    } else {
+        return compile_bareword($compiler, $expr);
+    }
+}
+
+sub compile_macro {
+    my ($compiler, $expr) = @_;
+    my ($name, @parameters) = @$expr;
+    die "Expected a macro expression, got $name"
+        unless my ($macro) = $name =~ m/^&(\w+)/;
+    return '.' => sprintf('%s(%s)', $macro, join(', ', @parameters));
+}
+
+sub compile_operator {
+    my ($compiler, $expr, $num_operands) = @_;
+    die "$expr is not a valid operator" unless exists $EXPR_OPS{$expr};
+    die "Invalid size $num_operands" unless looks_like_number($num_operands);
+    return ('n' => $PREFIX . uc($expr), 's' => $num_operands);
+}
+
+sub compile_bareword {
+    my ($compiler, $expr) = @_;
+    return '.' => $PREFIX . uc($expr);
+}
+
+sub emit {
+    my ($compiler, @code) = @_;
+    my $node = @{$compiler->{tmpl}};
+    while (@code) {
+        push @{$compiler->{desc}}, shift @code;
+        push @{$compiler->{tmpl}}, shift @code;
+    }
+    return $node;
+}
+
+
 
 my %SEEN;
 
@@ -356,16 +395,15 @@ sub parse_file {
             my $opcode   = shift @$tree;
             my $template = shift @$tree;
             my $flags    = 0;
-            if (substr($opcode, -1) eq '!') {
-                # destructive template
-                $opcode = substr $opcode, 0, -1;
+            if ($opcode =~ s/!$//) {
+                die "No write operand for destructive template $opcode"
+                    unless grep $_ eq 'w', @{$MOAR_OPERAND_DIRECTION{$opcode}};
                 $flags |= 1;
             }
             die "Opcode '$opcode' unknown" unless defined $OPNAMES{$opcode};
             die "Opcode '$opcode' redefined" if defined $info{$opcode};
-            # Validate template for consistency with expr.h node definitions
-            validate_template($template);
-            my $compiled = compile_template($template);
+
+            my $compiled = compile_template($template, $opcode);
 
             $info{$opcode} = {
                 idx => scalar @templates,

--- a/tools/expr_ops.pm
+++ b/tools/expr_ops.pm
@@ -1,10 +1,10 @@
 package expr_ops;
 use strict;
 use warnings;
-use File::Spec;
+use File::Spec::Functions qw(catdir  updir catpath splitpath);
 use constant EXPR_OPS_H => do {
-    my ($path, $directory, $filename) = File::Spec->splitpath(__FILE__);
-    File::Spec->catpath($path, File::Spec->catdir($directory, File::Spec->updir(), 'src','jit'), 'expr_ops.h');
+    my ($path, $directory, $filename) = splitpath(__FILE__);
+    catpath($path, catdir($directory, updir(), 'src','jit'), 'expr_ops.h');
 };
 
 sub parse_expr_ops {
@@ -23,7 +23,7 @@ sub parse_expr_ops {
 
 sub import {
     my ($class, @args) = @_;
-    my @keys     = qw(name num_childs num_args cast);
+    my @keys     = qw(name num_operands num_params cast);
     my @expr_ops = parse_expr_ops(@args ? @args : EXPR_OPS_H);
     my %expr_ops = map {
         my ($i, $op) = ($_, $expr_ops[$_]);

--- a/tools/sexpr.pm
+++ b/tools/sexpr.pm
@@ -1,7 +1,18 @@
 package sexpr;
 use strict;
 use warnings;
+use Carp qw(croak);
+use Exporter qw(import);
+our @EXPORT = qw(sexpr_decode);
 
+{
+    # good thing perl is single threaded ;-)
+    my $PARSER = __PACKAGE__->parser;
+    sub sexpr_decode {
+        open local $PARSER->{input}, '<', \$_[0];
+        $PARSER->parse;
+    }
+}
 # declare keyword syntax regex
 my $tokenize = qr/
     \A


### PR DESCRIPTION
- Single-pass compilation (no separate 'validate_template' step
- Better type and format checking (operands should be expressions or references, parameters should be barewords, numbers or macros)
- Write-out parameters need to be refered with a `\$` sigil, like `\$0`, and templates without output operands should not get a '!' suffix

Already caught a few issues this way.