### PR TITLE
Fix miscellaneous compiler flag passing on OpenBSD

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -223,6 +223,11 @@ if ($config{cc} eq 'gcc' && !$config{can_specific_werror}) {
     $config{ccmiscflags} =~ s/^ +$//;
 }
 
+# Disable ROP vulnerability protection on OpenBSD, since it breaks the legojit.
+if ($^O eq 'openbsd' && $config{cc} eq 'clang') {
+	$config{ccmiscflags} .= ' -fno-ret-protector';
+}
+
 # Set the remaining ldmiscflags. Do this after probing for gcc -Werror probe to not miss that change for the linker.
 $config{ldmiscflags}  = $config{ccmiscflags} unless defined $config{ldmiscflags};
 

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -506,10 +506,6 @@ our %OS_OPENBSD = (
     %OS_POSIX,
 
     syslibs     => [ @{$OS_POSIX{syslibs}}, qw( kvm ) ],
-    # XXX: this is required at the moment because of the legojit. If possible,
-    # the legojit should be protected against ROP vulnerabilities and this line
-    # should be removed.
-    ccmiscflags => '-fno-ret-protector',
 
     -thirdparty => {
         uv => { %TP_UVDUMMY, objects => '$(UV_OPENBSD)' },


### PR DESCRIPTION
`-fno-omit-frame-pointer` and `-fno-optimize-sibling-calls` were getting
overwritten by `-fno-ret-protector` the way this was originally written.