### PR TITLE
Fix wrong field in exprjit cast template and add macro

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -748,9 +748,7 @@
 (template: objprimspec
   (if
     (nz $1)
-    (ucast
-      (^getf (^storage_spec $1) MVMStorageSpec boxed_primitive)
-      int_sz (&SIZEOF_MEMBER MVMStorageSpec boxed_primitive))
+    (^getf_ucast (^storage_spec $1) MVMStorageSpec boxed_primitive int_sz)
     (^zero)))
 
 (template: gethow
@@ -2222,9 +2220,7 @@
     (let: (($ss (^storage_spec $1)))
       (if
         (nz (^getf $ss MVMStorageSpec boxed_primitive))
-        (ucast
-          (^getf $ss MVMStorageSpec bits)
-          int_sz (&SIZEOF_MEMBER MVMStorageSpec boxed_primitive))
+        (^getf_ucast $ss MVMStorageSpec bits int_sz)
         (^zero)))
     (^zero)))
 
@@ -2234,9 +2230,7 @@
     (let: (($ss (^storage_spec $1)))
       (if
         (eq (^getf $ss MVMStorageSpec boxed_primitive) (^one))
-        (ucast
-          (^getf $ss MVMStorageSpec is_unsigned)
-          int_sz (&SIZEOF_MEMBER MVMStorageSpec is_unsigned))
+        (^getf_ucast $ss MVMStorageSpec is_unsigned int_sz)
         (^zero)))
     (^zero)))
 

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -7,6 +7,16 @@
 (macro: ^setf (,object ,type ,field ,value)
     (store (^addrf ,object ,type ,field) ,value (&SIZEOF_MEMBER ,type ,field)))
 
+(macro: ^getf_scast (,object ,type ,field ,cast_to_sz)
+  (scast
+    (^getf ,object ,type ,field)
+    ,cast_to_sz (&SIZEOF_MEMBER ,type ,field)))
+
+(macro: ^getf_ucast (,object ,type ,field ,cast_to_sz)
+  (ucast
+    (^getf ,object ,type ,field)
+    ,cast_to_sz (&SIZEOF_MEMBER ,type ,field)))
+
 (macro: ^cu_callsite_addr (,a) (idx  (^getf (cu) MVMCompUnit body.callsites) ,a ptr_sz))
 
 (macro: ^frame () (^getf (tc) MVMThreadContext cur_frame))


### PR DESCRIPTION
In the 'objprimbits' template, accidently used the wrong field name for
cast's from_size value ('boxed_primitive' instead of 'bits').

In this case, 'boxed_primitive' and 'bits' are both the same size, but
that doesn't make it less wrong just less painfully wrong 😉.

Added a macro that makes this idiom more DRY and less prone to this type
of error.