### PR TITLE
Fix bogus "Decoder may not be used concurrently" after exceptions

### DIFF
--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -112,11 +112,13 @@ void MVM_decoder_ensure_decoder(MVMThreadContext *tc, MVMObject *decoder, const 
 static void enter_single_user(MVMThreadContext *tc, MVMDecoder *decoder) {
     if (!MVM_trycas(&(decoder->body.in_use), 0, 1))
        MVM_exception_throw_adhoc(tc, "Decoder may not be used concurrently");
+    MVM_tc_set_ex_release_atomic(tc, &(decoder->body.in_use));
 }
 
 /* Releases the decoder single-user sanity check flag. */
 static void exit_single_user(MVMThreadContext *tc, MVMDecoder *decoder) {
     decoder->body.in_use = 0;
+    MVM_tc_clear_ex_release_mutex(tc);
 }
 
 /* Configures the decoder with the specified encoding and other configuration. */

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -120,15 +120,26 @@ void MVM_tc_destroy(MVMThreadContext *tc) {
     MVM_free(tc);
 }
 
-/* Setting and clearing mutex to release on exception throw. */
+/* Setting and clearing mutex to release on exception throw.
+ * If the LSB of the mutex' address is set, it's not actually a mutex but a
+ * simple flag (an AO_t) that will be cleared on release. */
 void MVM_tc_set_ex_release_mutex(MVMThreadContext *tc, uv_mutex_t *mutex) {
     if (tc->ex_release_mutex)
         MVM_exception_throw_adhoc(tc, "Internal error: multiple ex_release_mutex");
     tc->ex_release_mutex = mutex;
 }
+void MVM_tc_set_ex_release_atomic(MVMThreadContext *tc, AO_t *flag) {
+    if (tc->ex_release_mutex)
+        MVM_exception_throw_adhoc(tc, "Internal error: multiple ex_release_mutex");
+    tc->ex_release_mutex = (uv_mutex_t *)((uintptr_t)flag | 1);
+}
 void MVM_tc_release_ex_release_mutex(MVMThreadContext *tc) {
     if (tc->ex_release_mutex)
-        uv_mutex_unlock(tc->ex_release_mutex);
+        if (MVM_UNLIKELY((uintptr_t)tc->ex_release_mutex & 1)) {
+            *((AO_t*)((uintptr_t)tc->ex_release_mutex & ~(uintptr_t)1)) = 0;
+        } else {
+            uv_mutex_unlock(tc->ex_release_mutex);
+        }
     tc->ex_release_mutex = NULL;
 }
 void MVM_tc_clear_ex_release_mutex(MVMThreadContext *tc) {

--- a/src/core/threadcontext.h
+++ b/src/core/threadcontext.h
@@ -333,5 +333,6 @@ struct MVMThreadContext {
 MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance);
 void MVM_tc_destroy(MVMThreadContext *tc);
 void MVM_tc_set_ex_release_mutex(MVMThreadContext *tc, uv_mutex_t *mutex);
+void MVM_tc_set_ex_release_atomic(MVMThreadContext *tc, AO_t *flag);
 void MVM_tc_release_ex_release_mutex(MVMThreadContext *tc);
 void MVM_tc_clear_ex_release_mutex(MVMThreadContext *tc);


### PR DESCRIPTION
If stream decoding throws an exception (like on bad UTF-8) the deocder's
in_use flag would stay set, preventing any further use of the decoder.
This can lead to great action-at-a-distance effects.

Fix by extending the MVM_tc_(set|release)_ex_release_mutex mechanism to
support such flags in addition to fully blown mutexes. This way we can
keep the light weight in_use flag for the cost of a single bit test and
branch when throwing exceptions.