### PR TITLE
Simplify abs_n to just use fabs and also jit it

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -770,13 +770,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 4;
                 goto NEXT;
             OP(abs_n):
-                {
-                    MVMnum64 num = GET_REG(cur_op, 2).n64;
-                    /* The 1.0/num logic checks for a negative zero */
-                    if (num < 0 || (num == 0 && 1.0/num < 0) ) num = num * -1;
-                    GET_REG(cur_op, 0).n64 = num;
-                    cur_op += 4;
-                }
+                GET_REG(cur_op, 0).n64 = fabs(GET_REG(cur_op, 2).n64);
+                cur_op += 4;
                 goto NEXT;
             OP(pow_n):
                 GET_REG(cur_op, 0).n64 = pow(GET_REG(cur_op, 2).n64, GET_REG(cur_op, 4).n64);

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -322,6 +322,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_floor_n: return floor;
     case MVM_OP_pow_I: return MVM_bigint_pow;
     case MVM_OP_rand_I: return MVM_bigint_rand;
+    case MVM_OP_abs_n: return fabs;
     case MVM_OP_pow_n: return pow;
     case MVM_OP_time_n: return MVM_proc_time_n;
     case MVM_OP_randscale_n: return MVM_proc_randscale_n;
@@ -3421,6 +3422,7 @@ start:
         jg_append_call_c(tc, jg, op_to_func(tc, op), 2, args, MVM_JIT_RV_PTR, dst);
         break;
     }
+    case MVM_OP_abs_n:
     case MVM_OP_floor_n:
     case MVM_OP_sqrt_n:
     case MVM_OP_sin_n:


### PR DESCRIPTION
NQP passes `make m-test` and Rakudo passes `make m-test m-spectest`. With this patch a spesh log of `my $a; $a = now for ^10_000; say $a` no longer has any `# JIT: bailed completely because of <abs_n>`.