### PR TITLE
Fix incorrect return type in get_effective_size

### DIFF
--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -190,7 +190,7 @@ static int is_graph_inlineable(MVMThreadContext *tc, MVMSpeshGraph *inliner,
 
 /* Gets the effective size for inlining considerations of a specialization,
  * which is its code size minus the code size of its inlines. */
-MVMint32 get_effective_size(MVMThreadContext *tc, MVMSpeshCandidate *cand) {
+MVMuint32 get_effective_size(MVMThreadContext *tc, MVMSpeshCandidate *cand) {
     MVMint32 result = cand->bytecode_size;
     MVMuint32 i;
     for (i = 0; i < cand->num_inlines; i++)


### PR DESCRIPTION
Probably a typo. The code makes certain the the return value can't
be negative.