### PR TITLE
Fix #1010. Remove errant check in get_attribute.

### DIFF
--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -455,51 +455,46 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 if (!obj) {
                     /* No cached object. */
                     void *cobj = get_ptr_at_offset(body->cstruct, repr_data->struct_offsets[slot]);
-                    if (cobj) {
-                        MVMObject **child_objs = body->child_objs;
-                        if (type == MVM_CSTRUCT_ATTR_CARRAY) {
-                            if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                obj = MVM_nativecall_make_carray(tc, typeobj,
-                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                            else
-                                obj = MVM_nativecall_make_carray(tc, typeobj, cobj);
-                        }
-                        else if(type == MVM_CSTRUCT_ATTR_CSTRUCT) {
-                            if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                obj = MVM_nativecall_make_cstruct(tc, typeobj,
-                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                            else
-                                obj = MVM_nativecall_make_cstruct(tc, typeobj, cobj);
-                        }
-                        else if(type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
-                            if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                obj = MVM_nativecall_make_cppstruct(tc, typeobj,
-                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                            else
-                                obj = MVM_nativecall_make_cppstruct(tc, typeobj, cobj);
-                        }
-                        else if(type == MVM_CSTRUCT_ATTR_CUNION) {
-                            if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                obj = MVM_nativecall_make_cunion(tc, typeobj,
-                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                            else
-                                obj = MVM_nativecall_make_cunion(tc, typeobj, cobj);
-                        }
-                        else if(type == MVM_CSTRUCT_ATTR_CPTR) {
-                            obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
-                        }
-                        else if(type == MVM_CSTRUCT_ATTR_STRING) {
-                            MVMROOT(tc, typeobj, {
-                                MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
-                                    cobj, strlen(cobj));
-                                obj = MVM_repr_box_str(tc, typeobj, str);
-                            });
-                        }
-                        child_objs[real_slot] = obj;
-                    }
-                    else {
-                        obj = typeobj;
-                    }
+					MVMObject **child_objs = body->child_objs;
+					if (type == MVM_CSTRUCT_ATTR_CARRAY) {
+						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+							obj = MVM_nativecall_make_carray(tc, typeobj,
+								(char *)body->cstruct + repr_data->struct_offsets[slot]);
+						else
+							obj = MVM_nativecall_make_carray(tc, typeobj, cobj);
+					}
+					else if(type == MVM_CSTRUCT_ATTR_CSTRUCT) {
+						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+							obj = MVM_nativecall_make_cstruct(tc, typeobj,
+								(char *)body->cstruct + repr_data->struct_offsets[slot]);
+						else
+							obj = MVM_nativecall_make_cstruct(tc, typeobj, cobj);
+					}
+					else if(type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
+						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+							obj = MVM_nativecall_make_cppstruct(tc, typeobj,
+								(char *)body->cstruct + repr_data->struct_offsets[slot]);
+						else
+							obj = MVM_nativecall_make_cppstruct(tc, typeobj, cobj);
+					}
+					else if(type == MVM_CSTRUCT_ATTR_CUNION) {
+						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+							obj = MVM_nativecall_make_cunion(tc, typeobj,
+								(char *)body->cstruct + repr_data->struct_offsets[slot]);
+						else
+							obj = MVM_nativecall_make_cunion(tc, typeobj, cobj);
+					}
+					else if(type == MVM_CSTRUCT_ATTR_CPTR) {
+						obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
+					}
+					else if(type == MVM_CSTRUCT_ATTR_STRING) {
+						MVMROOT(tc, typeobj, {
+							MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
+								cobj, strlen(cobj));
+							obj = MVM_repr_box_str(tc, typeobj, str);
+						});
+					}
+					child_objs[real_slot] = obj;
                 }
                 result_reg->o = obj;
             }

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -455,46 +455,46 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 if (!obj) {
                     /* No cached object. */
                     void *cobj = get_ptr_at_offset(body->cstruct, repr_data->struct_offsets[slot]);
-					MVMObject **child_objs = body->child_objs;
-					if (type == MVM_CSTRUCT_ATTR_CARRAY) {
-						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-							obj = MVM_nativecall_make_carray(tc, typeobj,
-								(char *)body->cstruct + repr_data->struct_offsets[slot]);
-						else
-							obj = MVM_nativecall_make_carray(tc, typeobj, cobj);
-					}
-					else if(type == MVM_CSTRUCT_ATTR_CSTRUCT) {
-						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-							obj = MVM_nativecall_make_cstruct(tc, typeobj,
-								(char *)body->cstruct + repr_data->struct_offsets[slot]);
-						else
-							obj = MVM_nativecall_make_cstruct(tc, typeobj, cobj);
-					}
-					else if(type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
-						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-							obj = MVM_nativecall_make_cppstruct(tc, typeobj,
-								(char *)body->cstruct + repr_data->struct_offsets[slot]);
-						else
-							obj = MVM_nativecall_make_cppstruct(tc, typeobj, cobj);
-					}
-					else if(type == MVM_CSTRUCT_ATTR_CUNION) {
-						if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-							obj = MVM_nativecall_make_cunion(tc, typeobj,
-								(char *)body->cstruct + repr_data->struct_offsets[slot]);
-						else
-							obj = MVM_nativecall_make_cunion(tc, typeobj, cobj);
-					}
-					else if(type == MVM_CSTRUCT_ATTR_CPTR) {
-						obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
-					}
-					else if(type == MVM_CSTRUCT_ATTR_STRING) {
-						MVMROOT(tc, typeobj, {
-							MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
-								cobj, strlen(cobj));
-							obj = MVM_repr_box_str(tc, typeobj, str);
-						});
-					}
-					child_objs[real_slot] = obj;
+                    MVMObject **child_objs = body->child_objs;
+                    if (type == MVM_CSTRUCT_ATTR_CARRAY) {
+                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+                            obj = MVM_nativecall_make_carray(tc, typeobj,
+                                (char *)body->cstruct + repr_data->struct_offsets[slot]);
+                        else
+                            obj = MVM_nativecall_make_carray(tc, typeobj, cobj);
+                    }
+                    else if(type == MVM_CSTRUCT_ATTR_CSTRUCT) {
+                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+                            obj = MVM_nativecall_make_cstruct(tc, typeobj,
+                                (char *)body->cstruct + repr_data->struct_offsets[slot]);
+                        else
+                            obj = MVM_nativecall_make_cstruct(tc, typeobj, cobj);
+                    }
+                    else if(type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
+                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+                            obj = MVM_nativecall_make_cppstruct(tc, typeobj,
+                                (char *)body->cstruct + repr_data->struct_offsets[slot]);
+                        else
+                            obj = MVM_nativecall_make_cppstruct(tc, typeobj, cobj);
+                    }
+                    else if(type == MVM_CSTRUCT_ATTR_CUNION) {
+                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
+                            obj = MVM_nativecall_make_cunion(tc, typeobj,
+                                (char *)body->cstruct + repr_data->struct_offsets[slot]);
+                        else
+                            obj = MVM_nativecall_make_cunion(tc, typeobj, cobj);
+                    }
+                    else if(type == MVM_CSTRUCT_ATTR_CPTR) {
+                        obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
+                    }
+                    else if(type == MVM_CSTRUCT_ATTR_STRING) {
+                        MVMROOT(tc, typeobj, {
+                            MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
+                                cobj, strlen(cobj));
+                            obj = MVM_repr_box_str(tc, typeobj, str);
+                        });
+                    }
+                    child_objs[real_slot] = obj;
                 }
                 result_reg->o = obj;
             }


### PR DESCRIPTION
[Issue is here.](https://github.com/MoarVM/MoarVM/issues/1010) I think there might have been some confusion because of the variable name. Here, get_ptr_at_offset is returning the value at the beginning of the native structure. 

void *cobj = get_ptr_at_offset(body->cstruct, repr_data->struct_offsets[slot]);
if (cobj) {
...
else {obj = typeobj;