### PR TITLE
Attempt to fix MoarVM build on AIX

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -463,6 +463,11 @@ if ($config{cc} eq 'cl') {
 build::probe::C_type_bool(\%config, \%defaults);
 build::probe::computed_goto(\%config, \%defaults);
 build::probe::pthread_yield(\%config, \%defaults);
+if ($^O eq 'aix') {
+    build::probe::numbits(\%config, \%defaults);
+    $config{ldflags} = join(',', $config{ldflags}, '-bmaxdata:0x80000000')
+        if $config{arch_bits} == 32;
+}
 build::probe::rdtscp(\%config, \%defaults);
 
 my $order = $config{be} ? 'big endian' : 'little endian';

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -480,6 +480,7 @@ UV_SOLARIS = 3rdparty/libuv/src/unix/sunos@obj@ \
             $(UV_UNIX)
 
 UV_AIX = 3rdparty/libuv/src/unix/aix@obj@ \
+         3rdparty/libuv/src/unix/aix-common@obj@ \
          $(UV_UNIX)
 
 UV_OBJECTS = @uvobjects@

--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -5,7 +5,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #define DEFAULT_MODE 0x01B6
-typedef struct stat STAT;
+typedef struct stat STAT_t;
 #else
 #include <fcntl.h>
 #include <errno.h>
@@ -23,7 +23,7 @@ typedef struct stat STAT;
 #define isatty _isatty
 #define ftruncate _chsize
 #define fstat _fstat
-typedef struct _stat STAT;
+typedef struct _stat STAT_t;
 #endif
 
 /* Data that we keep for a file-based handle. */
@@ -164,7 +164,7 @@ static MVMint64 mvm_eof(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOFileData *data = (MVMIOFileData *)h->body.data;
     if (data->seekable) {
         MVMint64 seek_pos;
-        STAT statbuf;
+        STAT_t statbuf;
         if (fstat(data->fd, &statbuf) == -1)
             MVM_exception_throw_adhoc(tc, "Failed to stat file descriptor: %s",
                 strerror(errno));
@@ -439,7 +439,7 @@ MVMObject * MVM_file_open_fh(MVMThreadContext *tc, MVMString *filename, MVMStrin
     char * const fname = MVM_string_utf8_c8_encode_C_string(tc, filename);
     int fd;
     int flag;
-    STAT statbuf;
+    STAT_t statbuf;
 
     /* Resolve mode description to flags. */
     char * const fmode  = MVM_string_utf8_encode_C_string(tc, mode);

--- a/src/strings/siphash/csiphash.h
+++ b/src/strings/siphash/csiphash.h
@@ -65,6 +65,8 @@ typedef struct siphash siphash;
     /* See: http://sourceforge.net/p/predef/wiki/Endianness/ */
 #      if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #        include <sys/endian.h>
+#      elif defined(_AIX)
+#        include <sys/machine.h>
 #      else
 #        include <endian.h>
 #      endif
@@ -84,6 +86,7 @@ typedef struct siphash siphash;
 #    define MVM_MAYBE_TO_LITTLE_ENDIAN_64(x) ((uint64_t)(x))
 #    define MVM_MAYBE_TO_LITTLE_ENDIAN_32(x) ((uint32_t)(x))
 #endif
+
 #if !defined(MVM_CAN_UNALIGNED_INT64)
 #   include <string.h>
 #endif


### PR DESCRIPTION
Use sys/machine.h on AIX systems in csiphash.h
    
    This is needed so there isn't a build error on AIX systems. It is also
    needed for AIX systems that use big endian instead of little endian.
    Reported by ItchyPlant.
Add missing libuv file to Makefile.in for AIX

 Enable detection of 32 bit AIX systems in Configure.pl
    
    If we detect a 32 bit AIX system, add -bmaxdata:0x80000000 to the
    ldflags. This allows the compiled program to use a 'large' memory space.
    
    https://www.ibm.com/support/knowledgecenter/ssw_aix_71/com.ibm.aix.genprogc/lrg_prg_support.htm

Reported by ItchyPlant at https://www.reddit.com/r/perl6/comments/9s2v1o/perl_6_201809_on_aix7/