### PR TITLE
keep end of string bytes \x0000

### DIFF
--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -400,7 +400,7 @@ char * MVM_string_utf16_encode_substr_main(MVMThreadContext *tc, MVMString *str,
     if (!output_size)
         output_size = &scratch_space;
     *output_size = (char *)result_pos - (char *)result;
-    result = MVM_realloc(result, *output_size);
+    result = MVM_realloc(result, *output_size + 2);
     MVM_free(repl_bytes);
     return (char *)result;
 }

--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -397,6 +397,7 @@ char * MVM_string_utf16_encode_substr_main(MVMThreadContext *tc, MVMString *str,
         }
     }
     result_pos[0] = 0;
+    result_pos[1] = 0;
     if (!output_size)
         output_size = &scratch_space;
     *output_size = (char *)result_pos - (char *)result;


### PR DESCRIPTION
Fixes #1017
This is also related to https://stackoverflow.com/questions/53691576/perl6-nativecall-with-str-is-encodedutf16-got-randomly-corrupted-result

This fix add the missing space for the end of string char which is 2 bytes for utf16.