### PR TITLE
Jit getuniprop_(int|bool|str)

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -399,6 +399,11 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_callercode: return MVM_frame_caller_code;
     case MVM_OP_stat: return MVM_file_stat;
     case MVM_OP_lstat: return MVM_file_stat;
+
+    case MVM_OP_getuniprop_int: return MVM_unicode_codepoint_get_property_int;
+    case MVM_OP_getuniprop_bool: return MVM_unicode_codepoint_get_property_bool;
+    case MVM_OP_getuniprop_str: return MVM_unicode_codepoint_get_property_str;
+
     default:
         MVM_oops(tc, "JIT: No function for op %d in op_to_func (%s)", opcode, MVM_op_get_op(opcode)->name);
     }
@@ -2749,6 +2754,27 @@ start:
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
                                  { MVM_JIT_REG_VAL, { obj } } };
         jg_append_call_c(tc, jg, op_to_func(tc, op), 2, args, MVM_JIT_RV_PTR, dst);
+        break;
+    }
+    case MVM_OP_getuniprop_int:
+    case MVM_OP_getuniprop_bool: {
+        MVMint16 dst       = ins->operands[0].reg.orig;
+        MVMint16 grapheme  = ins->operands[1].reg.orig;
+        MVMint16 prop_code = ins->operands[2].reg.orig;
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { grapheme } },
+                                 { MVM_JIT_REG_VAL, { prop_code } } };
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 3, args, MVM_JIT_RV_INT, dst);
+        break;
+    }
+    case MVM_OP_getuniprop_str: {
+        MVMint16 dst       = ins->operands[0].reg.orig;
+        MVMint16 grapheme  = ins->operands[1].reg.orig;
+        MVMint16 prop_code = ins->operands[2].reg.orig;
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_REG_VAL, { grapheme } },
+                                 { MVM_JIT_REG_VAL, { prop_code } } };
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 3, args, MVM_JIT_RV_PTR, dst);
         break;
     }
     case MVM_OP_stat:


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.