### PR TITLE
Implement shift ops for exprjit

### DIFF
--- a/docs/jit/overview.org
+++ b/docs/jit/overview.org
@@ -127,61 +127,64 @@ And an example of a macro definition would be:
 *** Operators
 
 These are all the operators that are known by the expression language
-as of today (<2017-09-25 Mon>).
+as of today (<2018-09-30 Sun>).
 
-| Operator  | Shape                            | Type     | Semantics                                              |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =LOAD=    | =(load reg $size)=               | =reg=    | Load a value from a memory address                     |
-| =STORE=   | =(store reg reg $size)=          | =void=   | Store a value to a memory address                      |
-| =CONST=   | =(const $value $size)=           | =reg=    | Load a constant value to a register                    |
-| =ADDR=    | =(addr reg $ofs)=                | =reg=    | Add a constant offset to a pointer                     |
-| =IDX=     | =(idx reg reg $scale)=           | =reg=    | Compute a pointer for an index in an array             |
-| =COPY=    | =(copy reg)=                     | =reg=    | Copy this value (opaque to tiling)                     |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =LT=      | =(lt reg reg)=                   | =flag=   | First operand is smaller than second                   |
-| =LE=      | =(le reg reg)=                   | =flag=   | First operand is smaller than or equal to second       |
-| =EQ=      | =(eq reg reg)=                   | =flag=   | First operand is equal to second                       |
-| =NE=      | =(ne reg reg)=                   | =flag=   | First operand is not equal to second                   |
-| =GE=      | =(ge reg reg)=                   | =flag=   | First operand is larger than or equal to second        |
-| =GT=      | =(gt reg reg)=                   | =flag=   | First operand is larger than second                    |
-| =NZ=      | =(nz reg)=                       | =flag=   | Operand is nonzero                                     |
-| =ZR=      | =(zr reg)=                       | =flag=   | Operand equals zero                                    |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =CAST=    | =(cast reg $to $from $sign)=     | =reg=    | Convert a value from smaller to larger representation  |
-| =FLAGVAL= | =(flagval flag)=                 | =reg=    | Binary value of comparison operator                    |
-| =DISCARD= | =(discard reg)=                  | =void=   | Discard value of child operator                        |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =ADD=     | =(add reg reg)=                  | =reg=    | Add two integer values                                 |
-| =SUB=     | =(sub reg reg)=                  | =reg=    | Subtract second operand from first                     |
-| =AND=     | =(and reg reg)=                  | =reg=    | Binary AND (intersection) of two operands              |
-| =OR=      | =(or reg reg)=                   | =reg=    | Binary OR (union) of two operands                      |
-| =XOR=     | =(xor reg reg)=                  | =reg=    | Binary XOR of two operands                             |
-| =NOT=     | =(not reg)=                      | =reg=    | Binary negation of operand                             |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =ALL=     | =(all flag+)=                    | =flag=   | Variadic short-circuit logical AND                     |
-| =ANY=     | =(any flag+)=                    | =flag=   | Variadic short-circuit logical OR                      |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =DO=      | =(do void* reg)=                 | =reg=    | Execute multiple statements and return last expression |
-| =DOV=     | =(do void+)=                     | =void=   | Execute multiple statements                            |
-| =WHEN=    | =(when flag void)=               | =void=   | Execute statement if condition is met                  |
-| =IF=      | =(if flag reg reg)=              | =reg=    | Yield value of conditional expression                  |
-| =IFV=     | =(ifv flag void void)=           | =void=   | Conditionally execute one of two statements            |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =BRANCH=  | =(branch reg)=                   | =void=   | Jump to code position                                  |
-| =LABEL=   | =(label $label)=                 | =reg=    | Load position of code                                  |
-| =MARK=    | =(mark (label $label))=          | =void=   | Mark this position                                     |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =CALL=    | =(call reg (arglist ...) $size)= | =reg=    | Call a function and return a value                     |
-| =CALLV=   | =(call reg (arglist ...))=       | =void=   | Call a function without a return value                 |
-| =ARGLIST= | =(arglist (carg reg $type)+)=    | =c_args= | Setup function call arguments                          |
-| =CARG=    | =(carg reg $type)=               | =void=   | Annotate value with 'parameter type'                   |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =GUARD=   | =(guard void $before $after)=    | =void=   | Wrap a statement with code before and after            |
-|-----------+----------------------------------+----------+--------------------------------------------------------|
-| =TC=      | =(tc)=                           | =reg=    | Refer to MoarVM thread context                         |
-| =CU=      | =(cu)=                           | =reg=    | Refer to current compilation unit                      |
-| =LOCAL=   | =(local)=                        | =reg=    | Refer to current frame working memory                  |
-| =STACK=   | =(stack)=                        | =reg=    | Refer to top of C frame stack                          |
+| Operator  | Shape                            | Type     | Semantics                                                                                             |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =LOAD=    | =(load reg $size)=               | =reg=    | Load a value from a memory address                                                                    |
+| =STORE=   | =(store reg reg $size)=          | =void=   | Store a value to a memory address                                                                     |
+| =CONST=   | =(const $value $size)=           | =reg=    | Load a constant value to a register                                                                   |
+| =ADDR=    | =(addr reg $ofs)=                | =reg=    | Add a constant offset to a pointer                                                                    |
+| =IDX=     | =(idx reg reg $scale)=           | =reg=    | Compute a pointer for an index in an array                                                            |
+| =COPY=    | =(copy reg)=                     | =reg=    | Copy this value (opaque to tiling)                                                                    |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =LT=      | =(lt reg reg)=                   | =flag=   | First operand is smaller than second                                                                  |
+| =LE=      | =(le reg reg)=                   | =flag=   | First operand is smaller than or equal to second                                                      |
+| =EQ=      | =(eq reg reg)=                   | =flag=   | First operand is equal to second                                                                      |
+| =NE=      | =(ne reg reg)=                   | =flag=   | First operand is not equal to second                                                                  |
+| =GE=      | =(ge reg reg)=                   | =flag=   | First operand is larger than or equal to second                                                       |
+| =GT=      | =(gt reg reg)=                   | =flag=   | First operand is larger than second                                                                   |
+| =NZ=      | =(nz reg)=                       | =flag=   | Operand is nonzero                                                                                    |
+| =ZR=      | =(zr reg)=                       | =flag=   | Operand equals zero                                                                                   |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =SCAST=   | =(scast reg $to $from $sign)=    | =reg=    | Convert a signed value from smaller to larger representation                                          |
+| =UCAST=   | =(ucast reg $to $from $sign)=    | =reg=    | Convert an unsigned value from one representation to another (larger to smaller or smaller to larger) |
+| =FLAGVAL= | =(flagval flag)=                 | =reg=    | Binary value of comparison operator                                                                   |
+| =DISCARD= | =(discard reg)=                  | =void=   | Discard value of child operator                                                                       |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =ADD=     | =(add reg reg)=                  | =reg=    | Add two integer values                                                                                |
+| =SUB=     | =(sub reg reg)=                  | =reg=    | Subtract second operand from first                                                                    |
+| =AND=     | =(and reg reg)=                  | =reg=    | Binary AND (intersection) of two operands                                                             |
+| =OR=      | =(or reg reg)=                   | =reg=    | Binary OR (union) of two operands                                                                     |
+| =XOR=     | =(xor reg reg)=                  | =reg=    | Binary XOR of two operands                                                                            |
+| =NOT=     | =(not reg)=                      | =reg=    | Binary negation of operand                                                                            |
+| =LSHIFT=  | =(lshift reg reg)=               | =reg=    | Binary left shift of operand                                                                          |
+| =RSHIFT=  | =(rshift reg reg)=               | =reg=    | Binary right shift of operand. Bits shifted in match previous sign bit                                |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =ALL=     | =(all flag+)=                    | =flag=   | Variadic short-circuit logical AND                                                                    |
+| =ANY=     | =(any flag+)=                    | =flag=   | Variadic short-circuit logical OR                                                                     |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =DO=      | =(do void* reg)=                 | =reg=    | Execute multiple statements and return last expression                                                |
+| =DOV=     | =(do void+)=                     | =void=   | Execute multiple statements                                                                           |
+| =WHEN=    | =(when flag void)=               | =void=   | Execute statement if condition is met                                                                 |
+| =IF=      | =(if flag reg reg)=              | =reg=    | Yield value of conditional expression                                                                 |
+| =IFV=     | =(ifv flag void void)=           | =void=   | Conditionally execute one of two statements                                                           |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =BRANCH=  | =(branch reg)=                   | =void=   | Jump to code position                                                                                 |
+| =LABEL=   | =(label $label)=                 | =reg=    | Load position of code                                                                                 |
+| =MARK=    | =(mark (label $label))=          | =void=   | Mark this position                                                                                    |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =CALL=    | =(call reg (arglist ...) $size)= | =reg=    | Call a function and return a value                                                                    |
+| =CALLV=   | =(call reg (arglist ...))=       | =void=   | Call a function without a return value                                                                |
+| =ARGLIST= | =(arglist (carg reg $type)+)=    | =c_args= | Setup function call arguments                                                                         |
+| =CARG=    | =(carg reg $type)=               | =void=   | Annotate value with 'parameter type'                                                                  |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =GUARD=   | =(guard void $before $after)=    | =void=   | Wrap a statement with code before and after                                                           |
+|-----------+----------------------------------+----------+-------------------------------------------------------------------------------------------------------|
+| =TC=      | =(tc)=                           | =reg=    | Refer to MoarVM thread context                                                                        |
+| =CU=      | =(cu)=                           | =reg=    | Refer to current compilation unit                                                                     |
+| =LOCAL=   | =(local)=                        | =reg=    | Refer to current frame working memory                                                                 |
+| =STACK=   | =(stack)=                        | =reg=    | Refer to top of C frame stack                                                                         |
 
 
 *** Tree iteration and manipulation

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -144,6 +144,11 @@
 
 (template: add_i (add $1 $2))
 (template: sub_i (sub $1 $2))
+
+(template: abs_i
+  (let: (($mask (rshift $1 (const 63 int_sz))))
+    (xor (add $1 $mask) $mask)))
+
 (template: inc_i (add $1 (^one)))
 (template: dec_i (sub $1 (^one)))
 
@@ -151,6 +156,9 @@
 (template: bor_i  (or  $1 $2))
 (template: bxor_i (xor $1 $2))
 (template: bnot_i (not $1))
+
+(template: blshift_i (lshift $1 $2))
+(template: brshift_i (rshift $1 $2))
 
 (template: not_i (flagval (zr $1)))
 

--- a/src/jit/expr.c
+++ b/src/jit/expr.c
@@ -502,6 +502,15 @@ static void analyze_node(MVMThreadContext *tc, MVMJitTreeTraverser *traverser,
             cast_mode = MVM_JIT_UCAST;
             break;
         }
+        /* signed binary operations */
+   case MVM_JIT_LSHIFT:
+   case MVM_JIT_RSHIFT:
+        {
+            node_size = MAX(MVM_JIT_EXPR_INFO(tree, links[0])->size,
+                            MVM_JIT_EXPR_INFO(tree, links[1])->size);
+            cast_mode = MVM_JIT_SCAST;
+            break;
+        }
    case MVM_JIT_FLAGVAL:
         /* XXX THIS IS A HACK
          *

--- a/src/jit/expr_ops.h
+++ b/src/jit/expr_ops.h
@@ -49,6 +49,8 @@
     _(OR, 2, 0),  \
     _(XOR, 2, 0), \
     _(NOT, 1, 0), \
+    _(LSHIFT, 2, 0), \
+    _(RSHIFT, 2, 0), \
     /* boolean logic */ \
     _(ALL, -1, 0), \
     _(ANY, -1, 0), \

--- a/src/jit/x64/tile_decl.h
+++ b/src/jit/x64/tile_decl.h
@@ -39,6 +39,11 @@ MVM_JIT_TILE_DECL(or_reg);
 MVM_JIT_TILE_DECL(xor_reg);
 MVM_JIT_TILE_DECL(not_reg);
 
+MVM_JIT_TILE_DECL(lshift_reg);
+MVM_JIT_TILE_DECL(lshift_const);
+MVM_JIT_TILE_DECL(rshift_reg);
+MVM_JIT_TILE_DECL(rshift_const);
+
 MVM_JIT_TILE_DECL(test);
 MVM_JIT_TILE_DECL(test_addr);
 MVM_JIT_TILE_DECL(test_idx);

--- a/src/jit/x64/tile_pattern.tile
+++ b/src/jit/x64/tile_pattern.tile
@@ -77,6 +77,11 @@
 (tile: xor_reg       (xor reg reg) reg 2)
 (tile: not_reg       (not reg) reg 2)
 
+(tile: lshift_reg    (lshift reg reg) reg 2)
+(tile: lshift_const  (lshift reg (const $val $size)) reg 3)
+(tile: rshift_reg    (rshift reg reg) reg 2)
+(tile: rshift_const  (rshift reg (const $val $size)) reg 3)
+
 (tile: sub_reg       (sub reg reg) reg 2)
 (tile: sub_const     (sub reg (const $val $size)) reg 3)
 (tile: sub_load_addr (sub reg (load (subr reg $ofs) $sz)) reg 6)

--- a/src/jit/x64/tiles.dasc
+++ b/src/jit/x64/tiles.dasc
@@ -590,6 +590,44 @@ MVM_JIT_TILE_DECL(not_reg) {
     | not Rq(out);
 }
 
+MVM_JIT_TILE_DECL(lshift_reg) {
+    MVMint8 reg[2];
+    ensure_two_operand_pre(tc, compiler, tile, reg);
+    | sal Rq(reg[0]), reg[1];
+    ensure_two_operand_post(tc, compiler, tile, reg);
+}
+
+MVM_JIT_TILE_DECL(lshift_const) {
+    MVMint8 out  = tile->values[0];
+    MVMint8 in1  = tile->values[1];
+    MVMint32 val = tile->args[0];
+    MVMint32 sz  = tile->args[1];
+
+    if (out != in1) {
+        | mov Rq(out), Rq(in1);
+    }
+    | sal Rq(out), val;
+}
+
+MVM_JIT_TILE_DECL(rshift_reg) {
+    MVMint8 reg[2];
+    ensure_two_operand_pre(tc, compiler, tile, reg);
+    | sar Rq(reg[0]), reg[1];
+    ensure_two_operand_post(tc, compiler, tile, reg);
+}
+
+MVM_JIT_TILE_DECL(rshift_const) {
+    MVMint8 out  = tile->values[0];
+    MVMint8 in1  = tile->values[1];
+    MVMint32 val = tile->args[0];
+    MVMint32 sz  = tile->args[1];
+
+    if (out != in1) {
+        | mov Rq(out), Rq(in1);
+    }
+    | sar Rq(out), val;
+}
+
 MVM_JIT_TILE_DECL(sub_reg) {
     MVMint8 reg[2];
     ensure_two_operand_pre(tc, compiler, tile, reg);


### PR DESCRIPTION
* Implement binary arithmetic shift ops (left and right) for the exprjit
  (AMD64).
* +3 templates (using new ops)
* Updated JIT docs to include new ops