### PR TITLE
Allow CStruct pass-by-value in Nativecall

### DIFF
--- a/src/6model/bootstrap.c
+++ b/src/6model/bootstrap.c
@@ -543,6 +543,7 @@ static void string_consts(MVMThreadContext *tc) {
     string_creator(attribute, "attribute");
     string_creator(of, "of");
     string_creator(rw, "rw");
+    string_creator(copy, "copy");
     string_creator(type, "type");
     string_creator(typeobj, "typeobj");
     string_creator(free_str, "free_str");

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -588,7 +588,15 @@ static void bind_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                         if (REPR(value)->ID != MVM_REPR_ID_MVMCStruct)
                             MVM_exception_throw_adhoc(tc,
                                 "Can only store CStruct attribute in CStruct slot in CStruct");
-                        cobj = ((MVMCStruct *)value)->body.cstruct;
+                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED) {
+                            memcpy((char *)body->cstruct + repr_data->struct_offsets[slot],
+                                   ((MVMCStruct *)value)->body.cstruct,
+                                   ((MVMCStructREPRData *)STABLE(value)->REPR_data)->struct_size);
+                            ((MVMCStruct *)value)->body.cstruct = (char *)body->cstruct + repr_data->struct_offsets[slot];
+                            break;
+                        }
+                        else
+                            cobj = ((MVMCStruct *)value)->body.cstruct;
                     }
                     else if (type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
                         if (REPR(value)->ID != MVM_REPR_ID_MVMCPPStruct)

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -46,6 +46,7 @@ struct MVMStringConsts {
     MVMString *attribute;
     MVMString *of;
     MVMString *rw;
+    MVMString *copy;
     MVMString *type;
     MVMString *typeobj;
     MVMString *free_str;

--- a/src/core/nativecall.h
+++ b/src/core/nativecall.h
@@ -35,6 +35,8 @@
 #define MVM_NATIVECALL_ARG_NO_RW           0
 #define MVM_NATIVECALL_ARG_RW              256
 #define MVM_NATIVECALL_ARG_RW_MASK         256
+#define MVM_NATIVECALL_ARG_NO_COPY         0
+#define MVM_NATIVECALL_ARG_COPY            512
 
 /* Native callback entry. Hung off MVMNativeCallbackCacheHead, which is
  * a hash owned by the ThreadContext. All MVMNativeCallbacks in a linked

--- a/src/core/nativecall_libffi.h
+++ b/src/core/nativecall_libffi.h
@@ -2,7 +2,7 @@
 
 typedef void DLLib;
 
-ffi_type * MVM_nativecall_get_ffi_type(MVMThreadContext *tc, MVMuint64 type_id);
+ffi_type * MVM_nativecall_get_ffi_type(MVMThreadContext *tc, MVMuint64 type_id, MVMObject *info);
 ffi_abi MVM_nativecall_get_calling_convention(MVMThreadContext *tc, MVMString *name);
 #define MVM_nativecall_load_lib(path)       dlopen(path, RTLD_NOW|RTLD_GLOBAL)
 #define MVM_nativecall_free_lib(lib)        do { if(lib) dlclose(lib); } while (0)


### PR DESCRIPTION
Second version of the patch, @bdw ++

This feature can be implemented only on libffi.

This is the initial implementation of the pass-by-value
functionality for nativecall, it recognizes the 'copy' key on
parameter/return hashes. Then it build up the libffi parameter
definition by analyzing the STables and REPRs of the members. It
currently works only on P6num P6int and CStruct member types but
will be extended upon review. This functionality can be implemented
only on the libffi nativecall backend, and might render dyncall
obsolete for MoarVM.