### PR TITLE
Deoptimization in the expression JIT compiler

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -2684,6 +2684,66 @@
 (template: sp_p6obind_s
   (^store_write_barrier! $0 (add (^p6obody $0) $1) $2))
 
+(macro: ^deopt_one (,deopt_idx)
+  (dov (callv (^func MVM_spesh_deopt_one) (arglist (carg (tc) ptr) (carg ,deopt_idx int))) (^exit)))
+
+# Optimization guards
+(template: sp_guard
+  (let: (($check (copy $1)))
+    (when (any (zr $check) (ne (^stable $check) (^spesh_slot_value $2)))
+       (^deopt_one $3))
+    (copy $check)))
+
+(template: sp_guardconc
+  (let: (($check (copy $1)))
+    (when (any (zr $check) (^is_type_obj $check) (ne (^stable $check) (^spesh_slot_value $2)))
+       (^deopt_one $3))
+    (copy $check)))
+
+(template: sp_guardtype
+  (let: (($check (copy $1)))
+     (when (any (zr $check) (^is_conc_obj $check) (ne (^stable $check) (^spesh_slot_value $2)))
+       (^deopt_one $3))
+     (copy $check)))
+
+(template: sp_guardsf
+  (let: (($check (copy $0)))
+    (when (any (^not_repr_id $check MVM_REPR_ID_MVMCode)
+               (ne (^getf $check MVMCode body.sf) (^spesh_slot_value $1)))
+         (^deopt_one $2))))
+
+(template: sp_guardsfouter
+  (let: (($check (copy $0)))
+    (when (any (^not_repr_id $check MVM_REPR_ID_MVMCode)
+               (ne (^getf $check MVMCode body.sf) (^spesh_slot_value $1))
+               (ne (^getf $check MVMCode body.outer) (^frame)))
+         (^deopt_one $2))))
+
+(template: sp_guardobj
+  (let: (($check (copy $1)))
+     (when (ne $check (^spesh_slot_value $2))
+       (^deopt_one $3))
+     (copy $check)))
+
+(template: sp_guardnotobj
+  (let: (($check (copy $1)))
+     (when (eq $check (^spesh_slot_value $2))
+       (^deopt_one $3))
+     (copy $check)))
+
+(template: sp_guardjustconc
+  (let: (($check (copy $1)))
+    (when (^is_type_obj $check)
+      (^deopt_one $2))
+    (copy $check)))
+
+(template: sp_guardjusttype
+  (let: (($check (copy $1)))
+    (when (^is_conc_obj $check)
+      (^deopt_one $2))
+    (copy $check)))
+
+
 # MVMCompUnit *dep = (MVMCompUnit *)tc->cur_frame->effective_spesh_slots[GET_UI16(cur_op, 2)];
 # MVMuint16 idx = GET_UI32(cur_op, 4);
 # GET_REG(cur_op, 0).s = MVM_cu_string(tc, dep, idx);

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -431,8 +431,7 @@ static void jg_append_guard(MVMThreadContext *tc, MVMJitGraph *jg,
         MVM_oops(tc, "Can't find deopt idx annotation on spesh ins <%s>",
             ins->info->name);
     }
-    node->u.guard.deopt_target = ins->operands[target_operand].lit_ui32;
-    node->u.guard.deopt_offset = jg->sg->deopt_addrs[2 * deopt_idx + 1];
+    node->u.guard.deopt_idx = deopt_idx;
     jg_append_node(jg, node);
 }
 

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -419,17 +419,24 @@ static void jg_append_guard(MVMThreadContext *tc, MVMJitGraph *jg,
     MVMint32 deopt_idx;
     node->type = MVM_JIT_NODE_GUARD;
     node->u.guard.ins = ins;
-    while (ann) {
-        if (ann->type == MVM_SPESH_ANN_DEOPT_ONE_INS ||
-            ann->type == MVM_SPESH_ANN_DEOPT_INLINE) {
-            deopt_idx = ann->data.deopt_idx;
-            break;
-        }
-        ann = ann->next;
-    }
-    if (!ann) {
-        MVM_oops(tc, "Can't find deopt idx annotation on spesh ins <%s>",
-            ins->info->name);
+    switch (ins->info->opcode) {
+    case MVM_OP_sp_guard:
+    case MVM_OP_sp_guardconc:
+    case MVM_OP_sp_guardtype:
+    case MVM_OP_sp_guardobj:
+    case MVM_OP_sp_guardnotobj:
+    case MVM_OP_sp_rebless:
+        deopt_idx = ins->operands[3].lit_ui32;
+        break;
+    case MVM_OP_sp_guardsf:
+    case MVM_OP_sp_guardsfouter:
+    case MVM_OP_sp_guardjustconc:
+    case MVM_OP_sp_guardjusttype:
+        deopt_idx = ins->operands[2].lit_ui32;
+        break;
+    default:
+        abort();
+        break;
     }
     node->u.guard.deopt_idx = deopt_idx;
     jg_append_node(jg, node);

--- a/src/jit/graph.h
+++ b/src/jit/graph.h
@@ -51,8 +51,7 @@ struct MVMJitPrimitive {
 
 struct MVMJitGuard {
     MVMSpeshIns * ins;
-    MVMint32      deopt_target;
-    MVMint32      deopt_offset;
+    MVMuint32 deopt_idx;
 };
 
 

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -3210,9 +3210,8 @@ void MVM_jit_emit_guard(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGr
     |1:
     /* emit deopt */
     | mov ARG1, TC;
-    | mov ARG2, guard->deopt_offset;
-    | mov ARG3, guard->deopt_target;
-    | callp &MVM_spesh_deopt_one_direct;
+    | mov ARG2, guard->deopt_idx;
+    | callp &MVM_spesh_deopt_one;
     /* jump out */
     | jmp ->exit;
     |2:

--- a/src/spesh/deopt.h
+++ b/src/spesh/deopt.h
@@ -1,5 +1,3 @@
 void MVM_spesh_deopt_all(MVMThreadContext *tc);
-void MVM_spesh_deopt_one(MVMThreadContext *tc, MVMuint32 deopt_target);
-void MVM_spesh_deopt_one_direct(MVMThreadContext *tc, MVMuint32 deopt_offset,
-                                MVMuint32 deopt_target);
+void MVM_spesh_deopt_one(MVMThreadContext *tc, MVMuint32 deopt_idx);
 MVMint32 MVM_spesh_deopt_find_inactive_frame_deopt_idx(MVMThreadContext *tc, MVMFrame *f);

--- a/src/spesh/facts.c
+++ b/src/spesh/facts.c
@@ -378,7 +378,7 @@ static void log_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
         guard->operands[1] = preguard_reg;
         guard->operands[2].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
             (MVMCollectable *)agg_type->st);
-        guard->operands[3].lit_ui32 = g->deopt_addrs[2 * deopt_one_ann->data.deopt_idx];
+        guard->operands[3].lit_ui32 = deopt_one_ann->data.deopt_idx;
         if (ins->next)
             MVM_spesh_manipulate_insert_ins(tc, bb, ins, guard);
         else

--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -489,6 +489,28 @@ static void rewrite_hlltype(MVMThreadContext *tc, MVMSpeshGraph *inlinee, MVMSpe
     ins->info = MVM_op_get_op(MVM_OP_sp_getspeshslot);
 }
 
+static void tweak_guard_deopt_idx(MVMSpeshIns *ins, MVMSpeshAnn *ann) {
+    /* Twiddle guard opcode to point to the correct deopt index */
+    switch (ins->info->opcode) {
+    case MVM_OP_sp_guard:
+    case MVM_OP_sp_guardconc:
+    case MVM_OP_sp_guardtype:
+    case MVM_OP_sp_guardobj:
+    case MVM_OP_sp_guardnotobj:
+    case MVM_OP_sp_rebless:
+        ins->operands[3].lit_ui32 = ann->data.deopt_idx;
+        break;
+    case MVM_OP_sp_guardsf:
+    case MVM_OP_sp_guardsfouter:
+    case MVM_OP_sp_guardjustconc:
+    case MVM_OP_sp_guardjusttype:
+        ins->operands[2].lit_ui32 = ann->data.deopt_idx;
+        break;
+    default:
+        break;
+    }
+}
+
 /* Merges the inlinee's spesh graph into the inliner. */
 MVMSpeshBB * merge_graph(MVMThreadContext *tc, MVMSpeshGraph *inliner,
                  MVMSpeshGraph *inlinee, MVMStaticFrame *inlinee_sf,
@@ -552,6 +574,7 @@ MVMSpeshBB * merge_graph(MVMThreadContext *tc, MVMSpeshGraph *inliner,
                 case MVM_SPESH_ANN_DEOPT_INLINE:
                 case MVM_SPESH_ANN_DEOPT_OSR:
                     ann->data.deopt_idx += inliner->num_deopt_addrs;
+                    tweak_guard_deopt_idx(ins, ann);
                     for (i = 0; i < MVM_VECTOR_ELEMS(regs_for_deopt); i++)
                         MVM_spesh_usages_add_deopt_usage_by_reg(tc, inliner,
                                 regs_for_deopt[i], ann->data.deopt_idx);

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1609,7 +1609,7 @@ static void insert_arg_type_guard(MVMThreadContext *tc, MVMSpeshGraph *g,
     guard->operands[2].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
         (MVMCollectable *)type_info->type->st);
     find_deopt_target_and_index(tc, g, arg_info->prepargs_ins, &deopt_target, &deopt_index);
-    guard->operands[3].lit_ui32 = deopt_target;
+    guard->operands[3].lit_ui32 = deopt_index;
     MVM_spesh_manipulate_insert_ins(tc, arg_info->prepargs_bb,
         arg_info->prepargs_ins->prev, guard);
     MVM_spesh_usages_add_by_reg(tc, g, preguard_reg, guard);
@@ -1662,7 +1662,7 @@ static void insert_arg_decont_type_guard(MVMThreadContext *tc, MVMSpeshGraph *g,
     guard->operands[1] = temp;
     guard->operands[2].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
         (MVMCollectable *)type_info->decont_type->st);
-    guard->operands[3].lit_ui32 = deopt_target;
+    guard->operands[3].lit_ui32 = deopt_index;
     MVM_spesh_manipulate_insert_ins(tc, arg_info->prepargs_bb,
         arg_info->prepargs_ins->prev, guard);
     MVM_spesh_usages_add_by_reg(tc, g, temp, guard);
@@ -1807,7 +1807,7 @@ static void tweak_for_target_sf(MVMThreadContext *tc, MVMSpeshGraph *g,
     guard->operands[0] = temp;
     guard->operands[1].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
         (MVMCollectable *)target_sf);
-    guard->operands[2].lit_ui32 = deopt_target;
+    guard->operands[2].lit_ui32 = deopt_index;
     MVM_spesh_usages_add_by_reg(tc, g, temp, guard);
     MVM_spesh_manipulate_insert_ins(tc, arg_info->prepargs_bb,
         arg_info->prepargs_ins->prev, guard);
@@ -2373,7 +2373,7 @@ static void tweak_rebless(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns *i
     new_operands[1] = ins->operands[1];
     new_operands[2] = ins->operands[2];
     find_deopt_target_and_index(tc, g, ins, &deopt_target, &deopt_index);
-    new_operands[3].lit_ui32 = deopt_target;
+    new_operands[3].lit_ui32 = deopt_index;
     ins->info = MVM_op_get_op(MVM_OP_sp_rebless);
     ins->operands = new_operands;
 }

--- a/src/spesh/plugin.c
+++ b/src/spesh/plugin.c
@@ -666,7 +666,7 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
          * deopt position. */
         MVMSpeshAnn *stolen_deopt_ann = steal_prepargs_deopt(tc, ins);
         MVMuint32 stolen_deopt_ann_used = 0;
-        MVMuint32 deopt_to = g->deopt_addrs[2 * stolen_deopt_ann->data.deopt_idx];
+        MVMuint32 deopt_idx = stolen_deopt_ann->data.deopt_idx;
 
         /* Collect registers that go with each argument, and delete the arg
          * and prepargs instructions. */
@@ -715,7 +715,7 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
                         MVM_spesh_usages_add_by_reg(tc, g, preguard_reg, guard_ins);
                         guard_ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
                                 (MVMCollectable *)guard->u.object);
-                        guard_ins->operands[3].lit_ui32 = deopt_to;
+                        guard_ins->operands[3].lit_ui32 = deopt_idx;
                         guard_ins->annotations = stolen_deopt_ann;
                         MVM_spesh_manipulate_insert_ins(tc, bb, ins->prev, guard_ins);
                         guarded_facts->flags |= MVM_SPESH_FACT_KNOWN_VALUE;
@@ -756,7 +756,7 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
                         MVM_spesh_usages_add_by_reg(tc, g, preguard_reg, guard_ins);
                         guard_ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
                                 (MVMCollectable *)guard->u.object);
-                        guard_ins->operands[3].lit_ui32 = deopt_to;
+                        guard_ins->operands[3].lit_ui32 = deopt_idx;
                         guard_ins->annotations = stolen_deopt_ann;
                         MVM_spesh_manipulate_insert_ins(tc, bb, ins->prev, guard_ins);
                         stolen_deopt_ann_used = 1;
@@ -782,7 +782,7 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
                         MVM_spesh_usages_add_by_reg(tc, g, preguard_reg, guard_ins);
                         guard_ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
                                 (MVMCollectable *)guard->u.type);
-                        guard_ins->operands[3].lit_ui32 = deopt_to;
+                        guard_ins->operands[3].lit_ui32 = deopt_idx;
                         guard_ins->annotations = stolen_deopt_ann;
                         MVM_spesh_manipulate_insert_ins(tc, bb, ins->prev, guard_ins);
                         guarded_facts->flags |= MVM_SPESH_FACT_KNOWN_TYPE;
@@ -808,7 +808,7 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
                         guarded_facts->writer = guard_ins;
                         guard_ins->operands[1] = preguard_reg;
                         MVM_spesh_usages_add_by_reg(tc, g, preguard_reg, guard_ins);
-                        guard_ins->operands[2].lit_ui32 = deopt_to;
+                        guard_ins->operands[2].lit_ui32 = deopt_idx;
                         guard_ins->annotations = stolen_deopt_ann;
                         MVM_spesh_manipulate_insert_ins(tc, bb, ins->prev, guard_ins);
                         guarded_facts->flags |= MVM_SPESH_FACT_CONCRETE;
@@ -833,7 +833,7 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
                         guarded_facts->writer = guard_ins;
                         guard_ins->operands[1] = preguard_reg;
                         MVM_spesh_usages_add_by_reg(tc, g, preguard_reg, guard_ins);
-                        guard_ins->operands[2].lit_ui32 = deopt_to;
+                        guard_ins->operands[2].lit_ui32 = deopt_idx;
                         guard_ins->annotations = stolen_deopt_ann;
                         MVM_spesh_manipulate_insert_ins(tc, bb, ins->prev, guard_ins);
                         guarded_facts->flags |= MVM_SPESH_FACT_TYPEOBJ;

--- a/src/spesh/plugin.c
+++ b/src/spesh/plugin.c
@@ -695,8 +695,10 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
             MVMSpeshPluginGuard *guard = &(gs->guards[guards_start]);
             MVMSpeshFacts *preguarded_facts = MVM_spesh_get_facts(tc, g, arg_regs[guard->test_idx]);
             if (guard->kind != MVM_SPESH_PLUGIN_GUARD_GETATTR) {
-                if (stolen_deopt_ann_used)
+                if (stolen_deopt_ann_used) {
                     stolen_deopt_ann = clone_deopt_ann(tc, g, stolen_deopt_ann);
+                    deopt_idx = stolen_deopt_ann->data.deopt_idx;
+                }
             }
             switch (guard->kind) {
                 case MVM_SPESH_PLUGIN_GUARD_OBJ: {


### PR DESCRIPTION
Adds deoptimization guard support in the expression JIT compiler.
To achieve this, I made the argument to deopt_one be the deopt_idx, using which we lookup the deopt_target, rather than using the deopt_target itself. This saves another search in the materialization logic. This makes the implementation of the `sp_guard` opcodes non-special as far as the template preprocessor is concerned, except that we do have to introduce a global sync.