### PR TITLE
Move freeing of event_loop_wakeup to after uv_loop_close

### DIFF
--- a/src/io/eventloop.c
+++ b/src/io/eventloop.c
@@ -292,11 +292,13 @@ void MVM_io_eventloop_destroy(MVMThreadContext *tc) {
 
     if (instance->event_loop) {
         uv_close((uv_handle_t*)instance->event_loop_wakeup, NULL);
-        instance->event_loop_wakeup = NULL;
 
         /* Not sure we can always do this */
         uv_loop_close(instance->event_loop);
+       
         MVM_free(instance->event_loop_wakeup);
+        instance->event_loop_wakeup = NULL;
+        
         MVM_free(instance->event_loop);
         instance->event_loop = NULL;
     }

--- a/src/io/eventloop.c
+++ b/src/io/eventloop.c
@@ -292,11 +292,11 @@ void MVM_io_eventloop_destroy(MVMThreadContext *tc) {
 
     if (instance->event_loop) {
         uv_close((uv_handle_t*)instance->event_loop_wakeup, NULL);
-        MVM_free(instance->event_loop_wakeup);
         instance->event_loop_wakeup = NULL;
 
         /* Not sure we can always do this */
         uv_loop_close(instance->event_loop);
+        MVM_free(instance->event_loop_wakeup);
         MVM_free(instance->event_loop);
         instance->event_loop = NULL;
     }


### PR DESCRIPTION
Addresses part of the issue in #1068 . uv_loop_close tries to use instance->event_loop_wakeup, resulting in an invalid access of recently freed memory.