### PR TITLE
Jit captureposarg_n

### DIFF
--- a/src/core/args.c
+++ b/src/core/args.c
@@ -307,9 +307,15 @@ MVMArgInfo MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext
     autounbox(tc, MVM_CALLSITE_ARG_INT, "integer", result);
     return result;
 }
-MVMArgInfo MVM_args_get_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required) {
+MVMArgInfo MVM_args_get_required_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
     MVMArgInfo result;
-    args_get_pos(tc, ctx, pos, required, result);
+    args_get_pos(tc, ctx, pos, MVM_ARG_REQUIRED, result);
+    autounbox(tc, MVM_CALLSITE_ARG_NUM, "number", result);
+    return result;
+}
+MVMArgInfo MVM_args_get_optional_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
+    MVMArgInfo result;
+    args_get_pos(tc, ctx, pos, MVM_ARG_OPTIONAL, result);
     autounbox(tc, MVM_CALLSITE_ARG_NUM, "number", result);
     return result;
 }

--- a/src/core/args.h
+++ b/src/core/args.h
@@ -63,7 +63,8 @@ MVMObject * MVM_args_get_required_pos_obj(MVMThreadContext *tc, MVMArgProcContex
 MVMArgInfo MVM_args_get_optional_pos_obj(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMint64 MVM_args_get_required_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMArgInfo MVM_args_get_optional_pos_int(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
-MVMArgInfo MVM_args_get_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos, MVMuint8 required);
+MVMArgInfo MVM_args_get_required_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
+MVMArgInfo MVM_args_get_optional_pos_num(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMString * MVM_args_get_required_pos_str(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMArgInfo MVM_args_get_optional_pos_str(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);
 MVMuint64 MVM_args_get_required_pos_uint(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos);

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -1058,8 +1058,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 4;
                 goto NEXT;
             OP(param_rp_n):
-                GET_REG(cur_op, 0).n64 = MVM_args_get_pos_num(tc, &tc->cur_frame->params,
-                    GET_UI16(cur_op, 2), MVM_ARG_REQUIRED).arg.n64;
+                GET_REG(cur_op, 0).n64 = MVM_args_get_required_pos_num(tc, &tc->cur_frame->params,
+                    GET_UI16(cur_op, 2)).arg.n64;
                 cur_op += 4;
                 goto NEXT;
             OP(param_rp_s):
@@ -1089,8 +1089,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             }
             OP(param_op_n):
             {
-                MVMArgInfo param = MVM_args_get_pos_num(tc, &tc->cur_frame->params,
-                    GET_UI16(cur_op, 2), MVM_ARG_OPTIONAL);
+                MVMArgInfo param = MVM_args_get_optional_pos_num(tc, &tc->cur_frame->params,
+                    GET_UI16(cur_op, 2));
                 if (param.exists) {
                     GET_REG(cur_op, 0).n64 = param.arg.n64;
                     cur_op = bytecode_start + GET_UI32(cur_op, 4);
@@ -1404,8 +1404,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMObject *obj = GET_REG(cur_op, 2).o;
                 if (IS_CONCRETE(obj) && REPR(obj)->ID == MVM_REPR_ID_MVMCallCapture) {
                     MVMCallCapture *cc = (MVMCallCapture *)obj;
-                    GET_REG(cur_op, 0).n64 = MVM_args_get_pos_num(tc, cc->body.apc,
-                        (MVMuint32)GET_REG(cur_op, 4).i64, MVM_ARG_REQUIRED).arg.n64;
+                    GET_REG(cur_op, 0).n64 = MVM_args_get_required_pos_num(tc, cc->body.apc,
+                        (MVMuint32)GET_REG(cur_op, 4).i64).arg.n64;
                 }
                 else {
                     MVM_exception_throw_adhoc(tc, "captureposarg_n needs a MVMCallCapture");

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1852,6 +1852,7 @@ start:
     case MVM_OP_capturehasnameds:
     case MVM_OP_captureposarg:
     case MVM_OP_captureposarg_i:
+    case MVM_OP_captureposarg_n:
     case MVM_OP_captureposarg_s:
     case MVM_OP_captureexistsnamed:
     case MVM_OP_capturenamedshash:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1084,6 +1084,26 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         |2:
         break;
     }
+    case MVM_OP_captureposarg_n: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 src = ins->operands[1].reg.orig;
+        MVMint16 pos = ins->operands[2].reg.orig;
+        | mov TMP5, qword WORK[src];
+        | test_type_object TMP5;
+        | jnz >1;
+        | cmp_repr_id TMP5, TMP6, MVM_REPR_ID_MVMCallCapture;
+        | jne >1;
+        | mov ARG1, TC;
+        | mov ARG2, aword CAPTURE:TMP5->body.apc;
+        | mov ARG3, qword WORK[pos];
+        | callp &MVM_args_get_required_pos_num;
+        | mov WORK[dst], RV;
+        | jmp >2;
+        |1:
+        | throw_adhoc "captureposarg_n needs a MVMCallCapture";
+        |2:
+        break;
+    }
     case MVM_OP_captureposarg_s: {
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 src = ins->operands[1].reg.orig;


### PR DESCRIPTION
Also change MVM_args_get_pos_num into MVM_args_get_required_pos_num and
MVM_args_get_optional_pos_num to match the implementations for the other
types.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.