### PR TITLE
Silence -Wlogical-op-parentheses warnings in clang

### DIFF
--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -933,8 +933,8 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
                 const MVMStorageSpec *flat_ss = flat_st->REPR->get_storage_spec(tc, flat_st);
                 add_slot_name_comment(tc, g, ins, name, ch_facts, st);
                 if (flat_st->REPR->ID == MVM_REPR_ID_P6int &&
-                        (flat_ss->bits == 64 || (flat_ss->bits == 32 || flat_ss->bits == 16 || flat_ss->bits == 8)
-                        && !flat_ss->is_unsigned)) {
+                        (flat_ss->bits == 64 || ((flat_ss->bits == 32 || flat_ss->bits == 16 || flat_ss->bits == 8)
+                        && !flat_ss->is_unsigned))) {
                     MVMSpeshOperand temp_reg = MVM_spesh_manipulate_get_temp_reg(tc, g, MVM_reg_int64);
                     MVMSpeshOperand orig_target = ins->operands[1];
                     if (opcode == MVM_OP_getattrs_i)

--- a/src/spesh/facts.c
+++ b/src/spesh/facts.c
@@ -92,8 +92,8 @@ static void decont_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns *in
      * info. */
     MVMint32 in_flags = in_facts->flags;
     if ((in_flags & MVM_SPESH_FACT_TYPEOBJ) ||
-            (in_flags & MVM_SPESH_FACT_KNOWN_TYPE) &&
-            !in_facts->type->st->container_spec) {
+            ((in_flags & MVM_SPESH_FACT_KNOWN_TYPE) &&
+            !in_facts->type->st->container_spec)) {
         copy_facts(tc, g, out_orig, out_i, in_orig, in_i);
         return;
     }

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -580,8 +580,8 @@ static void optimize_hllize(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns 
 static void optimize_decont(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb, MVMSpeshIns *ins) {
     MVMSpeshFacts *obj_facts = MVM_spesh_get_facts(tc, g, ins->operands[1]);
     if ((obj_facts->flags & MVM_SPESH_FACT_TYPEOBJ) ||
-            (obj_facts->flags & MVM_SPESH_FACT_KNOWN_TYPE) &&
-            !obj_facts->type->st->container_spec) {
+            ((obj_facts->flags & MVM_SPESH_FACT_KNOWN_TYPE) &&
+            !obj_facts->type->st->container_spec)) {
         /* Know that we don't need to decont. */
         ins->info = MVM_op_get_op(MVM_OP_set);
         MVM_spesh_use_facts(tc, g, obj_facts);
@@ -848,8 +848,8 @@ static void optimize_guard(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *b
         else if (opcode == MVM_OP_sp_guard && can_drop_type_guard) {
             turn_into_set = 1;
         }
-        else if (opcode == MVM_OP_sp_guardjustconc && can_drop_concrete_guard
-                || opcode == MVM_OP_sp_guardjusttype && can_drop_typeobj_guard) {
+        else if (  (opcode == MVM_OP_sp_guardjustconc && can_drop_concrete_guard)
+                || (opcode == MVM_OP_sp_guardjusttype && can_drop_typeobj_guard)) {
             turn_into_set = 1;
         }
     }
@@ -3016,7 +3016,7 @@ static MVMuint32 conflict_free(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshB
             /* Make sure there's no conflicting register use. */
             for (i = 0; i < check->info->num_operands; i++) {
                 MVMuint16 rw_mode = check->info->operands[i] & MVM_operand_rw_mask;
-                if (rw_mode == MVM_operand_write_reg || !allow_reads && rw_mode == MVM_operand_read_reg)
+                if (rw_mode == MVM_operand_write_reg || (!allow_reads && rw_mode == MVM_operand_read_reg))
                     if (check->operands[i].reg.orig == reg)
                         return 0;
             }

--- a/src/strings/latin1.c
+++ b/src/strings/latin1.c
@@ -111,7 +111,7 @@ MVMuint32 MVM_string_latin1_decodestream(MVMThreadContext *tc, MVMDecodeStream *
             last_accept_pos = pos;
             total++;
             if (MVM_string_decode_stream_maybe_sep(tc, seps, codepoint) ||
-                    stopper_chars && *stopper_chars == total) {
+                    (stopper_chars && *stopper_chars == total)) {
                 reached_stopper = 1;
                 goto done;
             }

--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -161,7 +161,7 @@ MVMuint32 MVM_string_utf16_decodestream_main(MVMThreadContext *tc, MVMDecodeStre
             last_accept_pos = pos += 2;
             total++;
             if (MVM_string_decode_stream_maybe_sep(tc, seps, value) ||
-                    stopper_chars && *stopper_chars == total) {
+                    (stopper_chars && *stopper_chars == total)) {
                 reached_stopper = 1;
                 goto done;
             }


### PR DESCRIPTION
But adding parentheses around some expressions.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.