### PR TITLE
free spesh log entries after consuming them

### DIFF
--- a/src/6model/reprs/MVMSpeshLog.c
+++ b/src/6model/reprs/MVMSpeshLog.c
@@ -34,6 +34,8 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
     MVMSpeshLogBody *log = (MVMSpeshLogBody *)data;
     MVMuint32 i;
     MVM_gc_worklist_add(tc, worklist, &(log->thread));
+    if (!log->entries)
+        return;
     for (i = 0; i < log->used; i++) {
         switch (log->entries[i].kind) {
             case MVM_SPESH_LOG_ENTRY:

--- a/src/spesh/worker.c
+++ b/src/spesh/worker.c
@@ -128,6 +128,11 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
                         uv_cond_signal(sl->body.block_condvar);
                         uv_mutex_unlock(sl->body.block_mutex);
                     }
+                    {
+                        MVMSpeshLogEntry *entries = sl->body.entries;
+                        sl->body.entries = NULL;
+                        MVM_free(entries);
+                    }
                 });
             }
             else if (MVM_is_null(tc, log_obj)) {


### PR DESCRIPTION
this prevents threads that do little to no
allocations but lots of spesh logging in an
otherwise idle program from growing to multiple
gigabytes of ram used solely for spesh log entries.

This happened with rakudo's ThreadPoolScheduler
supervisor thread when a program with multithreading
or async workloads was left idle, like for example
a Cro app.


This is one of three ways to solve this problem. A second way is to decrease the available size in the nursery to account for memory allocated for the spesh log entries buffer. The third way would be to re-use spesh logs completely, so that only a few buffers ever exist in total.

It's easier to argue that the second way is obviously correct, but it will also cause more GC load. Of course, if barely anything besides spesh logs are being created, that'd only be a millisecond of work each time.

The third way will definitely require some care so that re-use isn't susceptible to subtle problems like improper concurrent access, or stale data being accessed.

IMO the way implemented here is acceptable.