### PR TITLE
Fix alignment of nursery allocations

### DIFF
--- a/src/gc/allocation.c
+++ b/src/gc/allocation.c
@@ -9,6 +9,9 @@
  * trigger a GC run if there is not enough. */
 void * MVM_gc_allocate_nursery(MVMThreadContext *tc, size_t size) {
     void *allocated;
+    /* objects in the nursery must be aligned, so we pad at the end. The
+     * assumption that they are aligned is also encoded in the collector */
+    size = MVM_ALIGN_SIZE(size);
 
     /* Before an allocation is a GC safe-point and thus a good GC sync point
      * also; check if we've been signalled to collect. */

--- a/src/gc/allocation.h
+++ b/src/gc/allocation.h
@@ -15,5 +15,5 @@ void MVM_gc_allocate_gen2_default_clear(MVMThreadContext *tc);
 MVM_STATIC_INLINE void * MVM_gc_allocate(MVMThreadContext *tc, size_t size) {
     return tc->allocate_in_gen2
         ? MVM_gc_gen2_allocate_zeroed(tc->gen2, size)
-        : MVM_gc_allocate_nursery(tc, MVM_ALIGN_SIZE(size));
+        : MVM_gc_allocate_nursery(tc, size);
 }


### PR DESCRIPTION
Recent changes used a path to nursery allocation that are not aligned,
leading to segfaults on e.g. armhf. Alignment is really a property of
the nursery as it is also encoded in the collector, so doing the
alignment within the allocator, not at the call site.

Fixes https://github.com/MoarVM/MoarVM/issues/951