### PR TITLE
Exprjit: Macros & Alterations

### DIFF
--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1308,7 +1308,7 @@ MVMRegister * MVM_frame_find_lexical_by_name(MVMThreadContext *tc, MVMString *na
 
 /* Binds the specified value to the given lexical, finding it along the static
  * chain. */
-MVM_PUBLIC void MVM_frame_bind_lexical_by_name(MVMThreadContext *tc, MVMString *name, MVMuint16 type, MVMRegister *value) {
+MVM_PUBLIC void MVM_frame_bind_lexical_by_name(MVMThreadContext *tc, MVMString *name, MVMuint16 type, MVMRegister value) {
     MVMFrame *cur_frame = tc->cur_frame;
     while (cur_frame != NULL) {
         MVMLexicalRegistry *lexical_names = cur_frame->static_info->body.lexical_names;
@@ -1319,10 +1319,10 @@ MVM_PUBLIC void MVM_frame_bind_lexical_by_name(MVMThreadContext *tc, MVMString *
                 if (cur_frame->static_info->body.lexical_types[entry->value] == type) {
                     if (type == MVM_reg_obj || type == MVM_reg_str) {
                         MVM_ASSIGN_REF(tc, &(cur_frame->header),
-                            cur_frame->env[entry->value].o, value->o);
+                            cur_frame->env[entry->value].o, value.o);
                     }
                     else {
-                        cur_frame->env[entry->value] = *value;
+                        cur_frame->env[entry->value] = value;
                     }
                     return;
                 }

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -232,7 +232,7 @@ MVM_PUBLIC void MVM_frame_capture_inner(MVMThreadContext *tc, MVMObject *code);
 MVM_PUBLIC MVMObject * MVM_frame_takeclosure(MVMThreadContext *tc, MVMObject *code);
 MVM_PUBLIC MVMObject * MVM_frame_vivify_lexical(MVMThreadContext *tc, MVMFrame *f, MVMuint16 idx);
 MVM_PUBLIC MVMRegister * MVM_frame_find_lexical_by_name(MVMThreadContext *tc, MVMString *name, MVMuint16 type);
-MVM_PUBLIC void MVM_frame_bind_lexical_by_name(MVMThreadContext *tc, MVMString *name, MVMuint16 type, MVMRegister *value);
+MVM_PUBLIC void MVM_frame_bind_lexical_by_name(MVMThreadContext *tc, MVMString *name, MVMuint16 type, MVMRegister value);
 MVMObject * MVM_frame_find_lexical_by_name_outer(MVMThreadContext *tc, MVMString *name);
 MVM_PUBLIC MVMRegister * MVM_frame_find_lexical_by_name_rel(MVMThreadContext *tc, MVMString *name, MVMFrame *cur_frame);
 MVMRegister * MVM_frame_lexical_lookup_using_frame_walker(MVMThreadContext *tc,

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -379,25 +379,25 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(bindlex_ni):
                 MVM_frame_bind_lexical_by_name(tc,
                     MVM_cu_string(tc, cu, GET_UI32(cur_op, 0)),
-                    MVM_reg_int64, &(GET_REG(cur_op, 4)));
+                    MVM_reg_int64, GET_REG(cur_op, 4));
                 cur_op += 6;
                 goto NEXT;
             OP(bindlex_nn):
                 MVM_frame_bind_lexical_by_name(tc,
                     MVM_cu_string(tc, cu, GET_UI32(cur_op, 0)),
-                    MVM_reg_num64, &(GET_REG(cur_op, 4)));
+                    MVM_reg_num64, GET_REG(cur_op, 4));
                 cur_op += 6;
                 goto NEXT;
             OP(bindlex_ns):
                 MVM_frame_bind_lexical_by_name(tc,
                     MVM_cu_string(tc, cu, GET_UI32(cur_op, 0)),
-                    MVM_reg_str, &(GET_REG(cur_op, 4)));
+                    MVM_reg_str, GET_REG(cur_op, 4));
                 cur_op += 6;
                 goto NEXT;
             OP(bindlex_no):
                 MVM_frame_bind_lexical_by_name(tc,
                     MVM_cu_string(tc, cu, GET_UI32(cur_op, 0)),
-                    MVM_reg_obj, &(GET_REG(cur_op, 4)));
+                    MVM_reg_obj, GET_REG(cur_op, 4));
                 cur_op += 6;
                 goto NEXT;
             OP(getlex_ng):

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -750,7 +750,7 @@
     (nz $1)
     (ucast
       (^getf (^storage_spec $1) MVMStorageSpec boxed_primitive)
-      int_sz (&sizeof MVMuint16))
+      int_sz (&SIZEOF_MEMBER MVMStorageSpec boxed_primitive))
     (const 0 int_sz)))
 
 (template: gethow
@@ -2222,7 +2222,9 @@
     (let: (($ss (^storage_spec $1)))
       (if
         (nz (^getf $ss MVMStorageSpec boxed_primitive))
-        (ucast (^getf $ss MVMStorageSpec bits) int_sz (&sizeof MVMuint16))
+        (ucast
+          (^getf $ss MVMStorageSpec bits)
+          int_sz (&SIZEOF_MEMBER MVMStorageSpec boxed_primitive))
         (const 0 int_sz)))
     (const 0 int_sz)))
 
@@ -2232,7 +2234,9 @@
     (let: (($ss (^storage_spec $1)))
       (if
         (eq (^getf $ss MVMStorageSpec boxed_primitive) (const 1 int_sz))
-        (ucast (^getf $ss MVMStorageSpec is_unsigned) int_sz (&sizeof MVMuint8))
+        (ucast
+          (^getf $ss MVMStorageSpec is_unsigned)
+          int_sz (&SIZEOF_MEMBER MVMStorageSpec is_unsigned))
         (const 0 int_sz)))
     (const 0 int_sz)))
 
@@ -2494,7 +2498,7 @@
         (copy $type)))))
 
 (template: sp_p6oget_i (load (add (^p6obody $1) $2) int_sz))
-(template: sp_p6oget_n (load (add (^p6obody $1) $2) (&sizeof MVMnum64)))
+(template: sp_p6oget_n (load (add (^p6obody $1) $2) num_sz))
 (template: sp_p6oget_s (load (add (^p6obody $1) $2) ptr_sz))
 
 (template: sp_p6obind_o

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -128,7 +128,7 @@
       (arglist
         (carg (tc) ptr)
         (carg $0 ptr)
-        (carg (const 0 int_sz) int)))
+        (carg (^zero) int)))
     (callv (^func &MVM_frame_try_return)
       (arglist
         (carg (tc) ptr)))
@@ -144,8 +144,8 @@
 
 (template: add_i (add $1 $2))
 (template: sub_i (sub $1 $2))
-(template: inc_i (add $1 (const 1 int_sz)))
-(template: dec_i (sub $1 (const 1 int_sz)))
+(template: inc_i (add $1 (^one)))
+(template: dec_i (sub $1 (^one)))
 
 (template: band_i (and $1 $2))
 (template: bor_i  (or  $1 $2))
@@ -332,7 +332,7 @@
           (carg (tc) ptr)
           (carg $1 ptr)
           (carg $2 ptr)) int_sz)
-      (const 0 int_sz))))
+      (^zero))))
 
 (template: ge_s
   (flagval
@@ -342,7 +342,7 @@
           (carg (tc) ptr)
           (carg $1 ptr)
           (carg $2 ptr)) int_sz)
-      (const 0 int_sz))))
+      (^zero))))
 
 (template: lt_s
   (flagval
@@ -352,7 +352,7 @@
           (carg (tc) ptr)
           (carg $1 ptr)
           (carg $2 ptr)) int_sz)
-      (const 0 int_sz))))
+      (^zero))))
 
 (template: le_s
   (flagval
@@ -362,7 +362,7 @@
           (carg (tc) ptr)
           (carg $1 ptr)
           (carg $2 ptr)) int_sz)
-      (const 0 int_sz))))
+      (^zero))))
 
 (template: cmp_s
   (call (^func &MVM_string_compare)
@@ -540,7 +540,7 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)
-      (carg (const 0 int_sz) int)) int_sz))
+      (carg (^zero) int)) int_sz))
 
 (template: ordat
   (call (^func &MVM_string_ord_at)
@@ -687,7 +687,7 @@
       (carg $1   ptr)
       (carg (^cu_string $2) ptr)
       (carg \$0  ptr)
-      (carg (const 1 int_sz) int))))
+      (carg (^one) int))))
 
 (template: findmeth_s!
   (callv (^func &MVM_6model_find_method)
@@ -696,7 +696,7 @@
       (carg $1   ptr)
       (carg $2   ptr)
       (carg \$0  ptr)
-      (carg (const 1 int_sz) int))))
+      (carg (^one) int))))
 
 (template: can!
   (callv (^func &MVM_6model_can_method)
@@ -734,8 +734,8 @@
   (if (all
         (nz $1)
         (^is_conc_obj $1))
-    (const 1 int_sz)
-    (const 0 int_sz)))
+    (^one)
+    (^zero)))
 
 (template: istype!
   (callv (^func &MVM_6model_istype)
@@ -751,7 +751,7 @@
     (ucast
       (^getf (^storage_spec $1) MVMStorageSpec boxed_primitive)
       int_sz (&SIZEOF_MEMBER MVMStorageSpec boxed_primitive))
-    (const 0 int_sz)))
+    (^zero)))
 
 (template: gethow
   (let: (($how (^getf (^stable $1) MVMSTable HOW)))
@@ -1285,7 +1285,7 @@
       (carg \$0 ptr)
       (carg (^nullptr) ptr)
       (carg (^nullptr) ptr)
-      (carg (const 0 int_sz) int))))
+      (carg (^zero) int))))
 
 (template: isfalse!
   (callv (^func &MVM_coerce_istrue)
@@ -1295,7 +1295,7 @@
       (carg \$0 ptr)
       (carg (^nullptr) ptr)
       (carg (^nullptr) ptr)
-      (carg (const 1 int_sz) int))))
+      (carg (^one) int))))
 
 (template: bootint      (^get_instance_field boot_types.BOOTInt))
 (template: bootnum      (^get_instance_field boot_types.BOOTNum))
@@ -1310,36 +1310,36 @@
   (if (all
         (nz $1)
         (^is_repr_id $1 MVM_REPR_ID_P6int))
-    (const 1 int_sz)
-    (const 0 int_sz)))
+    (^one)
+    (^zero)))
 
 (template: isnum
   (if (all
         (nz $1)
         (^is_repr_id $1 MVM_REPR_ID_P6num))
-    (const 1 int_sz)
-    (const 0 int_sz)))
+    (^one)
+    (^zero)))
 
 (template: isstr
   (if (all
         (nz $1)
         (^is_repr_id $1 MVM_REPR_ID_P6str))
-    (const 1 int_sz)
-    (const 0 int_sz)))
+    (^one)
+    (^zero)))
 
 (template: islist
   (if (all
         (nz $1)
         (^is_repr_id $1 MVM_REPR_ID_VMArray))
-    (const 1 int_sz)
-    (const 0 int_sz)))
+    (^one)
+    (^zero)))
 
 (template: ishash
   (if (all
         (nz $1)
         (^is_repr_id $1 MVM_REPR_ID_MVMHash))
-    (const 1 int_sz)
-    (const 0 int_sz)))
+    (^one)
+    (^zero)))
 
 (template: hllboxtype_i
   (^getf (^hllconfig) MVMHLLConfig int_box_type))
@@ -1425,8 +1425,8 @@
     (any
       (zr $1)
       (eq (^getf (^stable $1) MVMSTable invoke) (^func &MVM_6model_invoke_default)))
-    (const 0 int_sz)
-    (const 1 int_sz)))
+    (^zero)
+    (^one)))
 
 (template: getcodeobj
   (call (^func &MVM_frame_get_code_object)
@@ -1438,7 +1438,7 @@
   (if
     (eq (^getf (^stable $1) MVMSTable invoke) (^func &MVM_6model_invoke_default))
     (flagval (nz (^getf (^stable $1) MVMSTable invocation_spec)))
-    (const 1 int_sz)))
+    (^one)))
 
 (template: setdispatcher
   (dov
@@ -1462,8 +1462,8 @@
 (template: iscont
   (if
     (any (^is_vmnull $1) (zr (^getf (^stable $1) MVMSTable container_spec)))
-    (const 0 int_sz)
-    (const 1 int_sz)))
+    (^zero)
+    (^one)))
 
 (template: decont!
   (ifv (any
@@ -1820,7 +1820,7 @@
       (carg (tc) ptr)
       (carg $1   ptr)
       (carg $2   int)
-      (carg (const 0 int_sz) int)) int_sz))
+      (carg (^zero) int)) int_sz))
 
 (template: tryfindmeth!
   (callv (^func &MVM_6model_find_method)
@@ -1829,7 +1829,7 @@
       (carg $1   ptr)
       (carg (^cu_string $2) ptr)
       (carg \$0  ptr)
-      (carg (const 0 int_sz) int))))
+      (carg (^zero) int))))
 
 (template: tryfindmeth_s!
   (callv (^func &MVM_6model_find_method)
@@ -1838,7 +1838,7 @@
       (carg $1   ptr)
       (carg $2   ptr)
       (carg \$0  ptr)
-      (carg (const 0 int_sz) int))))
+      (carg (^zero) int))))
 
 (template: rand_i
   (call (^func &MVM_proc_rand_i)
@@ -2128,7 +2128,7 @@
       (carg (tc) ptr)
       (carg $1   ptr)
       (carg $2   int)
-      (carg (const 1 int_sz) int)) int_sz))
+      (carg (^one) int)) int_sz))
 
 (template: iscont_i
   (call (^func MVM_6model_container_iscont_i)
@@ -2185,7 +2185,7 @@
 (template: isrwcont
   (if
     (^is_vmnull $1)
-    (const 0 int_sz)
+    (^zero)
     (let: (($cs (^getf (^stable $1) MVMSTable container_spec)))
       (if
         (nz $cs)
@@ -2193,7 +2193,7 @@
           (arglist
             (carg (tc) ptr)
             (carg $1 ptr)) int_sz)
-        (const 0 int_sz)))))
+        (^zero)))))
 
 (template: fc
   (call (^func &MVM_string_fc)
@@ -2225,20 +2225,20 @@
         (ucast
           (^getf $ss MVMStorageSpec bits)
           int_sz (&SIZEOF_MEMBER MVMStorageSpec boxed_primitive))
-        (const 0 int_sz)))
-    (const 0 int_sz)))
+        (^zero)))
+    (^zero)))
 
 (template: objprimunsigned
   (if
     (nz $1)
     (let: (($ss (^storage_spec $1)))
       (if
-        (eq (^getf $ss MVMStorageSpec boxed_primitive) (const 1 int_sz))
+        (eq (^getf $ss MVMStorageSpec boxed_primitive) (^one))
         (ucast
           (^getf $ss MVMStorageSpec is_unsigned)
           int_sz (&SIZEOF_MEMBER MVMStorageSpec is_unsigned))
-        (const 0 int_sz)))
-    (const 0 int_sz)))
+        (^zero)))
+    (^zero)))
 
 (template: coerce_iu  (copy $1))
 

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -42,7 +42,7 @@
       (arglist
         (carg (tc) ptr)
         (carg (^cu_string $1) ptr)
-        (carg (const (&QUOTE MVM_reg_int64) int_sz) int)) int_sz)
+        (carg (^reg_int) int)) int_sz)
     int_sz))
 
 (template: getlex_nn
@@ -51,7 +51,7 @@
       (arglist
         (carg (tc) ptr)
         (carg (^cu_string $1) ptr)
-        (carg (const (&QUOTE MVM_reg_num64) int_sz) int)) int_sz)
+        (carg (^reg_num) int)) int_sz)
     num_sz))
 
 (template: getlex_ns
@@ -60,7 +60,7 @@
       (arglist
         (carg (tc) ptr)
         (carg (^cu_string $1) ptr)
-        (carg (const (&QUOTE MVM_reg_str) int_sz) int)) int_sz)
+        (carg (^reg_str) int)) int_sz)
     ptr_sz))
 
 (template: getlex_no
@@ -68,7 +68,7 @@
                    (arglist
                      (carg (tc) ptr)
                      (carg (^cu_string $1) ptr)
-                     (carg (const (&QUOTE MVM_reg_obj) int_sz) int)) ptr_sz)))
+                     (carg (^reg_obj) int)) ptr_sz)))
     (if (nz $found) (load $found ptr_sz) (^vmnull))))
 
 (template: bindlex_ni
@@ -76,7 +76,7 @@
     (arglist
       (carg (tc) ptr)
       (carg (^cu_string $0) ptr)
-      (carg (const (&QUOTE MVM_reg_int64) int_sz) int)
+      (carg (^reg_int) int)
       (carg $1 ptr))))
 
 (template: bindlex_nn
@@ -84,7 +84,7 @@
     (arglist
       (carg (tc) ptr)
       (carg (^cu_string $0) ptr)
-      (carg (const (&QUOTE MVM_reg_num64) int_sz) int)
+      (carg (^reg_num) int)
       (carg $1 ptr))))
 
 (template: bindlex_ns
@@ -92,7 +92,7 @@
     (arglist
       (carg (tc) ptr)
       (carg (^cu_string $0) ptr)
-      (carg (const (&QUOTE MVM_reg_str) int_sz) int)
+      (carg (^reg_str) int)
       (carg $1 ptr))))
 
 (template: bindlex_no
@@ -100,7 +100,7 @@
     (arglist
       (carg (tc) ptr)
       (carg (^cu_string $0) ptr)
-      (carg (const (&QUOTE MVM_reg_obj) int_sz) int)
+      (carg (^reg_obj) int)
       (carg $1 ptr))))
 
 (template: getdynlex
@@ -812,7 +812,7 @@
       (carg (^body $1) ptr)
       (carg $2 int)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
+      (carg (^reg_int) int))))
 
 (template: atpos_n!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.at_pos)
@@ -823,7 +823,7 @@
       (carg (^body $1) ptr)
       (carg $2 int)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
+      (carg (^reg_num) int))))
 
 (template: atpos_s!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.at_pos)
@@ -834,7 +834,7 @@
       (carg (^body $1) ptr)
       (carg $2 int)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
+      (carg (^reg_str) int))))
 
 #  REPR(obj)->pos_funcs.at_pos(tc, STABLE(obj), obj,
 #       OBJECT_BODY(obj), GET_REG(cur_op, 4).i64,
@@ -850,7 +850,7 @@
         (carg (^body $1) ptr)
         (carg $2 int)
         (carg \$0 ptr)
-        (carg (const (&QUOTE MVM_reg_obj) int_sz) int)))))
+        (carg (^reg_obj) int)))))
 
 (template: bindpos_i
   (dov
@@ -862,7 +862,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_int64) int_sz) int)))
+        (carg (^reg_int) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -878,7 +878,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_num64) int_sz) int)))
+        (carg (^reg_num) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -894,7 +894,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_str) int_sz) int)))
+        (carg (^reg_str) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -910,7 +910,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_obj) int_sz) int)))
+        (carg (^reg_obj) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -925,7 +925,7 @@
         (carg $0 ptr)
         (carg (^body $0) ptr)
         (carg $1 ptr)
-        (carg (const (&QUOTE MVM_reg_int64) int_sz) int)))
+        (carg (^reg_int) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -940,7 +940,7 @@
         (carg $0 ptr)
         (carg (^body $0) ptr)
         (carg $1 ptr)
-        (carg (const (&QUOTE MVM_reg_num64) int_sz) int)))
+        (carg (^reg_num) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -955,7 +955,7 @@
         (carg $0 ptr)
         (carg (^body $0) ptr)
         (carg $1 ptr)
-        (carg (const (&QUOTE MVM_reg_str) int_sz) int)))
+        (carg (^reg_str) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -970,7 +970,7 @@
         (carg $0 ptr)
         (carg (^body $0) ptr)
         (carg $1 ptr)
-        (carg (const (&QUOTE MVM_reg_obj) int_sz) int)))
+        (carg (^reg_obj) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -984,7 +984,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
+      (carg (^reg_int) int))))
 
 (template: pop_n!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.pop)
@@ -994,7 +994,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
+      (carg (^reg_num) int))))
 
 (template: pop_s!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.pop)
@@ -1004,7 +1004,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
+      (carg (^reg_str) int))))
 
 (template: pop_o!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.pop)
@@ -1014,7 +1014,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_obj) int_sz) int))))
+      (carg (^reg_obj) int))))
 
 (template: shift_i!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.shift)
@@ -1024,7 +1024,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
+      (carg (^reg_int) int))))
 
 (template: shift_n!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.shift)
@@ -1034,7 +1034,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
+      (carg (^reg_num) int))))
 
 (template: shift_s!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.shift)
@@ -1044,7 +1044,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
+      (carg (^reg_str) int))))
 
 (template: shift_o!
   (callv (^getf (^repr $1) MVMREPROps pos_funcs.shift)
@@ -1054,7 +1054,7 @@
       (carg $1 ptr)
       (carg (^body $1) ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_obj) int_sz) int))))
+      (carg (^reg_obj) int))))
 
 (template: unshift_i
   (callv (^getf (^repr $0) MVMREPROps pos_funcs.unshift)
@@ -1064,7 +1064,7 @@
       (carg $0 ptr)
       (carg (^body $0) ptr)
       (carg $1 ptr)
-      (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
+      (carg (^reg_int) int))))
 
 (template: unshift_n
   (callv (^getf (^repr $0) MVMREPROps pos_funcs.unshift)
@@ -1074,7 +1074,7 @@
       (carg $0 ptr)
       (carg (^body $0) ptr)
       (carg $1 ptr)
-      (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
+      (carg (^reg_num) int))))
 
 (template: unshift_s
   (callv (^getf (^repr $0) MVMREPROps pos_funcs.unshift)
@@ -1084,7 +1084,7 @@
       (carg $0 ptr)
       (carg (^body $0) ptr)
       (carg $1 ptr)
-      (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
+      (carg (^reg_str) int))))
 
 (template: unshift_o
   (callv (^getf (^repr $0) MVMREPROps pos_funcs.unshift)
@@ -1094,7 +1094,7 @@
       (carg $0 ptr)
       (carg (^body $0) ptr)
       (carg $1 ptr)
-      (carg (const (&QUOTE MVM_reg_obj) int_sz) int))))
+      (carg (^reg_obj) int))))
 
 
 (template: splice
@@ -1133,7 +1133,7 @@
       (carg (^body $1) ptr)
       (carg $2 ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_int64) int_sz) int))))
+      (carg (^reg_int) int))))
 
 
 (template: atkey_n!
@@ -1145,7 +1145,7 @@
       (carg (^body $1) ptr)
       (carg $2 ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_num64) int_sz) int))))
+      (carg (^reg_num) int))))
 
 (template: atkey_s!
   (callv (^getf (^repr $1) MVMREPROps ass_funcs.at_key)
@@ -1156,7 +1156,7 @@
       (carg (^body $1) ptr)
       (carg $2 ptr)
       (carg \$0 ptr)
-      (carg (const (&QUOTE MVM_reg_str) int_sz) int))))
+      (carg (^reg_str) int))))
 
 #  REPR(obj)->ass_funcs.at_key(tc, STABLE(obj), obj, OBJECT_BODY(obj),
 #       (MVMObject *)GET_REG(cur_op, 4).s, &GET_REG(cur_op, 0), MVM_reg_obj);
@@ -1171,7 +1171,7 @@
         (carg (^body $1) ptr)
         (carg $2 ptr)
         (carg \$0 ptr)
-        (carg (const (&QUOTE MVM_reg_obj) int_sz) int)))))
+        (carg (^reg_obj) int)))))
 
 (template: bindkey_i
   (dov
@@ -1183,7 +1183,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_int64) int_sz) int)))
+        (carg (^reg_int) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -1199,7 +1199,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_num64) int_sz) int)))
+        (carg (^reg_num) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -1215,7 +1215,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_str) int_sz) int)))
+        (carg (^reg_str) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -1231,7 +1231,7 @@
         (carg (^body $0) ptr)
         (carg $1 ptr)
         (carg $2 ptr)
-        (carg (const (&QUOTE MVM_reg_obj) int_sz) int)))
+        (carg (^reg_obj) int)))
     (callv (^func &MVM_SC_WB_OBJ)
       (arglist
         (carg (tc) ptr)
@@ -2098,7 +2098,7 @@
                    (arglist
                      (carg (tc) ptr)
                      (carg $1   ptr)
-                     (carg (const (&QUOTE MVM_reg_obj) int_sz) int)) ptr_sz)))
+                     (carg (^reg_obj) int)) ptr_sz)))
     (if (nz $found) (load $found ptr_sz) (^vmnull))))
 
 (template: getlexperinvtype_o
@@ -2106,7 +2106,7 @@
                    (arglist
                      (carg (tc) ptr)
                      (carg $1   ptr)
-                     (carg (const (&QUOTE MVM_reg_obj) int_sz) int)) ptr_sz)))
+                     (carg (^reg_obj) int)) ptr_sz)))
     (if (nz $found) (load $found ptr_sz) (^vmnull))))
 
 (template: execname

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -111,3 +111,6 @@
            (^not_repr_id ,decoder MVM_REPR_ID_Decoder)
            (zr (flagval (^is_conc_obj ,decoder))))
 	(^throw_adhoc (&CAT3 "Operation '" ,op "'can only work on an object with the Decoder representation"))))
+
+(macro: ^zero () (const 0 int_sz))
+(macro: ^one  () (const 1 int_sz))

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -114,3 +114,8 @@
 
 (macro: ^zero () (const 0 int_sz))
 (macro: ^one  () (const 1 int_sz))
+
+(macro: ^reg_int () (const (&QUOTE MVM_reg_int64) int_sz))
+(macro: ^reg_num () (const (&QUOTE MVM_reg_num64) int_sz))
+(macro: ^reg_str () (const (&QUOTE MVM_reg_str)   int_sz))
+(macro: ^reg_obj () (const (&QUOTE MVM_reg_obj)   int_sz))


### PR DESCRIPTION
Implements a few macros and alterations.

Also changes signature for and args passed to
MVM_frame_bind_lexical_by_name to better
accomodate the exprjit.