### PR TITLE
adapt bigint handling to new LibTomMath version

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -61,7 +61,7 @@ static const int mp_get_double_digits_needed
 = ((MANTISSA_BITS_IN_DOUBLE + DIGIT_BIT) / DIGIT_BIT) + 1;
 static const double mp_get_double_multiplier = (double)(MP_MASK + 1);
 
-static MVMnum64 s_mp_get_double(mp_int *a, int shift) {
+static MVMnum64 MVM_mp_get_double(mp_int *a, int shift) {
     MVMnum64 d;
     int i, limit, final_shift;
     d = 0.0;
@@ -714,8 +714,8 @@ MVMObject * MVM_bigint_pow(MVMThreadContext *tc, MVMObject *a, MVMObject *b,
         }
     }
     else {
-        MVMnum64 f_base = s_mp_get_double(base, 0);
-        MVMnum64 f_exp = s_mp_get_double(exponent, 0);
+        MVMnum64 f_base = MVM_mp_get_double(base, 0);
+        MVMnum64 f_exp = MVM_mp_get_double(exponent, 0);
         r = MVM_repr_box_num(tc, num_type, pow(f_base, f_exp));
     }
     clear_temp_bigints(tmp, 2);
@@ -1082,7 +1082,7 @@ MVMnum64 MVM_bigint_to_num(MVMThreadContext *tc, MVMObject *a) {
 
     if (MVM_BIGINT_IS_BIG(ba)) {
         mp_int *ia = ba->u.bigint;
-        return s_mp_get_double(ia, 0);
+        return MVM_mp_get_double(ia, 0);
     } else {
         return (double)ba->u.smallint.value;
     }
@@ -1132,7 +1132,7 @@ MVMnum64 MVM_bigint_div_num(MVMThreadContext *tc, MVMObject *a, MVMObject *b) {
             if (mp_div(&scaled, ib, &scaled, NULL) != MP_OKAY)
                 MVM_exception_throw_adhoc(tc,
                     "Failed to preform bigint division");
-            c = s_mp_get_double(&scaled, bbits);
+            c = MVM_mp_get_double(&scaled, bbits);
             mp_clear(&scaled);
         }
         clear_temp_bigints(tmp, 2);


### PR DESCRIPTION
The new LibTomMath version has a slightly altered API regarding the generation of random numbers to make it cryptographically secure. That conflicts with your program according to the Debian maintainer here https://github.com/libtom/libtommath/issues/122 

We added a small function `mp_rand_digit` to the API and I took the liberty to adapt your code to use it. This patch is meant more as a hint but should work as posted, too.

It is a bit of a catch-22 because  `mp_rand_digit` might not be included in the next RC when you receive this pull request. Please check https://github.com/libtom/libtommath/pull/147 for the details regarding `mp_rand_digit`.
