### PR TITLE
Comment out problematic case in speshing deconting of _n

### DIFF
--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -1755,7 +1755,7 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
         }
         break;
     case MVM_OP_unbox_n:
-    case MVM_OP_decont_n:
+/*  case MVM_OP_decont_n:    XXX TODO: figure out why this case hangs/slow https://github.com/rakudo/rakudo/issues/2395 */
         if (repr_data->unbox_num_slot >= 0) {
             MVMSTable *embedded_st = repr_data->flattened_stables[repr_data->unbox_num_slot];
             if (embedded_st->REPR->ID == MVM_REPR_ID_P6num) {


### PR DESCRIPTION
This appears to fix R#2395 https://github.com/rakudo/rakudo/issues/2395 but I've no idea why.

I've absolutely no idea about this area of the codebase or the impact of this change.

I'm making this PR for last-resort type of situation, if we have to fix up R#2395 for the release, but I hope someone who knows this part of the code will figure out what's going on.