### PR TITLE
Implement 'cast_load_addr' tile for exprjit 

### DIFF
--- a/docs/jit/overview.org
+++ b/docs/jit/overview.org
@@ -147,7 +147,7 @@ as of today (<2017-09-25 Mon>).
 | =NZ=      | =(nz reg)=                       | =flag=   | Operand is nonzero                                     |
 | =ZR=      | =(zr reg)=                       | =flag=   | Operand equals zero                                    |
 |-----------+----------------------------------+----------+--------------------------------------------------------|
-| =CAST=    | =(cast reg $from $to $sign)=     | =reg=    | Convert a value from smaller to larger representation  |
+| =CAST=    | =(cast reg $to $from $sign)=     | =reg=    | Convert a value from smaller to larger representation  |
 | =FLAGVAL= | =(flagval flag)=                 | =reg=    | Binary value of comparison operator                    |
 | =DISCARD= | =(discard reg)=                  | =void=   | Discard value of child operator                        |
 |-----------+----------------------------------+----------+--------------------------------------------------------|

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -694,7 +694,7 @@
     (nz $1)
     (cast
       (^getf (^storage_spec $1) MVMStorageSpec boxed_primitive)
-      int_sz (&sizeof MVMuint16) (&QUOTE MVM_JIT_CAST_UNSIGNED))
+      int_sz (&sizeof MVMuint16) cast_unsigned)
     (const 0 int_sz)))
 
 (template: gethow

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -689,6 +689,14 @@
       (carg $2 ptr)
       (carg \$0 ptr))))
 
+(template: objprimspec
+  (if
+    (nz $1)
+    (cast
+      (^getf (^storage_spec $1) MVMStorageSpec boxed_primitive)
+      int_sz (&sizeof MVMuint16) (&QUOTE MVM_JIT_CAST_UNSIGNED))
+    (const 0 int_sz)))
+
 (template: gethow
   (let: (($how (^getf (^stable $1) MVMSTable HOW)))
   (if (nz $how)

--- a/src/jit/expr_ops.h
+++ b/src/jit/expr_ops.h
@@ -4,10 +4,7 @@
    consistent across multiple definitions.
 
    The first argument is the name, the second the number of children, the third
-   the number of parameters - together they define the size of the node. The
-   fourth argument defines the result type. This is strictly redundant for code
-   generation, although it is used by the template compiler. The fifth argument
-   determines how to generate a cast for mixed-sized oeprands.
+   the number of parameters - together they define the size of the node.
 
    NB: This file is parsed by tools/expr_ops.pm *AND* included by
    src/jit/expr.h, so keep it in order!

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -88,4 +88,10 @@
 
 (macro: ^body (,a) (addr ,a (&offsetof MVMObjectStooge data)))
 
+(macro: ^storage_spec (,a)
+  (call (^getf (^repr ,a) MVMREPROps get_storage_spec)
+    (arglist
+      (carg (tc) ptr)
+      (carg (^stable ,a) ptr)) ptr_sz))
+
 (macro: ^nullptr () (const 0 ptr_sz))

--- a/src/jit/tile.h
+++ b/src/jit/tile.h
@@ -17,7 +17,7 @@ struct MVMJitTile {
 
     MVMint32  num_refs;
     MVMint32   refs[4];
-    MVMint32   args[4];
+    MVMint32   args[6];
     MVMint8  values[4];
 
     MVMuint32 register_spec;

--- a/src/jit/x64/tile_pattern.tile
+++ b/src/jit/x64/tile_pattern.tile
@@ -55,7 +55,7 @@
 
 
 (tile: cast           (cast reg $to_size $from_size $signed) reg 2)
-(tile: cast_load_addr (cast (load (addr reg $ofs) $src_sz) $dst_size $signed) reg 5)
+(tile: cast_load_addr (cast (load (addr reg $ofs) $src_sz) $to_size $from_size $signed) reg 5)
 
 #
 # ARITHMETIC

--- a/src/jit/x64/tiles.dasc
+++ b/src/jit/x64/tiles.dasc
@@ -263,8 +263,68 @@ MVM_JIT_TILE_DECL(cast) {
 }
 
 
+/* Logic is the same as cast above except loading from memory instead of reg */
+/* See comments in cast above for more detail */
 MVM_JIT_TILE_DECL(cast_load_addr) {
-    DIE("NYI");
+    MVMint32 ofs       = tile->args[0];
+    MVMint32 load_size = tile->args[1];
+    MVMint32 to_size   = tile->args[2];
+    MVMint32 from_size = tile->args[3];
+    MVMint32 cast_mode = tile->args[4];
+
+    MVMint8  to_reg    = tile->values[0];
+    MVMint8  base      = tile->values[1];
+
+    MVMint32 size_conv = (from_size) | (to_size << 3);
+    if (cast_mode == MVM_JIT_CAST_SIGNED) {
+        switch (size_conv) {
+        case 17:
+            | movsx Rw(to_reg), byte [Rq(base)+ofs];
+            break;
+        case 33:
+            | movsx Rd(to_reg), byte [Rq(base)+ofs];
+            break;
+        case 34:
+            | movsx Rd(to_reg), word [Rq(base)+ofs];
+            break;
+        case 65:
+            | movsx Rq(to_reg), byte [Rq(base)+ofs];
+            break;
+        case 66:
+            | movsx Rq(to_reg), word [Rq(base)+ofs];
+            break;
+        case 68:
+            | mov eax, dword [Rq(base)+ofs];
+            | cdqe;
+            | mov Rq(to_reg), rax;
+            break;
+        default:
+            DIE("Unsupported signed cast %d -> %d\n", from_size, to_size);
+        }
+    } else {
+        switch (size_conv) {
+        case 17:
+            | movzx Rw(to_reg), byte [Rq(base)+ofs];
+            break;
+        case 33:
+            | movzx Rd(to_reg), byte [Rq(base)+ofs];
+            break;
+        case 34:
+            | movzx Rd(to_reg), word [Rq(base)+ofs];
+            break;
+        case 65:
+            | movzx Rq(to_reg), byte [Rq(base)+ofs];
+            break;
+        case 66:
+            | movzx Rq(to_reg), word [Rq(base)+ofs];
+            break;
+        case 68:
+            | mov Rd(to_reg),  dword [Rq(base)+ofs];
+            break;
+        default:
+            DIE("Unsupported unsigned cast %d -> %d\n", from_size, to_size);
+        }
+    }
 }
 
 /* binary operations have special requirements because x86 is two-operand form, e.g:


### PR DESCRIPTION
Implement the 'cast_load_addr' tile for the exprjit template.
Logic mirrors that of the standard cast operation.

Also adds a template that uses the new tile and a macro for storage_spec.

Compiles and passes spectest, but definitely could use review. ping @bdw.