### PR TITLE
Remove profiling overhead from profiles

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -503,6 +503,9 @@ struct MVMInstance {
     FILE *coverage_log_fh;
     MVMuint32  coverage_control;
 
+    /* The time it takes to run the profiler instrumentation. */
+    MVMuint64 profiling_overhead;
+
     /************************************************************************
      * Debugging
      ************************************************************************/


### PR DESCRIPTION
By calculating the average cost of executing the profiling functions and
then subtracting that times the number of entries from the exclusive
cost of an HLL block.

This gist (https://gist.github.com/MasterDuke17/ab7108070054f92e4cab5313033ea3f8) has some data for what the values were when https://github.com/MasterDuke17/MoarVM/blob/remove_profiling_overhead_from_profile/src/profiler/instrument.c#L399 and https://github.com/MasterDuke17/MoarVM/blob/remove_profiling_overhead_from_profile/src/profiler/instrument.c#L418 branches were taken when profiling `(^5_000).grep(*.is-prime).tail.say; my $a = (^100).pick(2).join; my $b; for ^100_000 { ++$b if $a ~~ / $_ / }; say $b`.