### PR TITLE
Restore accidentally deleted call to mp_neg()

### DIFF
--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -188,6 +188,7 @@ static mp_int * force_bigint(MVMThreadContext *tc, const MVMP6bigintBody *body, 
             }
             else {
                 mp_set_int(i, -value);
+                mp_neg(i, i);
             }
             return i;
         }


### PR DESCRIPTION
It seems to have accidentally been forgotten during recent
refactoring/optimization. Only affected 32 bit. Fixes M#1104.