### PR TITLE
Silence clang dangling-else & return-type warnings

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -96,6 +96,8 @@ static MVMuint64 switch_endian(MVMuint64 val, unsigned char size) {
         val = ((val << 16) & 0xFFFF0000FFFF0000ULL ) | ((val >> 16) & 0x0000FFFF0000FFFFULL );
         return (val << 32) | (val >> 32);
     }
+
+    MVM_panic(1, "Invalid size (%u) when attempting to switch endianness of %"PRIu64"\n", size, val);
 }
 
 /* This is the interpreter run loop. We have one of these per thread. */

--- a/src/gc/roots.c
+++ b/src/gc/roots.c
@@ -200,11 +200,12 @@ void MVM_gc_root_add_tc_roots_to_worklist(MVMThreadContext *tc, MVMGCWorklist *w
         MVM_spesh_sim_stack_gc_mark(tc, tc->spesh_sim_stack, worklist);
     else
         MVM_spesh_sim_stack_gc_describe(tc, snapshot, tc->spesh_sim_stack);
-    if (tc->spesh_active_graph)
+    if (tc->spesh_active_graph) {
         if (worklist)
             MVM_spesh_graph_mark(tc, tc->spesh_active_graph, worklist);
         else
             MVM_spesh_graph_describe(tc, tc->spesh_active_graph, snapshot);
+    }
     MVM_spesh_plugin_guard_list_mark(tc, tc->plugin_guards, tc->num_plugin_guards, worklist);
     add_collectable(tc, worklist, snapshot, tc->plugin_guard_args,
         "Plugin guard args");


### PR DESCRIPTION
With this, both clang 8.0.0-3 and gcc 8.3.0 don't show any warnings on my machine.