### PR TITLE
 Account for inlined CArrays when determining CUnion's size. Fixes #1012 

### DIFF
--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -137,7 +137,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
 
             if (num_dimensions > 1) {
                 MVM_exception_throw_adhoc(tc,
-                    "Only one dimensions supported in CStruct attribute");
+                    "Only one dimensions supported in CUnion attribute");
             }
 
             if (!MVM_is_null(tc, type)) {
@@ -191,9 +191,6 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                             MVMint64 dim_one     =  MVM_repr_at_pos_i(tc, dimensions, 0);
                             MVMObject *elem_type = carray_repr_data->elem_type;
 
-                            // How do we distinguish between these members:
-                            // a) struct  foo [32] alias;
-                            // b) struct *foo [32] alias;
                             if (carray_repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_CSTRUCT) {
                                 MVMCStructREPRData *cstruct_repr_data = (MVMCStructREPRData *)STABLE(elem_type)->REPR_data;
                                 bits                                  = cstruct_repr_data->struct_size * 8 * dim_one;

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -127,8 +127,19 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
             MVMObject *type  = MVM_repr_at_key_o(tc, attr, tc->instance->str_consts.type);
             MVMObject *inlined_val = MVM_repr_at_key_o(tc, attr, tc->instance->str_consts.inlined);
             MVMint64 inlined = !MVM_is_null(tc, inlined_val) && MVM_repr_get_int(tc, inlined_val);
+            MVMObject *dimensions         = MVM_repr_at_key_o(tc, attr, tc->instance->str_consts.dimensions);
+            MVMP6opaqueREPRData *dim_repr = (MVMP6opaqueREPRData *)STABLE(dimensions)->REPR_data;
+            MVMint64 num_dimensions       = dim_repr && dim_repr->pos_del_slot >= 0
+                                          ? MVM_repr_elems(tc, dimensions)
+                                          : 0;
             MVMint32   bits  = sizeof(void *) * 8;
             MVMint32   align = ALIGNOF(void *);
+
+            if (num_dimensions > 1) {
+                MVM_exception_throw_adhoc(tc,
+                    "Only one dimensions supported in CStruct attribute");
+            }
+
             if (!MVM_is_null(tc, type)) {
                 /* See if it's a type that we know how to handle in a C struct. */
                 const MVMStorageSpec *spec = REPR(type)->get_storage_spec(tc, STABLE(type));
@@ -171,6 +182,33 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                     repr_data->num_child_objs++;
                     repr_data->attribute_locations[i] = (cur_obj_attr++ << MVM_CUNION_ATTR_SHIFT) | MVM_CUNION_ATTR_CARRAY;
                     repr_data->member_types[i] = type;
+                    if (inlined) {
+                        MVMCArrayREPRData *carray_repr_data = (MVMCArrayREPRData *)STABLE(type)->REPR_data;
+                        bits                                = carray_repr_data->elem_size * 8;
+                        repr_data->attribute_locations[i]  |= MVM_CUNION_ATTR_INLINED;
+
+                        if (num_dimensions > 0) {
+                            MVMint64 dim_one     =  MVM_repr_at_pos_i(tc, dimensions, 0);
+                            MVMObject *elem_type = carray_repr_data->elem_type;
+
+                            // How do we distinguish between these members:
+                            // a) struct  foo [32] alias;
+                            // b) struct *foo [32] alias;
+                            if (carray_repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_CSTRUCT) {
+                                MVMCStructREPRData *cstruct_repr_data = (MVMCStructREPRData *)STABLE(elem_type)->REPR_data;
+                                bits                                  = cstruct_repr_data->struct_size * 8 * dim_one;
+                                align                                 = cstruct_repr_data->struct_align;
+                            }
+                            else if (carray_repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_NUMERIC) {
+                                const MVMStorageSpec *spec = REPR(elem_type)->get_storage_spec(tc, STABLE(elem_type));
+                                bits  = bits * dim_one;
+                                align = spec->align;
+                            }
+                            else {
+                                bits  = bits * dim_one;
+                            }
+                        }
+                    }
                 }
                 else if (type_id == MVM_REPR_ID_MVMCStruct) {
                     /* It's a CStruct. */


### PR DESCRIPTION
This patch works on my machine, passes rakudo tests, and doesn't leak under valgrind (on my machine), but I'm not making any claims about correctness. I'm somewhat new to perl6 and very new to Moar internals.  I was struggling with writing some bindings because pointers pointed all over and nothing was in the right place. It was mostly my code at fault, but this popped up while I was losing my mind. I'm still unfamiliar with the GC and write barriers, so I'm not sure why those things appear in CStruct.c's compute_allocation_strategy but not here.   Still, it's a start. Shoves in the right direction greatly appreciated.