### PR TITLE
Cleanup _I ops

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3427,10 +3427,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 8;
                 goto NEXT;
             OP(expmod_I): {
-                MVMObject *   const type = GET_REG(cur_op, 8).o;
-                MVMObject * const result = MVM_repr_alloc_init(tc, type);
-                MVM_bigint_expmod(tc, result, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o, GET_REG(cur_op, 6).o);
-                GET_REG(cur_op, 0).o = result;
+                GET_REG(cur_op, 0).o = MVM_bigint_expmod(tc, GET_REG(cur_op, 8).o, GET_REG(cur_op, 2).o,
+                    GET_REG(cur_op, 4).o, GET_REG(cur_op, 6).o);
                 cur_op += 10;
                 goto NEXT;
             }

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3310,26 +3310,26 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 8;
                 goto NEXT;
             OP(div_I): {
-                MVMObject *   const type = GET_REG(cur_op, 6).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_div(tc, type, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_div(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
                 cur_op += 8;
                 goto NEXT;
             }
             OP(mod_I): {
-                MVMObject *   const type = GET_REG(cur_op, 6).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_mod(tc, type, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_mod(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
                 cur_op += 8;
                 goto NEXT;
             }
             OP(neg_I): {
-                MVMObject *   const type = GET_REG(cur_op, 4).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_neg(tc, type, GET_REG(cur_op, 2).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_neg(tc, GET_REG(cur_op, 4).o,
+                    GET_REG(cur_op, 2).o);
                 cur_op += 6;
                 goto NEXT;
             }
             OP(abs_I): {
-                MVMObject *   const type = GET_REG(cur_op, 4).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_abs(tc, type, GET_REG(cur_op, 2).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_abs(tc, GET_REG(cur_op, 4).o,
+                    GET_REG(cur_op, 2).o);
                 cur_op += 6;
                 goto NEXT;
             }
@@ -3376,38 +3376,38 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(bor_I): {
-                MVMObject *   const type = GET_REG(cur_op, 6).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_or(tc, type, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_or(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
                 cur_op += 8;
                 goto NEXT;
             }
             OP(bxor_I): {
-                MVMObject *   const type = GET_REG(cur_op, 6).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_xor(tc, type, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_xor(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
                 cur_op += 8;
                 goto NEXT;
             }
             OP(band_I): {
-                MVMObject *   const type = GET_REG(cur_op, 6).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_and(tc, type, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_and(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
                 cur_op += 8;
                 goto NEXT;
             }
             OP(bnot_I): {
-                MVMObject *   const type = GET_REG(cur_op, 4).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_not(tc, type, GET_REG(cur_op, 2).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_not(tc, GET_REG(cur_op, 4).o,
+                    GET_REG(cur_op, 2).o);
                 cur_op += 6;
                 goto NEXT;
             }
             OP(blshift_I): {
-                MVMObject *   const type = GET_REG(cur_op, 6).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_shl(tc, type, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).i64);
+                GET_REG(cur_op, 0).o = MVM_bigint_shl(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).i64);
                 cur_op += 8;
                 goto NEXT;
             }
             OP(brshift_I): {
-                MVMObject *   const type = GET_REG(cur_op, 6).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_shr(tc, type, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).i64);
+                GET_REG(cur_op, 0).o = MVM_bigint_shr(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).i64);
                 cur_op += 8;
                 goto NEXT;
             }
@@ -3417,7 +3417,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 10;
                 goto NEXT;
             OP(gcd_I): {
-                GET_REG(cur_op, 0).o = MVM_bigint_gcd(tc, GET_REG(cur_op, 6).o, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_gcd(tc, GET_REG(cur_op, 6).o,
+                    GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
                 cur_op += 8;
                 goto NEXT;
             }
@@ -3440,8 +3441,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(rand_I): {
-                MVMObject * const type = GET_REG(cur_op, 4).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_rand(tc, type, GET_REG(cur_op, 2).o);
+                GET_REG(cur_op, 0).o = MVM_bigint_rand(tc, GET_REG(cur_op, 4).o,
+                    GET_REG(cur_op, 2).o);
                 cur_op += 6;
                 goto NEXT;
             }
@@ -3457,8 +3458,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(coerce_nI): {
-                MVMObject *   const type = GET_REG(cur_op, 4).o;
-                GET_REG(cur_op, 0).o = MVM_bigint_from_num(tc, type, GET_REG(cur_op, 2).n64);
+                GET_REG(cur_op, 0).o = MVM_bigint_from_num(tc, GET_REG(cur_op, 4).o,
+                    GET_REG(cur_op, 2).n64);
                 cur_op += 6;
                 goto NEXT;
             }

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -1710,20 +1710,14 @@
       (carg $1   ptr)
       (carg $2   ptr)) ptr_sz))
 
-(template: expmod_I!
-  (let: (($res (call (^func &MVM_repr_alloc_init)
-                 (arglist
-                   (carg (tc) ptr)
-                   (carg $4   ptr)) ptr_sz)))
-    (dov
-      (callv (^func &MVM_bigint_expmod)
-        (arglist
-          (carg (tc) ptr)
-          (carg $res ptr)
-          (carg $1   ptr)
-          (carg $2   ptr)
-          (carg $3   ptr)))
-      (store \$0 $res ptr_sz))))
+(template: expmod_I
+  (call (^func &MVM_bigint_expmod)
+    (arglist
+      (carg (tc) ptr)
+      (carg $4   ptr)
+      (carg $1   ptr)
+      (carg $2   ptr)
+      (carg $3   ptr)) ptr_sz))
 
 (template: isprime_I
   (call (^func &MVM_bigint_is_prime)

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -824,11 +824,12 @@ MVMObject *MVM_bigint_not(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
     return result;
 }
 
-void MVM_bigint_expmod(MVMThreadContext *tc, MVMObject *result, MVMObject *a, MVMObject *b, MVMObject *c) {
+MVMObject *MVM_bigint_expmod(MVMThreadContext *tc, MVMObject *result_type, MVMObject *a, MVMObject *b, MVMObject *c) {
     MVMP6bigintBody *ba = get_bigint_body(tc, a);
     MVMP6bigintBody *bb = get_bigint_body(tc, b);
     MVMP6bigintBody *bc = get_bigint_body(tc, c);
-    MVMP6bigintBody *bd = get_bigint_body(tc, result);
+    MVMP6bigintBody *bd;
+    MVMObject       *result;
 
     mp_int *tmp[3] = { NULL, NULL, NULL };
 
@@ -838,10 +839,18 @@ void MVM_bigint_expmod(MVMThreadContext *tc, MVMObject *result, MVMObject *a, MV
     mp_int *id = MVM_malloc(sizeof(mp_int));
     mp_init(id);
 
+    MVMROOT3(tc, a, b, c, {
+        result = MVM_repr_alloc_init(tc, result_type);
+    });
+
+    bd = get_bigint_body(tc, result);
+
     mp_exptmod(ia, ib, ic, id);
     store_bigint_result(bd, id);
     clear_temp_bigints(tmp, 3);
     adjust_nursery(tc, bd);
+
+    return result;
 }
 
 void MVM_bigint_from_str(MVMThreadContext *tc, MVMObject *a, const char *buf) {

--- a/src/math/bigintops.h
+++ b/src/math/bigintops.h
@@ -26,7 +26,7 @@ MVMObject * MVM_bigint_and(MVMThreadContext *tc, MVMObject *result, MVMObject *a
 MVMObject * MVM_bigint_shl(MVMThreadContext *tc, MVMObject *result, MVMObject *a, MVMint64 n);
 MVMObject * MVM_bigint_shr(MVMThreadContext *tc, MVMObject *result, MVMObject *a, MVMint64 n);
 
-void MVM_bigint_expmod(MVMThreadContext *tc, MVMObject *result, MVMObject *a, MVMObject *b, MVMObject *c);
+MVMObject * MVM_bigint_expmod(MVMThreadContext *tc, MVMObject *result, MVMObject *a, MVMObject *b, MVMObject *c);
 
 MVMint64 MVM_bigint_cmp(MVMThreadContext *tc, MVMObject *a, MVMObject *b);
 


### PR DESCRIPTION
Make the ops in interp.c more consistent, and convert `expmod_I` to allocate in the function like the other `*_I` ops do.

NQP builds ok and passe `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.