### PR TITLE
Make big Int stringification 1.58x as fast

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -991,6 +991,7 @@ static int mp_faster_radix_size (mp_int *a, int radix, int *size)
      * small enough to fit into a single mp_digit.
      */
     if (radix == 10) {
+        mp_clamp(&t);
         while ((&t)->used > 1) {
             if ((res = mp_div_d(&t, (mp_digit) 100000000000000000, &t, &d)) != MP_OKAY) {
               mp_clear(&t);


### PR DESCRIPTION
For Ints larger than 2⁶⁰ and only in base-10.

We do it by reducing the value by largest 10**n number that
fits into a single mp_digit and doing so until our remaining
number fits into a single mp_digit, at which point we continue
using the traditional algo.

The reason we go for mp_digit-sized divisor is because we can use
mp_div_d routine with it. I also tried using mp_div with an even
larger divisor, but that made things a lot slower than original.

The only modification to libtommath routine is the code inside `#if`/`#endif`
unsure if this is a decent way to do this sort of thing.

Perf measurements with this commit:

Measured with `say now - ENTER now` using the mean of three samples for each measurement.

|Number     | Old (s)      | New (s)      | Speedup
|-----------|--------------|--------------|-------------------
|10         | 1.4140471567 | 1.3842983    | noise (optimized codepath doesn't run for this case)
|10**10     | 1.16266601   | 1.1660879367 | noise (optimized codepath doesn't run for this case)
|2**64      | 5.0117614633 | 3.1652399633 | 1.58x as fast
|10**1000   | 2.17431698   | 1.2189989967 | 1.78x as fast
|10**100000 | 8.44483905   | 4.73683458   | 1.78x as fast
|10**200000 | 34.10054     | 18.62298607  | 1.83x as fast (took only 1 sample of each measurement)