### PR TITLE
Clean up CMP object files on Windows

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -55,7 +55,7 @@ our %TP_CMP = (
     name => 'cmp',
     path => '3rdparty/cmp',
     src  => [ '3rdparty/cmp' ],
-    clean => 'cd 3rdparty/cmp && $(RM) libcmp.a && $(MAKE) clean'
+    clean => 'cd 3rdparty/cmp && $(RM) libcmp.a && $(RM) cmp.lib && $(RM) cmp.obj && $(MAKE) clean'
 );
 
 our %TP_UVDUMMY = (


### PR DESCRIPTION
On Windows the object files for CMP are named differently. Fix `realclean`
to also clean up those.