### PR TITLE
Add context to error messages

### DIFF
--- a/src/core/args.c
+++ b/src/core/args.c
@@ -760,7 +760,7 @@ static void flatten_args(MVMThreadContext *tc, MVMArgProcContext *ctx) {
             MVMStorageSpec  lss   = REPR(list)->pos_funcs.get_elem_storage_spec(tc, STABLE(list));
 
             if ((MVMint64)new_arg_pos + count > 0xFFFF) {
-                MVM_exception_throw_adhoc(tc, "Too many arguments (%"PRId64") in flattening array, only %"PRId32" allowed.", (MVMint64)new_arg_pos + count), 0xFFFF;
+                MVM_exception_throw_adhoc(tc, "Too many arguments (%"PRId64") in flattening array, only %"PRId32" allowed.", (MVMint64)new_arg_pos + count, 0xFFFF);
             }
 
             for (i = 0; i < count; i++) {

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -682,7 +682,7 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
 
         if (lex_idx >= sf->body.num_lexicals) {
             MVM_reentrantmutex_unlock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
-            MVM_exception_throw_adhoc(tc, "Lexical index out of bounds: %d > %d", lex_idx, sf->body.num_lexicals);
+            MVM_exception_throw_adhoc(tc, "Lexical index out of bounds: %d >= %d", lex_idx, sf->body.num_lexicals);
         }
 
         sf->body.static_env_flags[lex_idx] = flags;

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -321,7 +321,7 @@ void MVM_coerce_smart_stringify(MVMThreadContext *tc, MVMObject *obj, MVMRegiste
         else if (ss->can_box & MVM_STORAGE_SPEC_CAN_BOX_NUM)
             res_reg->s = MVM_coerce_n_s(tc, REPR(obj)->box_funcs.get_num(tc, STABLE(obj), obj, OBJECT_BODY(obj)));
         else
-            MVM_exception_throw_adhoc(tc, "cannot stringify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_debug_name(tc, STABLE(obj)));
+            MVM_exception_throw_adhoc(tc, "Cannot stringify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
     }
 }
 
@@ -376,8 +376,7 @@ void MVM_coerce_smart_numify(MVMThreadContext *tc, MVMObject *obj, MVMRegister *
         else if (REPR(obj)->ID == MVM_REPR_ID_MVMHash)
             res_reg->n64 = (MVMnum64)REPR(obj)->elems(tc, STABLE(obj), obj, OBJECT_BODY(obj));
         else
-<<<<<<< HEAD
-            MVM_exception_throw_adhoc(tc, "Cannot numify this type (%s)", MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
+            MVM_exception_throw_adhoc(tc, "Cannot numify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
     }
 }
 
@@ -424,10 +423,7 @@ void MVM_coerce_smart_intify(MVMThreadContext *tc, MVMObject *obj, MVMRegister *
         else if (REPR(obj)->ID == MVM_REPR_ID_MVMHash)
             res_reg->i64 = REPR(obj)->elems(tc, STABLE(obj), obj, OBJECT_BODY(obj));
         else
-            MVM_exception_throw_adhoc(tc, "Cannot intify this type (%s)", MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
-=======
-            MVM_exception_throw_adhoc(tc, "cannot numify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_debug_name(tc, obj));
->>>>>>> wip 2
+            MVM_exception_throw_adhoc(tc, "Cannot intify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
     }
 }
 
@@ -451,11 +447,7 @@ MVMint64 MVM_coerce_simple_intify(MVMThreadContext *tc, MVMObject *obj) {
         else if (REPR(obj)->ID == MVM_REPR_ID_MVMHash)
             return REPR(obj)->elems(tc, STABLE(obj), obj, OBJECT_BODY(obj));
         else
-<<<<<<< HEAD
-            MVM_exception_throw_adhoc(tc, "Cannot intify this type (%s)", MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
-=======
-            MVM_exception_throw_adhoc(tc, "cannot intify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_debug_name(tc, obj));
->>>>>>> wip 2
+            MVM_exception_throw_adhoc(tc, "Cannot intify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
     }
 }
 

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -222,7 +222,7 @@ MVMString * MVM_coerce_i_s(MVMThreadContext *tc, MVMint64 i) {
         return result;
     }
     else {
-        MVM_exception_throw_adhoc(tc, "Could not stringify integer");
+        MVM_exception_throw_adhoc(tc, "Could not stringify integer (%"PRId64")", i);
     }
 }
 
@@ -248,7 +248,7 @@ MVMString * MVM_coerce_u_s(MVMThreadContext *tc, MVMuint64 i) {
         return result;
     }
     else {
-        MVM_exception_throw_adhoc(tc, "Could not stringify integer");
+        MVM_exception_throw_adhoc(tc, "Could not stringify integer (%"PRIu64")", i);
     }
 }
 
@@ -265,7 +265,7 @@ MVMString * MVM_coerce_n_s(MVMThreadContext *tc, MVMnum64 n) {
     else {
         char buf[64];
         if (dtoa_grisu3(n, buf, 64) < 0)
-            MVM_exception_throw_adhoc(tc, "Could not stringify number");
+            MVM_exception_throw_adhoc(tc, "Could not stringify number (%f)", n);
         else {
             MVMStringIndex len = strlen(buf);
             MVMGrapheme8 *blob = MVM_malloc(len);
@@ -321,7 +321,7 @@ void MVM_coerce_smart_stringify(MVMThreadContext *tc, MVMObject *obj, MVMRegiste
         else if (ss->can_box & MVM_STORAGE_SPEC_CAN_BOX_NUM)
             res_reg->s = MVM_coerce_n_s(tc, REPR(obj)->box_funcs.get_num(tc, STABLE(obj), obj, OBJECT_BODY(obj)));
         else
-            MVM_exception_throw_adhoc(tc, "Cannot stringify this type (%s)", MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
+            MVM_exception_throw_adhoc(tc, "cannot stringify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_debug_name(tc, STABLE(obj)));
     }
 }
 
@@ -376,6 +376,7 @@ void MVM_coerce_smart_numify(MVMThreadContext *tc, MVMObject *obj, MVMRegister *
         else if (REPR(obj)->ID == MVM_REPR_ID_MVMHash)
             res_reg->n64 = (MVMnum64)REPR(obj)->elems(tc, STABLE(obj), obj, OBJECT_BODY(obj));
         else
+<<<<<<< HEAD
             MVM_exception_throw_adhoc(tc, "Cannot numify this type (%s)", MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
     }
 }
@@ -424,6 +425,9 @@ void MVM_coerce_smart_intify(MVMThreadContext *tc, MVMObject *obj, MVMRegister *
             res_reg->i64 = REPR(obj)->elems(tc, STABLE(obj), obj, OBJECT_BODY(obj));
         else
             MVM_exception_throw_adhoc(tc, "Cannot intify this type (%s)", MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
+=======
+            MVM_exception_throw_adhoc(tc, "cannot numify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_debug_name(tc, obj));
+>>>>>>> wip 2
     }
 }
 
@@ -447,7 +451,11 @@ MVMint64 MVM_coerce_simple_intify(MVMThreadContext *tc, MVMObject *obj) {
         else if (REPR(obj)->ID == MVM_REPR_ID_MVMHash)
             return REPR(obj)->elems(tc, STABLE(obj), obj, OBJECT_BODY(obj));
         else
+<<<<<<< HEAD
             MVM_exception_throw_adhoc(tc, "Cannot intify this type (%s)", MVM_6model_get_stable_debug_name(tc, STABLE(obj)));
+=======
+            MVM_exception_throw_adhoc(tc, "cannot intify this object of type %s (%s)", REPR(obj)->name, MVM_6model_get_debug_name(tc, obj));
+>>>>>>> wip 2
     }
 }
 

--- a/src/core/dll.c
+++ b/src/core/dll.c
@@ -57,8 +57,10 @@ int MVM_dll_free(MVMThreadContext *tc, MVMString *name) {
     MVM_HASH_GET(tc, tc->instance->dll_registry, name, entry);
 
     if (!entry) {
+        char *c_name = MVM_string_utf8_encode_C_string(tc, name);
+        char *waste[] = { c_name, NULL };
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
-        MVM_exception_throw_adhoc(tc, "cannot free non-existent library '%s'", name);
+        MVM_exception_throw_adhoc_free(tc, waste, "cannot free non-existent library '%s'", c_name);
     }
 
     /* already freed */
@@ -68,8 +70,10 @@ int MVM_dll_free(MVMThreadContext *tc, MVMString *name) {
     }
 
     if (entry->refcount > 0) {
+        char *c_name = MVM_string_utf8_encode_C_string(tc, name);
+        char *waste[] = { c_name, NULL };
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
-        MVM_exception_throw_adhoc(tc, "cannot free in-use library '%s'", name);
+        MVM_exception_throw_adhoc_free(tc, waste, "cannot free in-use library '%s'", c_name);
     }
 
     MVM_nativecall_free_lib(entry->lib);
@@ -92,15 +96,19 @@ MVMObject * MVM_dll_find_symbol(MVMThreadContext *tc, MVMString *lib,
     MVM_HASH_GET(tc, tc->instance->dll_registry, lib, entry);
 
     if (!entry) {
+        char *c_lib = MVM_string_utf8_encode_C_string(tc, lib);
+        char *waste[] = { c_lib, NULL };
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
-        MVM_exception_throw_adhoc(tc,
-                "cannot find symbol '%s' in non-existent library", lib);
+        MVM_exception_throw_adhoc_free(tc, waste,
+                "cannot find symbol '%s' in non-existent library", c_lib);
     }
 
     if (!entry->lib) {
+        char *c_lib = MVM_string_utf8_encode_C_string(tc, lib);
+        char *waste[] = { c_lib, NULL };
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
-        MVM_exception_throw_adhoc(tc,
-                "cannot find symbol '%s' in unloaded library", lib);
+        MVM_exception_throw_adhoc_free(tc, waste,
+                "cannot find symbol '%s' in unloaded library", c_lib);
     }
 
     csym = MVM_string_utf8_c8_encode_C_string(tc, sym);

--- a/src/core/dll.c
+++ b/src/core/dll.c
@@ -58,7 +58,7 @@ int MVM_dll_free(MVMThreadContext *tc, MVMString *name) {
 
     if (!entry) {
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
-        MVM_exception_throw_adhoc(tc, "cannot free non-existent library");
+        MVM_exception_throw_adhoc(tc, "cannot free non-existent library '%s'", name);
     }
 
     /* already freed */
@@ -69,7 +69,7 @@ int MVM_dll_free(MVMThreadContext *tc, MVMString *name) {
 
     if (entry->refcount > 0) {
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
-        MVM_exception_throw_adhoc(tc, "cannot free in-use library");
+        MVM_exception_throw_adhoc(tc, "cannot free in-use library '%s'", name);
     }
 
     MVM_nativecall_free_lib(entry->lib);
@@ -94,13 +94,13 @@ MVMObject * MVM_dll_find_symbol(MVMThreadContext *tc, MVMString *lib,
     if (!entry) {
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
         MVM_exception_throw_adhoc(tc,
-                "cannot find symbol in non-existent library");
+                "cannot find symbol '%s' in non-existent library", lib);
     }
 
     if (!entry->lib) {
         uv_mutex_unlock(&tc->instance->mutex_dll_registry);
         MVM_exception_throw_adhoc(tc,
-                "cannot find symbol in unloaded library");
+                "cannot find symbol '%s' in unloaded library", lib);
     }
 
     csym = MVM_string_utf8_c8_encode_C_string(tc, sym);

--- a/src/core/ext.c
+++ b/src/core/ext.c
@@ -28,7 +28,7 @@ int MVM_ext_load(MVMThreadContext *tc, MVMString *lib, MVMString *ext) {
     });
     if (!sym) {
         uv_mutex_unlock(&tc->instance->mutex_ext_registry);
-        MVM_exception_throw_adhoc(tc, "extension symbol not found");
+        MVM_exception_throw_adhoc(tc, "extension symbol (%s) not found", name);
     }
 
     entry = MVM_malloc(sizeof *entry);

--- a/src/core/ext.c
+++ b/src/core/ext.c
@@ -27,8 +27,10 @@ int MVM_ext_load(MVMThreadContext *tc, MVMString *lib, MVMString *ext) {
         sym = (MVMDLLSym *)MVM_dll_find_symbol(tc, lib, ext);
     });
     if (!sym) {
+        char *c_name = MVM_string_utf8_encode_C_string(tc, name);
+        char *waste[] = { c_name, NULL };
         uv_mutex_unlock(&tc->instance->mutex_ext_registry);
-        MVM_exception_throw_adhoc(tc, "extension symbol (%s) not found", name);
+        MVM_exception_throw_adhoc_free(tc, waste, "extension symbol (%s) not found", c_name);
     }
 
     entry = MVM_malloc(sizeof *entry);

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -489,8 +489,11 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                             found = 1;
                         }
                     }
-                    if (!found)
-                        MVM_exception_throw_adhoc(tc, "setstaticlex given invalid lexical name (%s)", name);
+                    if (!found) {
+                        char *c_name = MVM_string_utf8_encode_C_string(tc, name);
+                        char *waste[] = { c_name, NULL };
+                        MVM_exception_throw_adhoc_free(tc, waste, "setstaticlex given invalid lexical name '%s'", c_name);
+                    }
                 }
                 else {
                     MVM_exception_throw_adhoc(tc, "setstaticlex needs a code ref");
@@ -5555,7 +5558,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (REPR(sc)->ID != MVM_REPR_ID_SCRef)
                     MVM_exception_throw_adhoc(tc,
                         "Must provide an SCRef operand to serialize, got %s (%s)",
-                        REPR(sc)->name, MVM_6model_get_debug_name(tc, sc();
+                        REPR(sc)->name, MVM_6model_get_debug_name(tc, sc));
                 GET_REG(cur_op, 0).o = MVM_serialization_serialize(
                     tc,
                     (MVMSerializationContext *)sc,

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -474,7 +474,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMObject *val  = GET_REG(cur_op, 6).o;
                 MVMint16   flag = GET_I16(cur_op, 8);
                 if (flag < 0 || flag > 2)
-                    MVM_exception_throw_adhoc(tc, "setlexvalue provided with invalid flag");
+                    MVM_exception_throw_adhoc(tc, "setlexvalue provided with invalid flag (%"PRId16")", flag);
                 if (IS_CONCRETE(code) && REPR(code)->ID == MVM_REPR_ID_MVMCode) {
                     MVMStaticFrame *sf = ((MVMCode *)code)->body.sf;
                     MVMuint8 found = 0;
@@ -490,7 +490,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                         }
                     }
                     if (!found)
-                        MVM_exception_throw_adhoc(tc, "setstaticlex given invalid lexical name");
+                        MVM_exception_throw_adhoc(tc, "setstaticlex given invalid lexical name (%s)", name);
                 }
                 else {
                     MVM_exception_throw_adhoc(tc, "setstaticlex needs a code ref");
@@ -1452,7 +1452,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     }
                     else {
                         MVM_exception_throw_adhoc(tc,
-                            "Bad argument index given to captureposprimspec");
+                            "Bad argument index (%"PRId64") given to captureposprimspec", i);
                     }
                 }
                 else {

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3766,8 +3766,13 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMString *lib = GET_REG(cur_op, 2).s;
                 MVMString *sym = GET_REG(cur_op, 4).s;
                 MVMObject *obj = MVM_dll_find_symbol(tc, lib, sym);
-                if (MVM_is_null(tc, obj))
-                    MVM_exception_throw_adhoc(tc, "symbol not found in DLL");
+                if (MVM_is_null(tc, obj)) {
+                    char *lib_cstr = MVM_string_utf8_encode_C_string(tc, lib);
+                    char *sym_cstr = MVM_string_utf8_encode_C_string(tc, sym);
+                    char *waste[] = { lib_cstr, sym_cstr, NULL };
+                    MVM_exception_throw_adhoc_free(tc, waste,
+                        "symbol (%s) not found in DLL (%s)", sym_cstr, lib_cstr);
+                }
 
                 GET_REG(cur_op, 0).o = obj;
                 cur_op += 6;
@@ -3798,7 +3803,9 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(getlexrel): {
                 MVMObject *ctx  = GET_REG(cur_op, 2).o;
                 if (REPR(ctx)->ID != MVM_REPR_ID_MVMContext || !IS_CONCRETE(ctx))
-                    MVM_exception_throw_adhoc(tc, "getlexrel needs a context");
+                    MVM_exception_throw_adhoc(tc,
+                        "getlexrel requires a concrete object with REPR MVMContext, got %s (%s)",
+                        REPR(ctx)->name, MVM_6model_get_debug_name(tc, ctx));
                 GET_REG(cur_op, 0).o = MVM_context_lexical_lookup(tc, (MVMContext *)ctx,
                         GET_REG(cur_op, 4).s);
                 cur_op += 6;
@@ -3807,7 +3814,9 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(getlexreldyn): {
                 MVMObject *ctx  = GET_REG(cur_op, 2).o;
                 if (REPR(ctx)->ID != MVM_REPR_ID_MVMContext || !IS_CONCRETE(ctx))
-                    MVM_exception_throw_adhoc(tc, "getlexreldyn needs a context");
+                    MVM_exception_throw_adhoc(tc,
+                        "getlexreldyn requires a concrete object with REPR MVMContext, got %s (%s)",
+                        REPR(ctx)->name, MVM_6model_get_debug_name(tc, ctx));
                 GET_REG(cur_op, 0).o = MVM_context_dynamic_lookup(tc, (MVMContext *)ctx,
                         GET_REG(cur_op, 4).s);
                 cur_op += 6;
@@ -3816,7 +3825,9 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(getlexrelcaller): {
                 MVMObject   *ctx  = GET_REG(cur_op, 2).o;
                 if (REPR(ctx)->ID != MVM_REPR_ID_MVMContext || !IS_CONCRETE(ctx))
-                    MVM_exception_throw_adhoc(tc, "getlexrelcaller needs a context");
+                    MVM_exception_throw_adhoc(tc,
+                        "getlexrelcaller requires a concrete object with REPR MVMContext, got %s (%s)",
+                        REPR(ctx)->name, MVM_6model_get_debug_name(tc, ctx));
                 GET_REG(cur_op, 0).o = MVM_context_caller_lookup(tc, (MVMContext *)ctx,
                         GET_REG(cur_op, 4).s);
                 cur_op += 6;
@@ -3883,7 +3894,9 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     GET_REG(cur_op, 0).o = MVM_args_slurpy_named(tc, cc->body.apc);
                 }
                 else {
-                    MVM_exception_throw_adhoc(tc, "capturehasnameds needs a MVMCallCapture");
+                    MVM_exception_throw_adhoc(tc,
+                        "capturehasnameds requires a concrete object with REPR MVMCallCapture, got %s (%s)",
+                        REPR(obj)->name, MVM_6model_get_debug_name(tc, obj));
                 }
                 cur_op += 4;
                 goto NEXT;
@@ -4059,7 +4072,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVM_semaphore_acquire(tc, (MVMSemaphore *)sem);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "semacquire requires a concrete object with REPR Semaphore");
+                        "semacquire requires a concrete object with REPR Semaphore, got %s (%s)",
+                        REPR(sem)->name, MVM_6model_get_debug_name(tc, sem));
                 cur_op += 2;
                 goto NEXT;
             }
@@ -4070,7 +4084,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                         (MVMSemaphore *)sem);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "semtryacquire requires a concrete object with REPR Semaphore");
+                        "semtryacquire requires a concrete object with REPR Semaphore, got %s (%s)",
+                        REPR(sem)->name, MVM_6model_get_debug_name(tc, sem));
                 cur_op += 4;
                 goto NEXT;
             }
@@ -4080,7 +4095,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVM_semaphore_release(tc, (MVMSemaphore *)sem);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "semrelease requires a concrete object with REPR Semaphore");
+                        "semrelease requires a concrete object with REPR Semaphore, got %s (%s)",
+                        REPR(sem)->name, MVM_6model_get_debug_name(tc, sem));
                 cur_op += 2;
                 goto NEXT;
             }
@@ -4091,7 +4107,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                         (MVMReentrantMutex *)lock, GET_REG(cur_op, 4).o);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "getlockcondvar requires a concrete object with REPR ReentrantMutex");
+                        "getlockcondvar requires a concrete object with REPR ReentrantMutex, got %s (%s)",
+                        REPR(lock)->name, MVM_6model_get_debug_name(tc, lock));
                 cur_op += 6;
                 goto NEXT;
             }
@@ -4101,7 +4118,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVM_conditionvariable_wait(tc, (MVMConditionVariable *)cv);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "condwait requires a concrete object with REPR ConditionVariable");
+                        "condwait requires a concrete object with REPR ConditionVariable, got %s (%s)",
+                        REPR(cv)->name, MVM_6model_get_debug_name(tc, cv));
                 cur_op += 2;
                 goto NEXT;
             }
@@ -4111,7 +4129,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVM_conditionvariable_signal_one(tc, (MVMConditionVariable *)cv);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "condsignalone requires a concrete object with REPR ConditionVariable");
+                        "condsignalone requires a concrete object with REPR ConditionVariable, got %s (%s)",
+                        REPR(cv)->name, MVM_6model_get_debug_name(tc, cv));
                 cur_op += 2;
                 goto NEXT;
             }
@@ -4121,7 +4140,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVM_conditionvariable_signal_all(tc, (MVMConditionVariable *)cv);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "condsignalall requires a concrete object with REPR ConditionVariable");
+                        "condsignalall requires a concrete object with REPR ConditionVariable, got %s (%s)",
+                        REPR(cv)->name, MVM_6model_get_debug_name(tc, cv));
                 cur_op += 2;
                 goto NEXT;
             }
@@ -4132,7 +4152,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                         (MVMConcBlockingQueue *)queue);
                 else
                     MVM_exception_throw_adhoc(tc,
-                        "queuepoll requires a concrete object with REPR ConcBlockingQueue");
+                        "queuepoll requires a concrete object with REPR ConcBlockingQueue, got %s (%s)",
+                        REPR(queue)->name, MVM_6model_get_debug_name(tc, queue));
                 cur_op += 4;
                 goto NEXT;
             }
@@ -4159,7 +4180,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(ctxouterskipthunks): {
                 MVMObject *ctx = GET_REG(cur_op, 2).o;
                 if (!IS_CONCRETE(ctx) || REPR(ctx)->ID != MVM_REPR_ID_MVMContext)
-                    MVM_exception_throw_adhoc(tc, "ctxouter needs an MVMContext");
+                    MVM_exception_throw_adhoc(tc, "ctxouter needs an MVMContext, got %s (%s)",
+                        REPR(ctx)->name, MVM_6model_get_debug_name(tc, ctx));
                 GET_REG(cur_op, 0).o = MVM_context_apply_traversal(tc, (MVMContext *)ctx,
                         MVM_CTX_TRAV_OUTER_SKIP_THUNKS);
                 cur_op += 4;
@@ -4168,7 +4190,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(ctxcallerskipthunks): {
                 MVMObject *ctx = GET_REG(cur_op, 2).o;
                 if (!IS_CONCRETE(ctx) || REPR(ctx)->ID != MVM_REPR_ID_MVMContext)
-                    MVM_exception_throw_adhoc(tc, "ctxcallerskipthunks needs an MVMContext");
+                    MVM_exception_throw_adhoc(tc, "ctxcallerskipthunks needs an MVMContext, got %s (%s)",
+                        REPR(ctx)->name, MVM_6model_get_debug_name(tc, ctx));
                 GET_REG(cur_op, 0).o = MVM_context_apply_traversal(tc, (MVMContext *)ctx,
                         MVM_CTX_TRAV_CALLER_SKIP_THUNKS);
                 cur_op += 4;
@@ -4782,7 +4805,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     cur_op += 4;
                 }
                 else {
-                    MVM_exception_throw_adhoc(tc, "ctxcode needs an MVMContext");
+                    MVM_exception_throw_adhoc(tc, "ctxcode needs an MVMContext, got %s (%s)",
+                        REPR(this_ctx)->name, MVM_6model_get_debug_name(tc, this_ctx));
                 }
                 goto NEXT;
             }
@@ -4887,7 +4911,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(unbox_u): {
                 MVMObject *obj = GET_REG(cur_op, 2).o;
                 if (!IS_CONCRETE(obj))
-                    MVM_exception_throw_adhoc(tc, "Cannot unbox a type object");
+                    MVM_exception_throw_adhoc(tc, "Cannot unbox a %s (%s) type object",
+                        REPR(obj)->name, MVM_6model_get_debug_name(tc, obj));
                 GET_REG(cur_op, 0).u64 = REPR(obj)->box_funcs.get_uint(tc,
                     STABLE(obj), obj, OBJECT_BODY(obj));
                 cur_op += 4;
@@ -5466,7 +5491,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (!IS_CONCRETE(buf))
                     MVM_exception_throw_adhoc(tc, "Cannot write to a %s type object", MVM_6model_get_debug_name(tc, buf));
                 if ((flags & 3) == 3 || size > 8) {
-                    MVM_exception_throw_adhoc(tc, "Invalid flags value for writeint");
+                    MVM_exception_throw_adhoc(tc, "Invalid flags (%"PRIu64") or size (%hhu) value for writeint", flags, size);
                 }
                 if ((flags & 3) == MVM_SWITCHENDIAN) {
                     value = switch_endian(value, size);
@@ -5529,7 +5554,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMObject *type = GET_REG(cur_op, 6).o;
                 if (REPR(sc)->ID != MVM_REPR_ID_SCRef)
                     MVM_exception_throw_adhoc(tc,
-                        "Must provide an SCRef operand to serialize");
+                        "Must provide an SCRef operand to serialize, got %s (%s)",
+                        REPR(sc)->name, MVM_6model_get_debug_name(tc, sc();
                 GET_REG(cur_op, 0).o = MVM_serialization_serialize(
                     tc,
                     (MVMSerializationContext *)sc,
@@ -5539,7 +5565,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 8;
                 goto NEXT;
             }
-            OP(readint):
+            OP(readint): /* XXX TODO: make consistent with writeintc */
             OP(readuint): {
                 MVMObject*    const buf   = GET_REG(cur_op, 2).o;
                 MVMint64      const off   = (MVMuint64)GET_REG(cur_op, 4).i64;
@@ -5715,9 +5741,10 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     target->o = check;
                 goto NEXT;
             }
-            OP(sp_rebless):
-                if (!REPR(GET_REG(cur_op, 2).o)->change_type) {
-                    MVM_exception_throw_adhoc(tc, "This REPR cannot change type");
+            OP(sp_rebless): {
+                MVMObject *obj = GET_REG(cur_op, 2).o;
+                if (!REPR(obj)->change_type) {
+                    MVM_exception_throw_adhoc(tc, "REPR %s (%s) cannot change type", REPR(obj)->name, MVM_6model_get_debug_name(tc, obj));
                 }
                 REPR(GET_REG(cur_op, 2).o)->change_type(tc, GET_REG(cur_op, 2).o, GET_REG(cur_op, 4).o);
                 GET_REG(cur_op, 0).o = GET_REG(cur_op, 2).o;
@@ -5726,6 +5753,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVM_spesh_deopt_all(tc);
                 MVM_spesh_deopt_one(tc, GET_UI32(cur_op, -4));
                 goto NEXT;
+            }
             OP(sp_resolvecode):
                 GET_REG(cur_op, 0).o = MVM_frame_resolve_invokee_spesh(tc,
                     GET_REG(cur_op, 2).o);

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -293,10 +293,11 @@ struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc, MVMString *host
     if (family == AF_UNIX) {
         struct sockaddr_un *result_un = MVM_malloc(sizeof(struct sockaddr_un));
 
-        if (strlen(host_cstr) > 107) {
+        MVMuint64 host_len = strlen(host_cstr);
+        if (host_len > 107) {
+            char *waste[] = { host_cstr, NULL };
             MVM_free(result_un);
-            MVM_free(host_cstr);
-            MVM_exception_throw_adhoc(tc, "Socket path can only be maximal 107 characters long");
+            MVM_exception_throw_adhoc_free(tc, waste, "Socket path '%s' is %"PRIu64" characters, max allowed is 107", host_cstr, host_len);
         }
 
         result_un->sun_family = AF_UNIX;

--- a/src/spesh/plugin.c
+++ b/src/spesh/plugin.c
@@ -324,7 +324,8 @@ static void add_resolution_to_guard_set(MVMThreadContext *tc, void *sr_data) {
     }
     else {
 #if MVM_SPESH_GUARD_DEBUG
-        fprintf(stderr, "Too many plugin guards added; probable spesh plugin bug\n");
+        fprintf(stderr, "Too many plugin guards added (%"PRIu32"); probable spesh plugin bug\n",
+            base_guards->num_guards);
         MVM_dump_backtrace(tc);
 #endif
     }
@@ -491,7 +492,9 @@ MVMSpeshPluginGuard * get_guard_to_record_into(MVMThreadContext *tc) {
             return &(tc->plugin_guards[tc->num_plugin_guards++]);
         }
         else {
-            MVM_exception_throw_adhoc(tc, "Too many guards recorded by spesh plugin");
+            MVM_exception_throw_adhoc(tc,
+                "Too many guards (%"PRIu32") recorded by spesh plugin, max allowed is %"PRId32"",
+                tc->num_plugin_guards, MVM_SPESH_PLUGIN_GUARD_LIMIT);
         }
     }
     else {

--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -20,7 +20,7 @@ MVMString * MVM_string_ascii_decode(MVMThreadContext *tc, const MVMObject *resul
         }
         else {
             MVM_exception_throw_adhoc(tc,
-                "Will not decode invalid ASCII (code point > 127 found)");
+                "Will not decode invalid ASCII (code point (%"PRId32") < 0 found)", ascii[i]);
         }
     }
     result->body.num_graphs = result_graphs;
@@ -72,7 +72,7 @@ MVMuint32 MVM_string_ascii_decodestream(MVMThreadContext *tc, MVMDecodeStream *d
             MVMGrapheme32 graph;
             if (codepoint > 127)
                 MVM_exception_throw_adhoc(tc,
-                    "Will not decode invalid ASCII (code point > 127 found)");
+                    "Will not decode invalid ASCII (code point (%"PRId32") > 127 found)", codepoint);
             if (last_was_cr) {
                 if (codepoint == '\n') {
                     graph = MVM_unicode_normalizer_translated_crlf(tc, &(ds->norm));
@@ -143,9 +143,9 @@ char * MVM_string_ascii_encode_substr(MVMThreadContext *tc, MVMString *str, MVMu
 
     /* must check start first since it's used in the length check */
     if (start < 0 || start > strgraphs)
-        MVM_exception_throw_adhoc(tc, "start out of range");
+        MVM_exception_throw_adhoc(tc, "start (%"PRId64") out of range (0..%"PRIu32")", start, strgraphs);
     if (length < -1 || start + lengthu > strgraphs)
-        MVM_exception_throw_adhoc(tc, "length out of range");
+        MVM_exception_throw_adhoc(tc, "length (%"PRId64") out of range (-1..%"PRIu32")", length, strgraphs);
 
     if (replacement)
         repl_bytes = (MVMuint8 *) MVM_string_ascii_encode_substr(tc, replacement,

--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -89,7 +89,7 @@ void MVM_string_decodestream_discard_to(MVMThreadContext *tc, MVMDecodeStream *d
         /* Guard against null pointer dereference below. */
         else
             MVM_exception_throw_adhoc(tc,
-                "Unknown error encountered in MVM_string_decodestream_discard_to");
+                "Unknown error encountered in MVM_string_decodestream_discard_to, pos = %"PRId32"", pos);
     }
     if (ds->bytes_head->length == pos) {
         /* We ate all of the new head buffer too; also free it. */
@@ -205,7 +205,7 @@ static MVMString * take_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint3
 
     MVMint32   result_chars = chars - exclude;
     if (result_chars < 0)
-        MVM_exception_throw_adhoc(tc, "DecodeStream take_chars: chars - exclude < 0 should never happen");
+        MVM_exception_throw_adhoc(tc, "DecodeStream take_chars: chars - exclude < 0 should never happen, got (%"PRId32")", result_chars);
 
     result                       = (MVMString *)MVM_repr_alloc_init(tc, tc->instance->VMString);
     result->body.storage_type    = MVM_STRING_GRAPHEME_32;
@@ -661,7 +661,7 @@ void MVM_string_decode_stream_sep_from_strings(MVMThreadContext *tc, MVMDecodeSt
     MVMint32 i, graph_length, graph_pos;
 
     if (num_seps > 0xFFF)
-        MVM_exception_throw_adhoc(tc, "Too many line separators");
+        MVM_exception_throw_adhoc(tc, "Too many line separators (%"PRId32"), max allowed is 4095", num_seps);
 
     MVM_free(sep_spec->sep_lengths);
     MVM_free(sep_spec->sep_graphemes);
@@ -673,7 +673,7 @@ void MVM_string_decode_stream_sep_from_strings(MVMThreadContext *tc, MVMDecodeSt
     for (i = 0; i < num_seps; i++) {
         MVMuint32 num_graphs = MVM_string_graphs(tc, seps[i]);
         if (num_graphs > 0xFFFF)
-            MVM_exception_throw_adhoc(tc, "Line separator too long");
+            MVM_exception_throw_adhoc(tc, "Line separator (%"PRIu32") too long, max allowed is 65535", num_graphs);
         sep_spec->sep_lengths[i] = num_graphs;
         graph_length += num_graphs;
     }

--- a/src/strings/latin1.c
+++ b/src/strings/latin1.c
@@ -149,9 +149,9 @@ char * MVM_string_latin1_encode_substr(MVMThreadContext *tc, MVMString *str, MVM
 
     /* must check start first since it's used in the length check */
     if (start < 0 || start > strgraphs)
-        MVM_exception_throw_adhoc(tc, "start out of range");
+        MVM_exception_throw_adhoc(tc, "start (%"PRId64") out of range (0..%"PRIu32")", start, strgraphs);
     if (length < -1 || start + lengthu > strgraphs)
-        MVM_exception_throw_adhoc(tc, "length out of range");
+        MVM_exception_throw_adhoc(tc, "length (%"PRId64") out of range (-1..%"PRIu32")", length, strgraphs);
 
     if (replacement)
         repl_bytes = (MVMuint8 *) MVM_string_latin1_encode_substr(tc,

--- a/src/strings/normalize.h
+++ b/src/strings/normalize.h
@@ -86,7 +86,7 @@ MVM_STATIC_INLINE MVMint32 MVM_unicode_normalizer_process_codepoint(MVMThreadCon
         if (MVM_UNLIKELY(in < 0)) {
             if (MVM_LIKELY(MVM_nfg_get_synthetic_info(tc, in)->is_utf8_c8))
                 return MVM_unicode_normalizer_process_codepoint_norm_terminator(tc, n, in, out);
-            MVM_exception_throw_adhoc(tc, "Internal error: encountered non-utf8-c8 synthetic during normalization");
+            MVM_exception_throw_adhoc(tc, "Internal error: encountered non-utf8-c8 synthetic (%"PRId32") during normalization", in);
         }
         /* If in isn't \r */
         if (in != 0x0D || !MVM_NORMALIZE_GRAPHEME(n->form))

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -684,7 +684,7 @@ MVMint64 MVM_string_index_from_end(MVMThreadContext *tc, MVMString *Haystack, MV
 
     if (start < 0 || H_graphs <= start)
         /* maybe return -1 instead? */
-        MVM_exception_throw_adhoc(tc, "index start offset out of range");
+        MVM_exception_throw_adhoc(tc, "index start offset (%"PRId64") out of range (0..%"PRIu32")", start, H_graphs);
 
     index = start;
 
@@ -2797,7 +2797,7 @@ MVMString * MVM_string_chr(MVMThreadContext *tc, MVMint64 cp) {
     MVMGrapheme32 g;
 
     if (cp < 0)
-        MVM_exception_throw_adhoc(tc, "chr codepoint cannot be negative");
+        MVM_exception_throw_adhoc(tc, "chr codepoint (%"PRId64") cannot be negative", cp);
     /* If the codepoint decomposes we may need to normalize it.
      * The first cp that decomposes is U+0340, but to be on the safe side
      * for now we go with the first significant character which at the time

--- a/src/strings/shiftjis.c
+++ b/src/strings/shiftjis.c
@@ -16,9 +16,9 @@ char * MVM_string_shiftjis_encode_substr(MVMThreadContext *tc, MVMString *str,
 
     /* must check start first since it's used in the length check */
     if (start < 0 || start > strgraphs)
-        MVM_exception_throw_adhoc(tc, "start out of range");
+        MVM_exception_throw_adhoc(tc, "start (%"PRId64") out of range (0..%"PRIu32")", start, strgraphs);
     if (length < -1 || start + lengthu > strgraphs)
-        MVM_exception_throw_adhoc(tc, "length out of range");
+        MVM_exception_throw_adhoc(tc, "length (%"PRId64") out of range (-1..%"PRIu32")", length, strgraphs);
 
     if (replacement)
         repl_bytes = (MVMuint8 *) MVM_string_shiftjis_encode_substr(tc,

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -977,7 +977,7 @@ MVMint32 unicode_cname_to_property_value_code(MVMThreadContext *tc, MVMint64 pro
                                    /* number + dash + property_value + NULL */
     MVMuint64 out_str_length = length_of_num(property_code) + 1 + cname_length + 1;
     if (1024 < out_str_length)
-        MVM_exception_throw_adhoc(tc, "Property value or name queried is larger than allowed.");
+        MVM_exception_throw_adhoc(tc, "Property value or name queried (%"PRIu64") is larger than allowed (1024).", out_str_length);
 
     out_str = alloca(sizeof(char) * out_str_length);
     snprintf(out_str, out_str_length, "%"PRIi64"-%s", property_code, cname);

--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -240,7 +240,7 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
     }
 
     if (bytes % 2) {
-        MVM_exception_throw_adhoc(tc, "Malformed UTF-16; odd number of bytes");
+        MVM_exception_throw_adhoc(tc, "Malformed UTF-16; odd number of bytes (%"PRIu64")", (MVMuint64)bytes);
     }
 
     utf16_end = utf16 + bytes;
@@ -336,9 +336,9 @@ char * MVM_string_utf16_encode_substr_main(MVMThreadContext *tc, MVMString *str,
 #endif
     /* must check start first since it's used in the length check */
     if (start < 0 || start > strgraphs)
-        MVM_exception_throw_adhoc(tc, "start out of range");
+        MVM_exception_throw_adhoc(tc, "start (%"PRId64") out of range (0..%"PRIu32")", start, strgraphs);
     if (start + lengthu > strgraphs)
-        MVM_exception_throw_adhoc(tc, "length out of range");
+        MVM_exception_throw_adhoc(tc, "length (%"PRId64") out of range (0..%"PRIu32")", length, strgraphs);
 
     if (replacement)
         repl_bytes = (MVMuint8 *) MVM_string_utf16_encode_substr(tc,

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -383,27 +383,25 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     lag_last_accept_pos = pos;
                     break;
                 }
-                case UTF8_REJECT:
+                case UTF8_REJECT: {
+                    char *waste[] = { (char *)buffer, NULL };
                     if (bufsize >= 3) {
                         MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
                     else if (bufsize == 2) {
                         MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
                     else if (bufsize == 1) {
                         MVMGrapheme32 a = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8");
                     }
                     break;
+                }
                 }
             }
 
@@ -449,27 +447,25 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     lag_last_accept_pos = pos;
                     break;
                 }
-                case UTF8_REJECT:
+                case UTF8_REJECT: {
+                    char *waste[] = { (char *)buffer, NULL };
                     if (bufsize >= 3) {
                         MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
                     else if (bufsize == 2) {
                         MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
                     else if (bufsize == 1) {
                         MVMGrapheme32 a = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8");
                     }
                     break;
+                }
                 }
             }
 
@@ -520,27 +516,25 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     }
                     break;
                 }
-                case UTF8_REJECT:
+                case UTF8_REJECT: {
+                    char *waste[] = { (char *)buffer, NULL };
                     if (bufsize >= 3) {
                         MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
                     else if (bufsize == 2) {
                         MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
                     else if (bufsize == 1) {
                         MVMGrapheme32 a = buffer[pos];
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
-                        MVM_free(buffer);
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8");
                     }
                     break;
+                }
                 }
             }
         }

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -384,8 +384,25 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT:
-                    MVM_free(buffer);
-                    MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                    if (bufsize >= 3) {
+                        MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                    }
+                    else if (bufsize == 2) {
+                        MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                    }
+                    else if (bufsize == 1) {
+                        MVMGrapheme32 a = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
+                    }
+                    else {
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                    }
                     break;
                 }
             }
@@ -433,8 +450,25 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT:
-                    MVM_free(buffer);
-                    MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                    if (bufsize >= 3) {
+                        MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                    }
+                    else if (bufsize == 2) {
+                        MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                    }
+                    else if (bufsize == 1) {
+                        MVMGrapheme32 a = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
+                    }
+                    else {
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                    }
                     break;
                 }
             }
@@ -487,8 +521,25 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT:
-                    MVM_free(buffer);
-                    MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                    if (bufsize >= 3) {
+                        MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                    }
+                    else if (bufsize == 2) {
+                        MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                    }
+                    else if (bufsize == 1) {
+                        MVMGrapheme32 a = buffer[pos];
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
+                    }
+                    else {
+                        MVM_free(buffer);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+                    }
                     break;
                 }
             }
@@ -522,11 +573,11 @@ char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
     MVMuint64        repl_length;
 
     if (start < 0 || start > strgraphs)
-        MVM_exception_throw_adhoc(tc, "start out of range");
+        MVM_exception_throw_adhoc(tc, "start (%"PRId64") out of range (0..%"PRIu32")", start, strgraphs);
     if (length == -1)
         length = strgraphs;
     if (length < 0 || start + length > strgraphs)
-        MVM_exception_throw_adhoc(tc, "length out of range");
+        MVM_exception_throw_adhoc(tc, "length (%"PRId64") out of range (0..%"PRIu32")", length, strgraphs);
 
     if (replacement)
         repl_bytes = (MVMuint8 *) MVM_string_utf8_encode_substr(tc,

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -637,7 +637,7 @@ static int hex2int(MVMThreadContext *tc, MVMCodepoint cp) {
     else if (cp >= 'A' && cp <= 'F')
         return 10 + (cp - 'A');
     else
-        MVM_exception_throw_adhoc(tc, "UTF-8 C-8 encoding encountered corrupt synthetic");
+        MVM_exception_throw_adhoc(tc, "UTF-8 C-8 encoding encountered corrupt synthetic (%"PRId32")", cp);
 }
 char * MVM_string_utf8_c8_encode_substr(MVMThreadContext *tc,
         MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length, MVMString *replacement) {
@@ -649,11 +649,11 @@ char * MVM_string_utf8_c8_encode_substr(MVMThreadContext *tc,
     MVMuint64        repl_length;
 
     if (start < 0 || start > strgraphs)
-        MVM_exception_throw_adhoc(tc, "start out of range");
+        MVM_exception_throw_adhoc(tc, "start (%"PRId64") out of range (0..%"PRIu32")", start, strgraphs);
     if (length == -1)
         length = strgraphs;
     if (length < 0 || start + length > strgraphs)
-        MVM_exception_throw_adhoc(tc, "length out of range");
+        MVM_exception_throw_adhoc(tc, "length (%"PRId64") out of range (0..%"PRIu32")", length, strgraphs);
 
     if (replacement)
         repl_bytes = (MVMuint8 *) MVM_string_utf8_c8_encode_substr(tc, replacement, &repl_length, 0, -1, NULL);

--- a/src/strings/windows1252.c
+++ b/src/strings/windows1252.c
@@ -576,9 +576,9 @@ char * MVM_string_windows125X_encode_substr(MVMThreadContext *tc, MVMString *str
 
     /* must check start first since it's used in the length check */
     if (start < 0 || strgraphs < start)
-        MVM_exception_throw_adhoc(tc, "start out of range");
+        MVM_exception_throw_adhoc(tc, "start (%"PRId64") out of range (0..%"PRIu32")", start, strgraphs);
     if (length < -1 || strgraphs < start + lengthu)
-        MVM_exception_throw_adhoc(tc, "length out of range");
+        MVM_exception_throw_adhoc(tc, "length (%"PRId64") out of range (-1..%"PRIu32")", length, strgraphs);
 
     if (replacement)
         repl_bytes = (MVMuint8 *) MVM_string_windows125X_encode_substr(tc,


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.