### PR TITLE
Trim array returned by nqp::decodelocaltime

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -5356,7 +5356,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             OP(decodelocaltime): {
                 int i;
-                MVMint64 decoded[9];
+                MVMint64 decoded[6];
                 MVMObject *result = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTIntArray);
 
                 GET_REG(cur_op, 0).o = result;
@@ -5365,7 +5365,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
 
                 MVMROOT(tc, result, {
                     REPR(result)->pos_funcs.set_elems(tc, STABLE(result), result, OBJECT_BODY(result), 9);
-                    for (i = 0; i < 9; i++) {
+                    for (i = 0; i < 6; i++) {
                         MVM_repr_bind_pos_i(tc, result, i, decoded[i]);
                     }
                 });

--- a/src/platform/posix/time.c
+++ b/src/platform/posix/time.c
@@ -66,7 +66,4 @@ void MVM_platform_decodelocaltime(MVMThreadContext *tc, MVMint64 time, MVMint64 
     decoded[3] = tm.tm_mday;
     decoded[4] = tm.tm_mon + 1;
     decoded[5] = tm.tm_year + 1900;
-    decoded[6] = tm.tm_wday;
-    decoded[7] = tm.tm_yday;
-    decoded[8] = tm.tm_isdst;
 }

--- a/src/platform/win32/time.c
+++ b/src/platform/win32/time.c
@@ -56,7 +56,4 @@ void MVM_platform_decodelocaltime(MVMThreadContext *tc, MVMint64 time, MVMint64 
     decoded[3] = tm.tm_mday;
     decoded[4] = tm.tm_mon + 1;
     decoded[5] = tm.tm_year + 1900;
-    decoded[6] = tm.tm_wday;
-    decoded[7] = tm.tm_yday;
-    decoded[8] = tm.tm_isdst;
 }


### PR DESCRIPTION
Remove elements that are unused by rakudo.
This makes it work the same as on other backends.