### PR TITLE
Use arithmetic right shift in JIT of brshift_i

### DIFF
--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1148,7 +1148,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
             break;
         case MVM_OP_brshift_i:
             | mov cl, byte WORK[reg_c];
-            | shr rax, cl;
+            | sar rax, cl;
             break;
         }
         | mov WORK[reg_a], rax;


### PR DESCRIPTION
The arithmetic right shift will preserve the sign of the integer by
ensuring that new bits shifted in match the initial sign bit.