### PR TITLE
NativeCall: output index of argument with repr mismatch

### DIFF
--- a/src/core/nativecall.h
+++ b/src/core/nativecall.h
@@ -36,6 +36,10 @@
 #define MVM_NATIVECALL_ARG_RW              256
 #define MVM_NATIVECALL_ARG_RW_MASK         256
 
+#define MVM_NATIVECALL_UNMARSHAL_KIND_GENERIC     -1
+#define MVM_NATIVECALL_UNMARSHAL_KIND_RETURN      -2
+#define MVM_NATIVECALL_UNMARSHAL_KIND_NATIVECAST  -3
+
 /* Native callback entry. Hung off MVMNativeCallbackCacheHead, which is
  * a hash owned by the ThreadContext. All MVMNativeCallbacks in a linked
  * list have the same cuid, which is the key to the CacheHead hash.
@@ -124,13 +128,13 @@ unsigned long long  MVM_nativecall_unmarshal_ulonglong(MVMThreadContext *tc, MVM
 float               MVM_nativecall_unmarshal_float(MVMThreadContext *tc, MVMObject *value);
 double              MVM_nativecall_unmarshal_double(MVMThreadContext *tc, MVMObject *value);
 
-char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, MVMint16 type, MVMint16 *free);
-void * MVM_nativecall_unmarshal_cstruct(MVMThreadContext *tc, MVMObject *value);
-void * MVM_nativecall_unmarshal_cppstruct(MVMThreadContext *tc, MVMObject *value);
-void * MVM_nativecall_unmarshal_cpointer(MVMThreadContext *tc, MVMObject *value);
-void * MVM_nativecall_unmarshal_carray(MVMThreadContext *tc, MVMObject *value);
-void * MVM_nativecall_unmarshal_vmarray(MVMThreadContext *tc, MVMObject *value);
-void * MVM_nativecall_unmarshal_cunion(MVMThreadContext *tc, MVMObject *value);
+char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, MVMint16 type, MVMint16 *free, MVMint16 unmarshal_kind);
+void * MVM_nativecall_unmarshal_cstruct(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
+void * MVM_nativecall_unmarshal_cppstruct(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
+void * MVM_nativecall_unmarshal_cpointer(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
+void * MVM_nativecall_unmarshal_carray(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
+void * MVM_nativecall_unmarshal_vmarray(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
+void * MVM_nativecall_unmarshal_cunion(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
 MVMThreadContext * MVM_nativecall_find_thread_context(MVMInstance *instance);
 MVMJitGraph *MVM_nativecall_jit_graph_for_caller_code(
     MVMThreadContext   *tc,

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -385,25 +385,25 @@ static void callback_handler(ffi_cif *cif, void *cb_result, void **cb_args, void
         case MVM_NATIVECALL_ARG_ASCIISTR:
         case MVM_NATIVECALL_ARG_UTF8STR:
         case MVM_NATIVECALL_ARG_UTF16STR:
-            *(void **)cb_result = MVM_nativecall_unmarshal_string(tc, res.o, data->typeinfos[0], NULL);
+            *(void **)cb_result = MVM_nativecall_unmarshal_string(tc, res.o, data->typeinfos[0], NULL, MVM_NATIVECALL_UNMARSHAL_KIND_RETURN);
             break;
         case MVM_NATIVECALL_ARG_CSTRUCT:
-            *(void **)cb_result = MVM_nativecall_unmarshal_cstruct(tc, res.o);
+            *(void **)cb_result = MVM_nativecall_unmarshal_cstruct(tc, res.o, MVM_NATIVECALL_UNMARSHAL_KIND_RETURN);
             break;
         case MVM_NATIVECALL_ARG_CPPSTRUCT:
-            *(void **)cb_result = MVM_nativecall_unmarshal_cppstruct(tc, res.o);
+            *(void **)cb_result = MVM_nativecall_unmarshal_cppstruct(tc, res.o, MVM_NATIVECALL_UNMARSHAL_KIND_RETURN);
             break;
         case MVM_NATIVECALL_ARG_CPOINTER:
-            *(void **)cb_result = MVM_nativecall_unmarshal_cpointer(tc, res.o);
+            *(void **)cb_result = MVM_nativecall_unmarshal_cpointer(tc, res.o, MVM_NATIVECALL_UNMARSHAL_KIND_RETURN);
             break;
         case MVM_NATIVECALL_ARG_CARRAY:
-            *(void **)cb_result = MVM_nativecall_unmarshal_carray(tc, res.o);
+            *(void **)cb_result = MVM_nativecall_unmarshal_carray(tc, res.o, MVM_NATIVECALL_UNMARSHAL_KIND_RETURN);
             break;
         case MVM_NATIVECALL_ARG_CUNION:
-            *(void **)cb_result = MVM_nativecall_unmarshal_cunion(tc, res.o);
+            *(void **)cb_result = MVM_nativecall_unmarshal_cunion(tc, res.o, MVM_NATIVECALL_UNMARSHAL_KIND_RETURN);
             break;
         case MVM_NATIVECALL_ARG_VMARRAY:
-            *(void **)cb_result = MVM_nativecall_unmarshal_vmarray(tc, res.o);
+            *(void **)cb_result = MVM_nativecall_unmarshal_vmarray(tc, res.o, MVM_NATIVECALL_UNMARSHAL_KIND_RETURN);
             break;
         case MVM_NATIVECALL_ARG_CALLBACK:
             *(void **)cb_result = unmarshal_callback(tc, res.o, data->types[0]);
@@ -534,7 +534,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
             case MVM_NATIVECALL_ARG_UTF8STR:
             case MVM_NATIVECALL_ARG_UTF16STR: {
                 MVMint16 free = 0;
-                char *str = MVM_nativecall_unmarshal_string(tc, value, arg_types[i], &free);
+                char *str = MVM_nativecall_unmarshal_string(tc, value, arg_types[i], &free, i);
                 if (free) {
                     if (!free_strs)
                         free_strs = (char**)MVM_malloc(num_args * sizeof(char *));
@@ -547,7 +547,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
             }
             case MVM_NATIVECALL_ARG_CSTRUCT:
                 values[i]           = MVM_malloc(sizeof(void *));
-                *(void **)values[i] = MVM_nativecall_unmarshal_cstruct(tc, value);
+                *(void **)values[i] = MVM_nativecall_unmarshal_cstruct(tc, value, i);
                 break;
             case MVM_NATIVECALL_ARG_CPPSTRUCT: {
                 /* We need to allocate the struct (THIS) for C++ constructor before passing it along. */
@@ -561,7 +561,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                 }
                 else {
                     values[i]           = MVM_malloc(sizeof(void *));
-                    *(void **)values[i] = MVM_nativecall_unmarshal_cppstruct(tc, value);
+                    *(void **)values[i] = MVM_nativecall_unmarshal_cppstruct(tc, value, i);
                 }
                 break;
             }
@@ -569,24 +569,24 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                 if ((arg_types[i] & MVM_NATIVECALL_ARG_RW_MASK) == MVM_NATIVECALL_ARG_RW) {
                     values[i]                     = MVM_malloc(sizeof(void *));
                     *(void **)values[i]           = MVM_malloc(sizeof(void *));
-                    *(void **)*(void **)values[i] = (void *)MVM_nativecall_unmarshal_cpointer(tc, value);
+                    *(void **)*(void **)values[i] = (void *)MVM_nativecall_unmarshal_cpointer(tc, value, i);
                 }
                 else {
                     values[i]           = MVM_malloc(sizeof(void *));
-                    *(void **)values[i] = MVM_nativecall_unmarshal_cpointer(tc, value);
+                    *(void **)values[i] = MVM_nativecall_unmarshal_cpointer(tc, value, i);
                 }
                 break;
             case MVM_NATIVECALL_ARG_CARRAY:
                 values[i]           = MVM_malloc(sizeof(void *));
-                *(void **)values[i] = MVM_nativecall_unmarshal_carray(tc, value);
+                *(void **)values[i] = MVM_nativecall_unmarshal_carray(tc, value, i);
                 break;
             case MVM_NATIVECALL_ARG_CUNION:
                 values[i]           = MVM_malloc(sizeof(void *));
-                *(void **)values[i] = MVM_nativecall_unmarshal_cunion(tc, value);
+                *(void **)values[i] = MVM_nativecall_unmarshal_cunion(tc, value, i);
                 break;
             case MVM_NATIVECALL_ARG_VMARRAY:
                 values[i]           = MVM_malloc(sizeof(void *));
-                *(void **)values[i] = MVM_nativecall_unmarshal_vmarray(tc, value);
+                *(void **)values[i] = MVM_nativecall_unmarshal_vmarray(tc, value, i);
                 break;
             case MVM_NATIVECALL_ARG_CALLBACK:
                 values[i]           = MVM_malloc(sizeof(void *));


### PR DESCRIPTION
also properly says "native cast" or "return type" for those.

before:

    Native call expected return type with CArray representation, but got a CPointer (NativeCall::Types::Pointer[int64])

after:

    Native call expected argument 3 with CArray representation, but got a CPointer (NativeCall::Types::Pointer[int64])