### PR TITLE
Pull out top-level API into standalone header

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -248,6 +248,7 @@ OBJECTS2 = src/6model/reprs/MVMDLLSym@obj@ \
 
 HEADERS = src/moar.h \
           src/types.h \
+          src/api.h \
           src/bithacks.h \
           src/6model/6model.h \
           src/core/instance.h \

--- a/src/api.h
+++ b/src/api.h
@@ -1,0 +1,40 @@
+#ifndef MVM_API_H
+#define MVM_API_H
+
+#include <stddef.h>
+
+#ifndef MVM_TYPES_INCLUDED
+#include <moar/types.h>
+#endif
+
+#ifndef MVM_PUBLIC
+#ifdef _WIN32
+#define MVM_PUBLIC __declspec(dllimport)
+#else
+#define MVM_PUBLIC
+#endif
+#endif
+
+#ifndef MVM_NO_RETURN
+#define MVM_NO_RETURN
+#endif
+
+#ifndef MVM_NO_RETURN_ATTRIBUTE
+#define MVM_NO_RETURN_ATTRIBUTE
+#endif
+
+MVM_PUBLIC MVMInstance * MVM_vm_create_instance(void);
+MVM_PUBLIC void MVM_vm_run_file(MVMInstance *instance, const char *filename);
+MVM_PUBLIC void MVM_vm_run_bytecode(MVMInstance *instance,
+        const void *bytes, size_t size);
+MVM_PUBLIC void MVM_vm_dump_file(MVMInstance *instance, const char *filename);
+MVM_PUBLIC MVM_NO_RETURN void MVM_vm_exit(MVMInstance *instance)
+        MVM_NO_RETURN_ATTRIBUTE;
+MVM_PUBLIC void MVM_vm_destroy_instance(MVMInstance *instance);
+MVM_PUBLIC void MVM_vm_set_clargs(MVMInstance *instance, int argc, char **argv);
+MVM_PUBLIC void MVM_vm_set_exec_name(MVMInstance *instance, const char *exec_name);
+MVM_PUBLIC void MVM_vm_set_prog_name(MVMInstance *instance, const char *prog_name);
+MVM_PUBLIC void MVM_vm_set_lib_path(MVMInstance *instance,
+        int count, const char **lib_path);
+
+#endif

--- a/src/moar.c
+++ b/src/moar.c
@@ -451,10 +451,12 @@ void MVM_vm_run_file(MVMInstance *instance, const char *filename) {
 }
 
 /* Loads bytecode from memory and runs it. */
-void MVM_vm_run_bytecode(MVMInstance *instance, MVMuint8 *bytes, MVMuint32 size) {
+void MVM_vm_run_bytecode(MVMInstance *instance, const void *bytes, size_t size) {
     /* Map the compilation unit into memory and dissect it. */
     MVMThreadContext *tc = instance->main_thread;
-    MVMCompUnit      *cu = MVM_cu_from_bytes(tc, bytes, size);
+
+    /* Casting const away, oh well... */
+    MVMCompUnit *cu = MVM_cu_from_bytes(tc, (MVMuint8 *)bytes, (MVMuint32)size);
 
     /* Run the deserialization frame, if any. */
     MVMROOT(tc, cu, { run_deserialization_frame(tc, cu); });

--- a/src/moar.h
+++ b/src/moar.h
@@ -221,7 +221,7 @@ MVMObject *MVM_backend_config(MVMThreadContext *tc);
 /* Top level VM API functions. */
 MVM_PUBLIC MVMInstance * MVM_vm_create_instance(void);
 MVM_PUBLIC void MVM_vm_run_file(MVMInstance *instance, const char *filename);
-MVM_PUBLIC void MVM_vm_run_bytecode(MVMInstance *instance, MVMuint8 *bytes, MVMuint32 size);
+MVM_PUBLIC void MVM_vm_run_bytecode(MVMInstance *instance, const void *bytes, size_t size);
 MVM_PUBLIC void MVM_vm_dump_file(MVMInstance *instance, const char *filename);
 MVM_PUBLIC MVM_NO_RETURN void MVM_vm_exit(MVMInstance *instance) MVM_NO_RETURN_ATTRIBUTE;
 MVM_PUBLIC void MVM_vm_destroy_instance(MVMInstance *instance);

--- a/src/moar.h
+++ b/src/moar.h
@@ -219,16 +219,7 @@ MVM_PUBLIC const MVMint32 MVM_jit_support(void);
 MVMObject *MVM_backend_config(MVMThreadContext *tc);
 
 /* Top level VM API functions. */
-MVM_PUBLIC MVMInstance * MVM_vm_create_instance(void);
-MVM_PUBLIC void MVM_vm_run_file(MVMInstance *instance, const char *filename);
-MVM_PUBLIC void MVM_vm_run_bytecode(MVMInstance *instance, const void *bytes, size_t size);
-MVM_PUBLIC void MVM_vm_dump_file(MVMInstance *instance, const char *filename);
-MVM_PUBLIC MVM_NO_RETURN void MVM_vm_exit(MVMInstance *instance) MVM_NO_RETURN_ATTRIBUTE;
-MVM_PUBLIC void MVM_vm_destroy_instance(MVMInstance *instance);
-MVM_PUBLIC void MVM_vm_set_clargs(MVMInstance *instance, int argc, char **argv);
-MVM_PUBLIC void MVM_vm_set_exec_name(MVMInstance *instance, const char *exec_name);
-MVM_PUBLIC void MVM_vm_set_prog_name(MVMInstance *instance, const char *prog_name);
-MVM_PUBLIC void MVM_vm_set_lib_path(MVMInstance *instance, int count, const char **lib_path);
+#include "api.h"
 
 /* Returns absolute executable path. */
 MVM_PUBLIC int MVM_exepath(char* buffer, size_t* size);

--- a/src/types.h
+++ b/src/types.h
@@ -1,3 +1,5 @@
+#define MVM_TYPES_INCLUDED
+
 /* struct and union types are forward-declared for convenience */
 
 typedef struct MVMActiveHandler MVMActiveHandler;


### PR DESCRIPTION
Our installed headers are broken: While one would expect something like 

    #include <moar/moar.h>

to work, it does not as we basically dump all out header files into the public include directory without any care for relative paths.

This will take some time to fix, but as a stopgap measure, this pull request adds `api.h` as a standalone header declaring the functions in the `MVM_vm_*` namespace.

The signature of the newly introduced `MVM_vm_run_bytecode()` function has been changed to no longer refer to any `MVM*` types (besides `MVMInstance`).