### PR TITLE
Default to doing a non-relocatable build

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -95,7 +95,10 @@ $args{optimize}     = 3 if not defined $args{optimize} or $args{optimize} eq "";
 $args{debug}        = 3 if defined $args{debug} and $args{debug} eq "";
 
 # Relocatability is not supported on AIX and OpenBSD.
-$args{'relocatable'} = 0 if $^O eq 'aix' || $^O eq 'openbsd';
+if ( $args{'relocatable'} == 1 && ($^O eq 'aix' || $^O eq 'openbsd') ) {
+    hardfail('Relocatability is not supported on ' . $^O .
+    ".\n    Leave off the --relocatable flag to do a non-relocatable build.");
+}
 
 for (qw(coverage instrument static big-endian has-libtommath has-sha has-libuv
         has-libatomic_ops asan ubsan valgrind show-vec)) {


### PR DESCRIPTION
Non relocatability is the more common case with less caveats.
Remove the --no-relocatable config, add --relocatable instead.