### PR TITLE
Fix long error messages on windows

### DIFF
--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -886,7 +886,7 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char 
     MVMROOT(tc, ex, {
         char      *c_message = MVM_malloc(1024);
         int        bytes     = vsnprintf(c_message, 1024, messageFormat, args);
-        int        to_encode = bytes > 1024 ? 1024 : bytes;
+        int        to_encode = (0 < bytes && bytes < 1024) ? bytes :1024;
         MVMString *message   = MVM_string_utf8_decode(tc, tc->instance->VMString, c_message, to_encode);
         MVM_free(c_message);
 

--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -886,7 +886,7 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char 
     MVMROOT(tc, ex, {
         char      *c_message = MVM_malloc(1024);
         int        bytes     = vsnprintf(c_message, 1024, messageFormat, args);
-        int        to_encode = (0 < bytes && bytes < 1024) ? bytes :1024;
+        int        to_encode = (0 < bytes && bytes < 1024) ? bytes : 1024;
         MVMString *message   = MVM_string_utf8_decode(tc, tc->instance->VMString, c_message, to_encode);
         MVM_free(c_message);
 


### PR DESCRIPTION
On windows `vsnprintf` returns -1 on overflow; in this scenario don't use the result of `vsnprintf` to determine string size

#1025