### PR TITLE
enforce wb in get_attribute of C reprs

### DIFF
--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -483,7 +483,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                                 obj = MVM_repr_box_str(tc, typeobj, str);
                             });
                         }
-                        child_objs[real_slot] = obj;
+                        MVM_ASSIGN_REF(tc, &(root->header), body->child_objs[real_slot], obj);
                     }
                     else {
                         obj = typeobj;

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -497,7 +497,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                                 obj = MVM_repr_box_str(tc, typeobj, str);
                             });
                         }
-                        child_objs[real_slot] = obj;
+                        MVM_ASSIGN_REF(tc, &(root->header), body->child_objs[real_slot], obj);
                     }
                     else {
                         obj = typeobj;

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -440,12 +440,12 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                                     obj = MVM_repr_box_str(tc, typeobj, str);
                                 });
                             }
-                            child_objs[real_slot] = obj;
                         }
                         else {
                             obj = typeobj;
                         }
                     }
+                    MVM_ASSIGN_REF(tc, &(root->header), body->child_objs[real_slot], obj);
                 }
                 result_reg->o = obj;
             }


### PR DESCRIPTION
Fixes non-deterministic crashes in anything that non-trivially uses
CStruct/CPPStruct/CUnion reprs.

The type of failure this fixes usually matches these 3 patterns, alternately:
- ｢Segmentation fault｣
- ｢MoarVM panic: Internal error: zeroed target thread ID in work pass｣
- /'MoarVM panic: Internal error: invalid thread ID '\d+' in GC work pass'/

Also fixed a separate bug in CUnion: it wasn't caching child objects for
attributes that are inlined.

Tested to fix the issue in MoarVM #800, Skarsnik/perl6-gumbo#5 and [perl6 RT 131003](https://rt.perl.org/Public/Bug/Display.html?id=131003).
Probably also fixes MoarVM #751 and #1087