### PR TITLE
Fix broken macro expansion on windows

### DIFF
--- a/src/spesh/deopt.c
+++ b/src/spesh/deopt.c
@@ -167,11 +167,11 @@ static void materialize_object(MVMThreadContext *tc, MVMFrame *f, MVMObject ***m
         MVMSpeshPEAMaterializeInfo *mi = &(cand->deopt_pea.materialize_info[info_idx]);
         MVMSTable *st = (MVMSTable *)cand->spesh_slots[mi->stable_sslot];
         MVMP6opaqueREPRData *repr_data = (MVMP6opaqueREPRData *)st->REPR_data;
-        MVMObject *obj = MVM_gc_allocate_object(tc, st);
-        char *data = (char *)OBJECT_BODY(obj);
-        MVMuint32 num_attrs = repr_data->num_attributes;
-        MVMuint32 i;
         MVMROOT(tc, f, {
+            MVMObject *obj = MVM_gc_allocate_object(tc, st);
+            char *data = (char *)OBJECT_BODY(obj);
+            MVMuint32 num_attrs = repr_data->num_attributes;
+            MVMuint32 i;
             for (i = 0; i < num_attrs; i++) {
                 MVMRegister value = f->work[mi->attr_regs[i]];
                 MVMuint16 offset = repr_data->attribute_offsets[i];

--- a/src/spesh/deopt.c
+++ b/src/spesh/deopt.c
@@ -164,14 +164,14 @@ static void materialize_object(MVMThreadContext *tc, MVMFrame *f, MVMObject ***m
     if (!*materialized)
         *materialized = MVM_calloc(MVM_VECTOR_ELEMS(cand->deopt_pea.materialize_info), sizeof(MVMObject *));
     if (!(*materialized)[info_idx]) {
+        MVMSpeshPEAMaterializeInfo *mi = &(cand->deopt_pea.materialize_info[info_idx]);
+        MVMSTable *st = (MVMSTable *)cand->spesh_slots[mi->stable_sslot];
+        MVMP6opaqueREPRData *repr_data = (MVMP6opaqueREPRData *)st->REPR_data;
+        MVMObject *obj = MVM_gc_allocate_object(tc, st);
+        char *data = (char *)OBJECT_BODY(obj);
+        MVMuint32 num_attrs = repr_data->num_attributes;
+        MVMuint32 i;
         MVMROOT(tc, f, {
-            MVMSpeshPEAMaterializeInfo *mi = &(cand->deopt_pea.materialize_info[info_idx]);
-            MVMSTable *st = (MVMSTable *)cand->spesh_slots[mi->stable_sslot];
-            MVMP6opaqueREPRData *repr_data = (MVMP6opaqueREPRData *)st->REPR_data;
-            MVMObject *obj = MVM_gc_allocate_object(tc, st);
-            char *data = (char *)OBJECT_BODY(obj);
-            MVMuint32 num_attrs = repr_data->num_attributes;
-            MVMuint32 i;
             for (i = 0; i < num_attrs; i++) {
                 MVMRegister value = f->work[mi->attr_regs[i]];
                 MVMuint16 offset = repr_data->attribute_offsets[i];
@@ -200,10 +200,10 @@ static void materialize_object(MVMThreadContext *tc, MVMFrame *f, MVMObject ***m
                 }
             }
             (*materialized)[info_idx] = obj;
-#if MVM_LOG_DEOPTS
-            fprintf(stderr, "    Materialized a %s\n", st->debug_name);
-#endif
         });
+#if MVM_LOG_DEOPTS
+        fprintf(stderr, "    Materialized a %s\n", st->debug_name);
+#endif
     }
     f->work[target_reg].o = (*materialized)[info_idx];
 }


### PR DESCRIPTION
Moves the MVM_LOG_DEOPTS macro outside of the MVMROOT macro, which fixes the build on windows.

Resolves: #1048