### PR TITLE
JIT sp_bind_i32

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1788,6 +1788,7 @@ start:
     case MVM_OP_sp_p6obind_o:
     case MVM_OP_sp_p6obind_i32:
     case MVM_OP_sp_bind_i64:
+    case MVM_OP_sp_bind_i32:
     case MVM_OP_sp_bind_n:
     case MVM_OP_sp_bind_s:
     case MVM_OP_sp_bind_s_nowb:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -757,6 +757,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         break;
     }
     case MVM_OP_sp_bind_i64:
+    case MVM_OP_sp_bind_i32:
     case MVM_OP_sp_bind_n:
     case MVM_OP_sp_bind_s:
     case MVM_OP_sp_bind_s_nowb:
@@ -776,7 +777,12 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
             | mov TMP2, aword WORK[val]; // reload value
             |2: // done
         }
-        | mov qword [TMP1+offset], TMP2; // store value into body
+        if (op == MVM_OP_sp_bind_i32) {
+            | mov dword [TMP1+offset], TMP2d; // store value into body
+        }
+        else {
+            | mov qword [TMP1+offset], TMP2; // store value into body
+        }
         break;
     }
     case MVM_OP_sp_get_i64:


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

This resolves some 'bailed completely' I saw in a spesh log of `gzslurp`ing a file using `Compress::Zlib`.

I would consider this a POC, somebody like @niner++ would probably be able to do a more complete job.