### PR TITLE
Add op name to jit "bailed completely" error

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1673,7 +1673,8 @@ skipdevirt:
 static void add_bail_comment(MVMThreadContext *tc, MVMJitGraph *jg, MVMSpeshIns *ins) {
     MVMSpeshGraph *g = jg->sg;
     if (MVM_spesh_debug_enabled(tc)) {
-        MVM_spesh_graph_add_comment(tc, g, ins, "JIT: bailed completely");
+        MVM_spesh_graph_add_comment(tc, g, ins, "JIT: bailed completely because of <%s>",
+                                    ins->info->name);
     }
 }
 


### PR DESCRIPTION
NQP passes `make m-test` and Rakudo passes `make m-test m-spectest`.