### PR TITLE
Silence some clang warnings

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -332,7 +332,7 @@ static void unmarshal_error(MVMThreadContext *tc, char *desired_repr, MVMObject 
     }
     else {
         MVM_exception_throw_adhoc(tc,
-            "Native call expected argument %ld with %s representation, but got a %s (%s)", unmarshal_kind + 1, desired_repr, REPR(value)->name, MVM_6model_get_debug_name(tc, value));
+            "Native call expected argument %d with %s representation, but got a %s (%s)", unmarshal_kind + 1, desired_repr, REPR(value)->name, MVM_6model_get_debug_name(tc, value));
     }
 }
 

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -134,12 +134,13 @@ void MVM_tc_set_ex_release_atomic(MVMThreadContext *tc, AO_t *flag) {
     tc->ex_release_mutex = (uv_mutex_t *)((uintptr_t)flag | 1);
 }
 void MVM_tc_release_ex_release_mutex(MVMThreadContext *tc) {
-    if (tc->ex_release_mutex)
+    if (tc->ex_release_mutex) {
         if (MVM_UNLIKELY((uintptr_t)tc->ex_release_mutex & 1)) {
             *((AO_t*)((uintptr_t)tc->ex_release_mutex & ~(uintptr_t)1)) = 0;
         } else {
             uv_mutex_unlock(tc->ex_release_mutex);
         }
+    }
     tc->ex_release_mutex = NULL;
 }
 void MVM_tc_clear_ex_release_mutex(MVMThreadContext *tc) {

--- a/src/profiler/configuration.c
+++ b/src/profiler/configuration.c
@@ -920,7 +920,7 @@ MVMint64 MVM_confprog_run(MVMThreadContext *tc, void *subject, MVMuint8 entrypoi
                 cur_op += 6;
                 goto NEXT;
             OP(getcodelocation): {
-                MVMuint32 line_out = 0;
+                MVMint32 line_out = 0;
                 MVMString *file_out = NULL;
                 MVMObject *code_obj = (MVMObject *)((MVMStaticFrame *)reg_base[REGISTER_STRUCT_ACCUMULATOR].any)->body.static_code;
                 cur_op += 4;

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -1739,10 +1739,10 @@ static void filemeta_to_filehandle_ver3(MVMThreadContext *tc, MVMHeapSnapshotCol
     snprintf(metadata, 1023,
             "{ "
             "\"subversion\": %d, "
-            "\"start_time\": %lld, "
+            "\"start_time\": %lu, "
             "\"pid\": %ld, "
             "\"highscore_structure\": { "
-                "\"entry_count\": %ld, "
+                "\"entry_count\": %d, "
                 "\"data_order\": ["
                     "\"types_by_count\", \"frames_by_count\", \"types_by_size\", \"frames_by_size\""
                 "]"
@@ -1786,14 +1786,14 @@ static void snapmeta_to_filehandle_ver3(MVMThreadContext *tc, MVMHeapSnapshotCol
 
     snprintf(metadata, 1023,
             "{ "
-            "\"snap_time\": %lld, "
-            "\"gc_seq_num\": %lld, "
-            "\"total_heap_size\": %lld, "
-            "\"total_objects\": %lld, "
-            "\"total_typeobjects\": %lld, "
-            "\"total_stables\": %lld, "
-            "\"total_frames\": %lld, "
-            "\"total_refs\": %lld "
+            "\"snap_time\": %lu, "
+            "\"gc_seq_num\": %lu, "
+            "\"total_heap_size\": %lu, "
+            "\"total_objects\": %lu, "
+            "\"total_typeobjects\": %lu, "
+            "\"total_stables\": %lu, "
+            "\"total_frames\": %lu, "
+            "\"total_refs\": %lu "
             "}",
             s->record_time / 1000,
             MVM_load(&tc->instance->gc_seq_number),

--- a/src/spesh/worker.c
+++ b/src/spesh/worker.c
@@ -48,7 +48,7 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
 
                     MVM_repr_pos_set_elems(tc, overview_subscription_packet, 15);
 
-                    overview_data = ((MVMArray *)overview_subscription_packet)->body.slots.u64;
+                    overview_data = ((MVMArray *)overview_subscription_packet)->body.slots.i64;
 
                     overview_data[0] = work_sequence_number;
                     overview_data[1] = now_time / 1000;


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.