### PR TITLE
Add a macro for decoder_ensure_decoder and ...

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -2163,6 +2163,43 @@
 (template: lastexpayload
   (^getf (tc) MVMThreadContext last_payload))
 
+(template: decoderaddbytes
+  (dov
+    (^decoder_ensure_decoder (tc) $0 (const_ptr "decoderaddbytes"))
+    (callv (^func &MVM_decoder_add_bytes)
+      (arglist
+        (carg (tc) ptr)
+        (carg $0 ptr)
+        (carg $1 ptr)))))
+
+(template: decodertakeline
+  (do
+    (^decoder_ensure_decoder (tc) $1 (const_ptr "decodertakeline"))
+    (call (^func &MVM_decoder_take_line)
+      (arglist
+        (carg (tc) ptr)
+        (carg $1 ptr)
+        (carg $2 int)
+        (carg $3 int)) ptr_sz)))
+
+(template: decodertakebytes
+  (do
+    (^decoder_ensure_decoder (tc) $1 (const_ptr "decodertakebytes"))
+    (call (^func &MVM_decoder_take_bytes)
+      (arglist
+        (carg (tc) ptr)
+        (carg $1 ptr)
+        (carg $2 ptr)
+        (carg $3 int)) ptr_sz)))
+
+(template: decoderempty
+  (do
+    (^decoder_ensure_decoder (tc) $1 (const_ptr "decoderempty"))
+    (call (^func &MVM_decoder_empty)
+      (arglist
+        (carg (tc) ptr)
+        (carg $1 ptr)) int_sz)))
+
 (template: unicmp_s
   (call (^func &MVM_unicode_string_compare)
     (arglist

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -89,3 +89,13 @@
 (macro: ^body (,a) (addr ,a (&offsetof MVMObjectStooge data)))
 
 (macro: ^nullptr () (const 0 ptr_sz))
+
+(macro: ^decoder_ensure_decoder (,tc ,decoder ,op)
+    (when (any
+           (ne (^getf (^repr ,decoder) MVMREPROps ID) (const (&QUOTE MVM_REPR_ID_Decoder) (&sizeof MVMuint32)))
+           (zr (flagval (^is_conc_obj ,decoder))))
+         (callv (^func &MVM_exception_throw_adhoc)
+           (arglist
+             (carg ,tc ptr)
+             (carg (const_ptr "Operation '%s' can only work on an object with the Decoder representation") ptr)
+             (carg ,op ptr)))))


### PR DESCRIPTION
templates for `decoder<addbytes takebytes takeline empty>`.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.