### PR TITLE
Fix pointer arithmetic in inlined CArrays in CStruct/CPPStruct REPRs

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -1011,15 +1011,15 @@ void MVM_nativecall_refresh(MVMThreadContext *tc, MVMObject *cthingy) {
         MVMint64            i;
 
         for (i = 0; i < repr_data->num_attributes; i++) {
-            MVMint32 kind = repr_data->attribute_locations[i] & MVM_CSTRUCT_ATTR_MASK;
-            MVMint32 slot = repr_data->attribute_locations[i] >> MVM_CSTRUCT_ATTR_SHIFT;
-            void **cptr = NULL;  /* Address of the struct member holding the pointer in the C storage. */
+            MVMint32  kind = repr_data->attribute_locations[i] & MVM_CSTRUCT_ATTR_MASK;
+            MVMint32  slot = repr_data->attribute_locations[i] >> MVM_CSTRUCT_ATTR_SHIFT;
+            void *cptr   = NULL; /* Address of the struct member holding the pointer in the C storage. */
             void *objptr = NULL; /* The pointer in the object representing the C object. */
 
             if (kind == MVM_CSTRUCT_ATTR_IN_STRUCT || !body->child_objs[slot])
                 continue;
 
-            cptr = (void**)((uintptr_t)storage + (uintptr_t)repr_data->struct_offsets[i]);
+            cptr = (void *)(storage + (uintptr_t)repr_data->struct_offsets[i]);
             if (IS_CONCRETE(body->child_objs[slot])) {
                 switch (kind) {
                     case MVM_CSTRUCT_ATTR_CARRAY:
@@ -1050,7 +1050,7 @@ void MVM_nativecall_refresh(MVMThreadContext *tc, MVMObject *cthingy) {
                 objptr = NULL;
             }
 
-            if (objptr != *cptr)
+            if (objptr != cptr)
                 body->child_objs[slot] = NULL;
             else
                 MVM_nativecall_refresh(tc, body->child_objs[slot]);
@@ -1071,7 +1071,7 @@ void MVM_nativecall_refresh(MVMThreadContext *tc, MVMObject *cthingy) {
             if (kind == MVM_CPPSTRUCT_ATTR_IN_STRUCT || !body->child_objs[slot])
                 continue;
 
-            cptr = (void*)((uintptr_t)storage + (uintptr_t)repr_data->struct_offsets[i]);
+            cptr = (void *)(storage + (uintptr_t)repr_data->struct_offsets[i]);
             if (IS_CONCRETE(body->child_objs[slot])) {
                 switch (kind) {
                     case MVM_CPPSTRUCT_ATTR_CARRAY:


### PR DESCRIPTION
Fixes https://github.com/rakudo/rakudo/issues/3009

I ran 5000 iterations of the test from the issue on both Windows and OpenBSD to confirm this fixes the issue.