### PR TITLE
Better takedispatcher opt

### DIFF
--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -492,7 +492,10 @@ MVMSpeshBB * merge_graph(MVMThreadContext *tc, MVMSpeshGraph *inliner,
                 /* If the inlining code doesn't set a dispatcher, takedispatcher
                  * in the inlinee can be assumed to always return null. */
                 if (!inliner->sets_dispatcher && !inlinee->sets_dispatcher) {
+                    MVMSpeshFacts *facts = MVM_spesh_get_facts(tc, inlinee, ins->operands[0]);
                     ins->info = MVM_op_get_op(MVM_OP_null);
+                    facts->flags = MVM_SPESH_FACT_KNOWN_TYPE;
+                    facts->type = tc->instance->VMNull;
                     ins->operands[0].reg.orig += inliner->num_locals;
                 }
             }

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -3068,6 +3068,12 @@ static void post_inline_visit_bb(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpes
             case MVM_OP_isnull:
                 optimize_isnull(tc, g, bb, ins);
                 break;
+            /* isnull being turned into a constant is not useful unless
+             * branches based on it get eliminated, too. */
+            case MVM_OP_if_i:
+            case MVM_OP_unless_i:
+                optimize_iffy(tc, g, ins, bb);
+                break;
             case MVM_OP_unbox_i:
             case MVM_OP_unbox_n:
             case MVM_OP_unbox_s:
@@ -3248,6 +3254,7 @@ void MVM_spesh_optimize(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshPlanned 
      * add new fact dependencies. Do a final dead instruction elimination pass
      * to clean up after it. */
     post_inline_pass(tc, g, g->entry);
+    eliminate_pointless_gotos(tc, g);
     MVM_spesh_eliminate_dead_ins(tc, g);
 #if MVM_SPESH_CHECK_DU
     MVM_spesh_usages_check(tc, g);

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -3062,6 +3062,12 @@ static void post_inline_visit_bb(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpes
             case MVM_OP_box_u:
                 try_eliminate_box_unbox_pair(tc, g, bb, ins, MVM_OP_unbox_u, MVM_OP_decont_u, pips);
                 break;
+            /* takedispatcher can be optimized out in the inlining step,
+             * but we will only benefit if we look for isnull instructions
+             * again in the post-inline pass. */
+            case MVM_OP_isnull:
+                optimize_isnull(tc, g, bb, ins);
+                break;
             case MVM_OP_unbox_i:
             case MVM_OP_unbox_n:
             case MVM_OP_unbox_s:


### PR DESCRIPTION
takedispatcher was already turned into a null instruction, but nothing downstream was taking advantage of this.

quoth jonathan at http://colabti.org/irclogger/irclogger_log/moarvm?date=2018-10-02#l50

> jnthn: Uh, yeah, you can't optimize much inside inlines at the moment :)
> jnthn: Because there's no information on what is retained for deopt available
> jnthn: So the chances of screwing things up is very high.
> timotimo: i'll create a PR for the changes, i suppose?
> jnthn: Yeah, but I'm going to reject it on principle in the immediate.
> jnthn: Or well, defer it until we have the things needed to do it safely.
> […]
> jnthn: fwiw, I think the better approah on this will be to do a normal optimize_bb pass on the inlinee - when we're got to the point where we can do it safely
