### PR TITLE
Fix double free in platform/sys.c

### DIFF
--- a/src/platform/sys.c
+++ b/src/platform/sys.c
@@ -4,9 +4,10 @@
 MVMuint32 MVM_platform_cpu_count(void) {
     int count;
     uv_cpu_info_t *info;
+    int e;
 
-    uv_cpu_info(&info, &count);
-    uv_free_cpu_info(info, count);
+    e = uv_cpu_info(&info, &count);
+    if (e == 0) uv_free_cpu_info(info, count);
 
     return count;
 }


### PR DESCRIPTION
libuv expects the info struct to have already been initialized.

See https://github.com/rakudo/rakudo/issues/2520