### PR TITLE
Unicode path support on Windows

### DIFF
--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -834,13 +834,12 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
 }
 
 #ifdef _WIN32
-DLLib* MVM_nativecall_load_lib(const char* path)
-{
+DLLib* MVM_nativecall_load_lib(const char* path) {
     HMODULE module;
     if (path != NULL) {
-        const int       len       = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+        const int       len   = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
         wchar_t * const wpath = (wchar_t *)MVM_malloc(len * sizeof(wchar_t));
-                                    MultiByteToWideChar(CP_UTF8, 0, path, -1, (LPWSTR)wpath, len);
+                                MultiByteToWideChar(CP_UTF8, 0, path, -1, (LPWSTR)wpath, len);
         module = LoadLibraryW(wpath);
         MVM_free(wpath);
     }

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -832,3 +832,21 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
     MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke");
     return result;
 }
+
+#ifdef _WIN32
+DLLib* MVM_nativecall_load_lib(const char* path)
+{
+    HMODULE module;
+    if (path != NULL) {
+        const int       len       = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+        wchar_t * const wpath = (wchar_t *)MVM_malloc(len * sizeof(wchar_t));
+                                    MultiByteToWideChar(CP_UTF8, 0, path, -1, (LPWSTR)wpath, len);
+        module = LoadLibraryW(wpath);
+        MVM_free(wpath);
+    }
+    else {
+        module = GetModuleHandle(NULL);
+    }
+    return (DLLib*)(module);
+}
+#endif

--- a/src/core/nativecall_dyncall.h
+++ b/src/core/nativecall_dyncall.h
@@ -1,4 +1,9 @@
 MVMint16 MVM_nativecall_get_calling_convention(MVMThreadContext *tc, MVMString *name);
+#ifdef _WIN32
+// Temporary hack until dyncall supports Unicode.
+DLLib* MVM_nativecall_load_lib(const char* path);
+#else
 #define MVM_nativecall_load_lib(path)       dlLoadLibrary(path)
+#endif
 #define MVM_nativecall_free_lib(lib)        dlFreeLibrary(lib)
 #define MVM_nativecall_find_sym(lib, name)  dlFindSymbol(lib, name)

--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -454,7 +454,8 @@ MVMObject * MVM_file_open_fh(MVMThreadContext *tc, MVMString *filename, MVMStrin
 #ifdef _WIN32
     flag |= _O_BINARY;
 #endif
-    if ((fd = open((const char *)fname, flag, DEFAULT_MODE)) == -1) {
+
+    if ((fd = MVM_platform_open((const char *)fname, flag, DEFAULT_MODE)) == -1) {
         char *waste[] = { fname, NULL };
         const char *err = strerror(errno);
         MVM_exception_throw_adhoc_free(tc, waste, "Failed to open file %s: %s", fname, err);

--- a/src/jit/dump.c
+++ b/src/jit/dump.c
@@ -5,7 +5,7 @@ void MVM_jit_dump_bytecode(MVMThreadContext *tc, MVMJitCode *code) {
     FILE * dump;
     snprintf(filename, sizeof(filename), "%s/moar-jit-%04d.bin",
              tc->instance->jit_bytecode_dir, code->seq_nr);
-    dump = fopen(filename, "w");
+    dump = MVM_platform_fopen(filename, "w");
     if (dump) {
         fwrite(code->func_ptr, sizeof(char), code->size, dump);
         fclose(dump);

--- a/src/jit/dump.c
+++ b/src/jit/dump.c
@@ -1,4 +1,5 @@
 #include "moar.h"
+#include "platform/io.h"
 
 void MVM_jit_dump_bytecode(MVMThreadContext *tc, MVMJitCode *code) {
     char filename[1024];

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <moar.h>
+#include "platform/io.h"
 
 #if MVM_TRACING
 #  define TRACING_OPT "[--tracing] "

--- a/src/main.c
+++ b/src/main.c
@@ -258,7 +258,7 @@ int wmain(int argc, wchar_t *wargv[])
              getpid()
 #endif
              );
-        fp = fopen(path, "w");
+        fp = MVM_platform_fopen(path, "w");
         if (fp) {
             MVM_telemetry_init(fp);
             telemeh_inited = 1;

--- a/src/moar.c
+++ b/src/moar.c
@@ -50,18 +50,18 @@ static FILE *fopen_perhaps_with_pid(char *env_var, char *path, const char *mode)
         /* We expect to pass only a single argument to snprintf here;
          * just bail out if there's more than one directive. */
         if (found_percents > 1) {
-            result = fopen(path, mode);
+            result = MVM_platform_fopen(path, mode);
         } else {
             char *fixed_path = malloc(path_length + 16);
             MVMint64 pid = MVM_proc_getpid(NULL);
             /* We make the brave assumption that
              * pids only go up to 16 characters. */
             snprintf(fixed_path, path_length + 16, path, pid);
-            result = fopen(fixed_path, mode);
+            result = MVM_platform_fopen(fixed_path, mode);
             free(fixed_path);
         }
     } else {
-        result = fopen(path, mode);
+        result = MVM_platform_fopen(path, mode);
     }
 
     if (result)
@@ -283,7 +283,7 @@ MVMInstance * MVM_vm_create_instance(void) {
             char perf_map_filename[32];
             snprintf(perf_map_filename, sizeof(perf_map_filename),
                      "/tmp/perf-%"PRIi64".map", MVM_proc_getpid(NULL));
-            instance->jit_perf_map = fopen(perf_map_filename, "w");
+            instance->jit_perf_map = MVM_platform_fopen(perf_map_filename, "w");
         }
     }
 #endif

--- a/src/moar.c
+++ b/src/moar.c
@@ -1,4 +1,5 @@
 #include "moar.h"
+#include "platform/io.h"
 #include <platform/threads.h>
 #include "platform/random.h"
 #include "platform/time.h"

--- a/src/platform/io.h
+++ b/src/platform/io.h
@@ -2,10 +2,14 @@
 MVMint64 MVM_platform_lseek(int fd, MVMint64 offset, int origin);
 MVMint64 MVM_platform_unlink(const char *pathname);
 int MVM_platform_fsync(int fd);
+int MVM_platform_open(const char *pathname, int flags, ...);
+FILE *MVM_platform_fopen(const char *pathname, const char *mode);
 #else
 #define MVM_platform_lseek lseek
 #define MVM_platform_unlink unlink
 #define MVM_platform_fsync fsync
+#define MVM_platform_open open
+#define MVM_platform_fopen fopen
 #endif
 
 #if defined(__APPLE__) || defined(__Darwin__)

--- a/src/platform/random.c
+++ b/src/platform/random.c
@@ -69,7 +69,7 @@
 #if !defined(_WIN32)
     #include <unistd.h>
     MVMint32 MVM_getrandom_urandom (MVMThreadContext *tc, void *out, size_t size) {
-        int fd = open("/dev/urandom", O_RDONLY);
+        int fd = MVM_platform_open("/dev/urandom", O_RDONLY);
         ssize_t num_read = 0;
         if (fd < 0 || (num_read = read(fd, out, size) <= 0)) {
             if (fd) close(fd);

--- a/src/platform/random.c
+++ b/src/platform/random.c
@@ -60,6 +60,7 @@
  * - NetBSD: I have not found evidence it has getentropy() or getrandom()
  *     Note: Uses __NetBSD_Version__ included from file <sys/param.h>. */
 #include "moar.h"
+#include "platform/io.h"
 /* On Unix like platforms that don't support getrandom() or getentropy()
  * we defualt to /dev/urandom. On platforms that do support these calls, we
  * only use /dev/urandom if those calls fail. This is also important on Linux,

--- a/src/platform/win32/io.c
+++ b/src/platform/win32/io.c
@@ -123,9 +123,7 @@ int MVM_platform_fsync(int fd) {
 
 int MVM_platform_open(const char *pathname, int flags, ...) {
     va_list args;
-    const int       len       = MultiByteToWideChar(CP_UTF8, 0, pathname, -1, NULL, 0);
-    wchar_t * const wpathname = (wchar_t *)MVM_malloc(len * sizeof(wchar_t));
-                                MultiByteToWideChar(CP_UTF8, 0, pathname, -1, (LPWSTR)wpathname, len);
+    wchar_t *wpathname = UTF8ToUnicode(pathname);
     int res;
     if (flags & _O_CREAT) {
         va_start(args, flags);
@@ -140,13 +138,9 @@ int MVM_platform_open(const char *pathname, int flags, ...) {
 }
 
 FILE *MVM_platform_fopen(const char *pathname, const char *mode) {
-    int             len       = MultiByteToWideChar(CP_UTF8, 0, pathname, -1, NULL, 0);
-    wchar_t * const wpathname = (wchar_t *)MVM_malloc(len * sizeof(wchar_t));
-                                MultiByteToWideChar(CP_UTF8, 0, pathname, -1, (LPWSTR)wpathname, len);
-                    len       = MultiByteToWideChar(CP_UTF8, 0, mode, -1, NULL, 0);
-    wchar_t * const wmode     = (wchar_t *)MVM_malloc(len * sizeof(wchar_t));
-                                MultiByteToWideChar(CP_UTF8, 0, mode, -1, (LPWSTR)wmode, len);
-    FILE *          res       = _wfopen(wpathname, wmode);
+    wchar_t *wpathname = UTF8ToUnicode(pathname);
+    wchar_t *wmode     = UTF8ToUnicode(mode);
+    FILE    *res       = _wfopen(wpathname, wmode);
     MVM_free(wpathname);
     MVM_free(wmode);
     return res;

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -55,7 +55,7 @@ void MVM_profile_heap_start(MVMThreadContext *tc, MVMObject *config) {
 
     path = MVM_string_utf8_encode_C_string(tc, path_str);
 
-    col->fh = fopen(path, "w");
+    col->fh = MVM_platform_fopen(path, "w");
 
     if (!col->fh) {
         char *waste[2] = {path, NULL};

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -1,4 +1,5 @@
 #include "moar.h"
+#include "platform/io.h"
 
 #ifndef MVM_HEAPSNAPSHOT_FORMAT
 #define MVM_HEAPSNAPSHOT_FORMAT 3


### PR DESCRIPTION
This change set makes rakudo runnable in folders that contain unicode characters on Windows.
I'd really like another set of eyes on these changes, thus the draft PR.