### PR TITLE
Fixed some small bugs exposed by `-Wall`.

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -215,9 +215,6 @@ if ($^O eq 'darwin') {
 # Probe the compiler.
 build::probe::compiler_usability(\%config, \%defaults);
 
-# Enable most (useful) warnings
-$config{ccwarnflags} = '-Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-maybe-uninitialized -Wno-missing-braces -Wno-unknown-pragmas -Wno-strict-aliasing';
-
 # Remove unsupported -Werror=* gcc flags if gcc doesn't support them.
 build::probe::specific_werror(\%config, \%defaults);
 if ($config{cc} eq 'gcc' && !$config{can_specific_werror}) {

--- a/Configure.pl
+++ b/Configure.pl
@@ -215,6 +215,9 @@ if ($^O eq 'darwin') {
 # Probe the compiler.
 build::probe::compiler_usability(\%config, \%defaults);
 
+# Enable most (useful) warnings
+$config{ccwarnflags} = '-Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-maybe-uninitialized -Wno-missing-braces -Wno-unknown-pragmas -Wno-strict-aliasing';
+
 # Remove unsupported -Werror=* gcc flags if gcc doesn't support them.
 build::probe::specific_werror(\%config, \%defaults);
 if ($config{cc} eq 'gcc' && !$config{can_specific_werror}) {

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -737,7 +737,7 @@ static void spawn_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
             MVMObject *error_cb;
             MVMString *msg_str;
 
-            snprintf(error_str, 127, "Failed to spawn process %s: %s (error code %d)",
+            snprintf(error_str, 127, "Failed to spawn process %s: %s (error code %ld)",
                     si->prog, uv_strerror(spawn_result), spawn_result);
 
             msg_str = MVM_string_ascii_decode_nt(tc,

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -91,7 +91,7 @@ static void read_one_packet(MVMThreadContext *tc, MVMIOSyncSocketData *data) {
 MVMint64 socket_read_bytes(MVMThreadContext *tc, MVMOSHandle *h, char **buf, MVMint64 bytes) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
     char *use_last_packet = NULL;
-    MVMuint16 use_last_packet_start, use_last_packet_end;
+    MVMuint16 use_last_packet_start = 0, use_last_packet_end = 0;
 
     /* If at EOF, nothing more to do. */
     if (data->eof) {

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -339,7 +339,8 @@ MVMint32 MVM_jit_spill_memory_select(MVMThreadContext *tc, MVMJitCompiler *compi
         idx = compiler->spills_free[bucket];
         compiler->spills_free[bucket] = compiler->spills[idx].next;
     } else {
-        MVM_VECTOR_ENSURE_SPACE(compiler->spills, idx = compiler->spills_num++);
+        idx = compiler->spills_num; compiler->spills_num++;
+        MVM_VECTOR_ENSURE_SPACE(compiler->spills, idx);
         compiler->spills[idx].reg_type = reg_type;
     }
     return compiler->spills_base + idx * sizeof(MVMRegister);

--- a/src/profiler/configuration.c
+++ b/src/profiler/configuration.c
@@ -405,7 +405,7 @@ static void validate_op(MVMThreadContext *tc, validatorstate *state) {
     state->prev_op_bc = prev_op_bc_ptr;
 }
 
-MVMuint8 MVM_confprog_validate(MVMThreadContext *tc, MVMConfigurationProgram *prog) {
+void MVM_confprog_validate(MVMThreadContext *tc, MVMConfigurationProgram *prog) {
     validatorstate state;
 
     state.confprog = prog;
@@ -920,7 +920,7 @@ MVMint64 MVM_confprog_run(MVMThreadContext *tc, void *subject, MVMuint8 entrypoi
                 cur_op += 6;
                 goto NEXT;
             OP(getcodelocation): {
-                MVMuint32 line_out = 0;
+                MVMint32 line_out = 0;
                 MVMString *file_out = NULL;
                 MVMObject *code_obj = (MVMObject *)((MVMStaticFrame *)reg_base[REGISTER_STRUCT_ACCUMULATOR].any)->body.static_code;
                 cur_op += 4;

--- a/src/spesh/arg_guard.c
+++ b/src/spesh/arg_guard.c
@@ -538,6 +538,7 @@ void MVM_spesh_arg_guard_gc_mark(MVMThreadContext *tc, MVMSpeshArgGuard *ag,
                 case MVM_SPESH_GUARD_OP_STABLE_TYPE:
                     MVM_gc_worklist_add(tc, worklist, &(ag->nodes[i].st));
                     break;
+                default: break;
             }
 #pragma clang diagnostic pop
         }
@@ -557,6 +558,7 @@ void MVM_spesh_arg_guard_gc_describe(MVMThreadContext *tc, MVMHeapSnapshotState 
                     MVM_profile_heap_add_collectable_rel_idx(tc, ss,
                         (MVMCollectable*)(ag->nodes[i].st), i);
                     break;
+                default: break;
             }
 #pragma clang diagnostic pop
         }

--- a/src/spesh/dump.c
+++ b/src/spesh/dump.c
@@ -90,6 +90,7 @@ static void dump_bb(MVMThreadContext *tc, DumpStr *ds, MVMSpeshGraph *g, MVMSpes
     MVMSpeshIns *cur_ins;
     MVMint64     i;
     MVMint32     size = 0;
+    MVMuint32    line_number;
 
     /* Heading. */
     appendf(ds, "  BB %d (%p):\n", bb->idx, bb);
@@ -101,7 +102,6 @@ static void dump_bb(MVMThreadContext *tc, DumpStr *ds, MVMSpeshGraph *g, MVMSpes
     {
         /* Also, we have a line number */
         MVMBytecodeAnnotation *bbba = MVM_bytecode_resolve_annotation(tc, &g->sf->body, bb->initial_pc);
-        MVMuint32 line_number;
         if (bbba) {
             line_number = bbba->line_number;
             MVM_free(bbba);
@@ -116,7 +116,6 @@ static void dump_bb(MVMThreadContext *tc, DumpStr *ds, MVMSpeshGraph *g, MVMSpes
     cur_ins = bb->first_ins;
     while (cur_ins) {
         MVMSpeshAnn *ann = cur_ins->annotations;
-        MVMuint32 line_number;
         MVMuint32 pop_inlines = 0;
         MVMuint32 num_comments = 0;
 


### PR DESCRIPTION
Hello!

This pull request fixes a couple minor bugs that showed up when I enabled `-Wall` (and one that showed up without it). The bugs include an `printf` formatting issue, an improperly specified return value, and a couple values which could end up uninitialized or strange depending on the code path taken.

I also added explicit defaults on a couple switch statements to be more explicit about their intents.