### PR TITLE
add MVM_vm_run_bytecode() as alternative to  MVM_vm_run_file()

### DIFF
--- a/src/moar.h
+++ b/src/moar.h
@@ -221,6 +221,7 @@ MVMObject *MVM_backend_config(MVMThreadContext *tc);
 /* Top level VM API functions. */
 MVM_PUBLIC MVMInstance * MVM_vm_create_instance(void);
 MVM_PUBLIC void MVM_vm_run_file(MVMInstance *instance, const char *filename);
+MVM_PUBLIC void MVM_vm_run_bytecode(MVMInstance *instance, MVMuint8 *bytes, MVMuint32 size);
 MVM_PUBLIC void MVM_vm_dump_file(MVMInstance *instance, const char *filename);
 MVM_PUBLIC MVM_NO_RETURN void MVM_vm_exit(MVMInstance *instance) MVM_NO_RETURN_ATTRIBUTE;
 MVM_PUBLIC void MVM_vm_destroy_instance(MVMInstance *instance);


### PR DESCRIPTION
Prerequisite to creating self-contained executables.