### PR TITLE
Only use -fno-ret-protector with Clang on OpenBSD if the JIT is enabled

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -223,8 +223,8 @@ if ($config{cc} eq 'gcc' && !$config{can_specific_werror}) {
     $config{ccmiscflags} =~ s/^ +$//;
 }
 
-# Disable ROP vulnerability protection on OpenBSD, since it breaks the legojit.
-if ($^O eq 'openbsd' && $config{cc} eq 'clang') {
+# Disable RETGUARD on OpenBSD, since it breaks the legojit.
+if ($^O eq 'openbsd' && $args{jit} && $config{cc} eq 'clang') {
 	$config{ccmiscflags} .= ' -fno-ret-protector';
 }
 


### PR DESCRIPTION
This flag is only needed to make the legojit work, every other part of
MoarVM works fine with RETGUARD enabled.