### PR TITLE
Deobfuscate debug port handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -226,7 +226,7 @@ int wmain(int argc, wchar_t *wargv[])
 
             case OPT_DEBUGPORT: {
                 MVMint64 port;
-                char *portstr = argv[argi] + strlen("--debugport=") + 1;
+                char *portstr = argv[argi] + strlen("--debug-port=");
                 char *endptr;
                 port = strtoll(portstr, &endptr, 10);
                 if (*endptr != '\0') {


### PR DESCRIPTION
The option actually is written `--debug-port=`. 
The diff speaks for itself I guess.