### PR TITLE
[IP6NS Grant] Retry connecting over IPv4 when IPv6 connections fail in certain cases

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -373,6 +373,11 @@ struct MVMInstance {
     /* Flags indicating the signals available on the host system */
     MVMuint64       valid_sigs;
 
+    /* Whether or not IPv6 actually works. This is necessary for systems where
+     * IPv6 is enabled, but misconfigured. */
+    uv_mutex_t      mutex_ipv6;
+    MVMuint8        ipv6;
+
     /************************************************************************
      * Caching and interning
      ************************************************************************/

--- a/src/io/syncsocket.h
+++ b/src/io/syncsocket.h
@@ -5,6 +5,30 @@ typedef enum {
     SOCKET_FAMILY_UNIX
 } MVMSocketFamily;
 
+typedef void (*MVMIOGetUsableAddressCB)(
+    MVMThreadContext  *tc,
+    char              *host_cstr,
+    int                port,
+    unsigned short     family,
+    struct addrinfo  **result,
+    void              *misc_data
+);
+
 MVMObject * MVM_io_socket_create(MVMThreadContext *tc, MVMint64 listen);
-struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc, MVMString *host, MVMint64 port, MVMuint16 family);
+void MVM_io_get_usable_address(
+    MVMThreadContext         *tc,
+    char                     *host_cstr,
+    int                       port,
+    unsigned short            family,
+    struct addrinfo         **result,
+    void                     *misc_data,
+    MVMIOGetUsableAddressCB   on_error
+);
+struct addrinfo * MVM_io_resolve_host_name(
+    MVMThreadContext *tc,
+    MVMString        *host,
+    MVMint64          port,
+    MVMuint16         family,
+    MVMint32          type
+);
 MVMString * MVM_io_get_hostname(MVMThreadContext *tc);

--- a/src/moar.c
+++ b/src/moar.c
@@ -144,6 +144,10 @@ MVMInstance * MVM_vm_create_instance(void) {
     /* Set up persistent object ID hash mutex. */
     init_mutex(instance->mutex_object_ids, "object ID hash");
 
+    /* Assume IPv6 works until it gets used for the first time. */
+    init_mutex(instance->mutex_ipv6, "IPv6");
+    instance->ipv6 = 1;
+
     /* Allocate all things during following setup steps directly in gen2, as
      * they will have program lifetime. */
     MVM_gc_allocate_gen2_default_set(instance->main_thread);


### PR DESCRIPTION
On systems where IPv6 is enabled, but misconfigured, hostnames can
resolve to IPv6 addresses when AF_UNSPEC is specified, but actually
trying to connect with them returns an error of some sort. Don't throw
when this happens; instead, keep track of whether or not IPv6 actually
works in the MoarVM instance, and when it doesn't, resolve the given
hostname to an IPv4 address before reattempting to connect, if
possible.

This comes with some minor refactors to make being able to check errors
like this possible in the future if needed when binding sockets. That I
currently have no way of testing since I don't own any domain names.

This alongside https://github.com/MoarVM/MoarVM/pull/1126 fixes https://github.com/rakudo/rakudo/issues/3007 and https://github.com/rakudo/rakudo/issues/2162, but the two cannot be merged at the same time as either one will need to be rebased after the other gets merged. The other pullreq should be merged first.

Passes nqp's `make test` and Rakudo's `make test` and `make spectest`.