### PR TITLE
Add a cancel handler for filewatch tasks

### DIFF
--- a/src/io/filewatchers.c
+++ b/src/io/filewatchers.c
@@ -75,11 +75,16 @@ static void gc_free(MVMThreadContext *tc, MVMObject *t, void *data) {
         MVM_free(data);
 }
 
+static void cancel(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *t, void *data) {
+    WatchInfo *wi = (WatchInfo *)data;
+    uv_fs_event_stop(&wi->handle);
+}
+
 /* Operations table for a file watcher task. */
 static const MVMAsyncTaskOps op_table = {
     setup,
     NULL,
-    NULL,
+    cancel,
     NULL,
     gc_free
 };


### PR DESCRIPTION
Without this, MVM_OP_watchfile is bound to leak a file descriptor and/or
other resources (depending on the platform). Stopping the libuv fs_event
in the cancel op allows rakudo to nqp::cancel the task and thus prevent
the leak.