### PR TITLE
Ask malloc to free kernel pages on GC collection

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -518,6 +518,7 @@ if ($config{cc} eq 'cl') {
 build::probe::C_type_bool(\%config, \%defaults);
 build::probe::computed_goto(\%config, \%defaults);
 build::probe::pthread_yield(\%config, \%defaults);
+build::probe::check_fn_malloc_trim(\%config, \%defaults);
 if ($^O eq 'aix') {
     build::probe::numbits(\%config, \%defaults);
     $config{ldflags} = join(',', $config{ldflags}, '-bmaxdata:0x80000000')

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -237,6 +237,7 @@ OBJECTS2 = src/6model/reprs/MVMDLLSym@obj@ \
           src/platform/sys@obj@ \
           src/platform/random@obj@ \
           src/platform/memmem32@obj@ \
+          src/platform/malloc_trim@obj@ \
           src/moar@obj@ \
           @platform@ \
           @jit_obj@
@@ -401,6 +402,7 @@ HEADERS = src/moar.h \
           src/platform/sys.h \
           src/platform/setjmp.h \
           src/platform/memmem.h \
+          src/platform/malloc_trim.h \
           src/platform/random.h \
           src/platform/fork.h \
           src/jit/graph.h \

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -33,6 +33,10 @@
 #define MVM_HAS_PTHREAD_YIELD @has_pthread_yield@
 #endif
 
+#if @has_fn_malloc_trim@
+#define MVM_HAS_FN_MALLOC_TRIM @has_fn_malloc_trim@
+#endif
+
 /* How this compiler does static inline functions. */
 #define MVM_STATIC_INLINE @static_inline@
 

--- a/build/probe.pm
+++ b/build/probe.pm
@@ -407,6 +407,29 @@ EOT
     $config->{cancgoto} = $can_cgoto || 0
 }
 
+sub check_fn_malloc_trim {
+    my ($config) = @_;
+    my $restore = _to_probe_dir();
+    my $includes = '#include <malloc.h>';
+    my $function = 'malloc_trim(0)';
+    _spew('try.c', <<"EOT");
+$includes
+
+int main(int argc, char **argv) {
+    $function;
+    return 0;
+}
+EOT
+
+    print ::dots('    probing existance of optional malloc_trim()');
+    my $can = compile($config, 'try');
+    unless ($config->{crossconf}) {
+        $can  &&= !system './try';
+    }
+    print $can ? "YES\n": "NO\n";
+    $config->{has_fn_malloc_trim} = $can || 0
+}
+
 sub C_type_bool {
     my ($config) = @_;
     my $restore = _to_probe_dir();

--- a/src/gc/orchestrate.c
+++ b/src/gc/orchestrate.c
@@ -1,5 +1,6 @@
 #include "moar.h"
 #include <platform/threads.h>
+#include "platform/malloc_trim.h"
 
 /* If we have the job of doing GC for a thread, we add it to our work
  * list. */
@@ -221,6 +222,9 @@ static void finish_gc(MVMThreadContext *tc, MVMuint8 gen, MVMuint8 is_coordinato
         else {
             /* Free gen2 unmarked if full collection. */
             if (gen == MVMGCGenerations_Both) {
+                /* Tell malloc implementation to free empty pages to kernel.
+                 * Currently only activated for Linux. */
+                MVM_malloc_trim();
                 GCDEBUG_LOG(tc, MVM_GC_DEBUG_ORCHESTRATE,
                     "Thread %d run %d : freeing gen2 of thread %d\n",
                     other->thread_id);

--- a/src/platform/malloc_trim.c
+++ b/src/platform/malloc_trim.c
@@ -1,4 +1,4 @@
-#ifdef __linux__
+#ifdef __GLIBC__
 #include <malloc.h>
 int MVM_malloc_trim(void) {
     /* 128*1024 is the glibc default. */

--- a/src/platform/malloc_trim.c
+++ b/src/platform/malloc_trim.c
@@ -1,0 +1,11 @@
+#ifdef __linux__
+#include <malloc.h>
+int MVM_malloc_trim(void) {
+    /* 128*1024 is the glibc default. */
+    return malloc_trim(128*1024);
+}
+#else
+int MVM_malloc_trim(void) {
+    return 1;
+}
+#endif

--- a/src/platform/malloc_trim.c
+++ b/src/platform/malloc_trim.c
@@ -1,4 +1,5 @@
-#ifdef __GLIBC__
+#ifdef MVM_HAS_FN_MALLOC_TRIM
+#warning "test warn"
 #include <malloc.h>
 int MVM_malloc_trim(void) {
     /* 128*1024 is the glibc default. */

--- a/src/platform/malloc_trim.h
+++ b/src/platform/malloc_trim.h
@@ -1,0 +1,1 @@
+int MVM_malloc_trim(void);


### PR DESCRIPTION
This reduces the max memory usage used by asking malloc to free memory
pages. We set it to 128KiB which is glibc's malloc default. This should
hopefully ensure it does get collected.

Credit to:
https://www.joyfulbikeshedding.com/blog/2019-03-14-what-causes-ruby-memory-bloat.html

PS: just want to say this isn't ready for merge yet, as not all libc's (though most) have malloc_trim