### PR TITLE
Fix access to freed memory in resolve_using_guards

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -185,6 +185,7 @@ OBJECTS2 = src/6model/reprs/MVMDLLSym@obj@ \
           src/6model/reprs/Decoder@obj@ \
           src/6model/reprs/MVMSpeshLog@obj@ \
           src/6model/reprs/MVMStaticFrameSpesh@obj@ \
+          src/6model/reprs/MVMSpeshPluginState@obj@ \
           src/6model/6model@obj@ \
           src/6model/bootstrap@obj@ \
           src/6model/sc@obj@ \
@@ -354,6 +355,7 @@ HEADERS = src/moar.h \
           src/6model/reprs/Decoder.h \
           src/6model/reprs/MVMSpeshLog.h \
           src/6model/reprs/MVMStaticFrameSpesh.h \
+          src/6model/reprs/MVMSpeshPluginState.h \
           src/6model/sc.h \
           src/spesh/dump.h \
           src/spesh/debug.h \

--- a/src/6model/bootstrap.c
+++ b/src/6model/bootstrap.c
@@ -639,6 +639,7 @@ void MVM_6model_bootstrap(MVMThreadContext *tc) {
     create_stub_boot_type(tc, MVM_REPR_ID_ReentrantMutex, boot_types.BOOTReentrantMutex, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
     create_stub_boot_type(tc, MVM_REPR_ID_MVMSpeshLog, SpeshLog, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
     create_stub_boot_type(tc, MVM_REPR_ID_MVMStaticFrameSpesh, StaticFrameSpesh, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
+    create_stub_boot_type(tc, MVM_REPR_ID_MVMSpeshPluginState, SpeshPluginState, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
 
     /* Bootstrap the KnowHOW type, giving it a meta-object. */
     bootstrap_KnowHOW(tc);
@@ -672,6 +673,9 @@ void MVM_6model_bootstrap(MVMThreadContext *tc) {
     meta_objectifier(tc, boot_types.BOOTQueue, "BOOTQueue");
     meta_objectifier(tc, boot_types.BOOTAsync, "BOOTAsync");
     meta_objectifier(tc, boot_types.BOOTReentrantMutex, "BOOTReentrantMutex");
+    meta_objectifier(tc, SpeshLog, "SpeshLog");
+    meta_objectifier(tc, StaticFrameSpesh, "StaticFrameSpesh");
+    meta_objectifier(tc, SpeshPluginState, "SpeshPluginState");
 
     /* Create the KnowHOWAttribute type. */
     create_KnowHOWAttribute(tc);

--- a/src/6model/reprs.c
+++ b/src/6model/reprs.c
@@ -282,6 +282,7 @@ void MVM_repr_initialize_registry(MVMThreadContext *tc) {
     register_core_repr(Decoder);
     register_core_repr(SpeshLog);
     register_core_repr(StaticFrameSpesh);
+    register_core_repr(SpeshPluginState);
 
     tc->instance->num_reprs = MVM_REPR_CORE_COUNT;
 }

--- a/src/6model/reprs.h
+++ b/src/6model/reprs.h
@@ -44,6 +44,7 @@
 #include "6model/reprs/Decoder.h"
 #include "6model/reprs/MVMSpeshLog.h"
 #include "6model/reprs/MVMStaticFrameSpesh.h"
+#include "6model/reprs/MVMSpeshPluginState.h"
 
 /* REPR related functions. */
 void MVM_repr_initialize_registry(MVMThreadContext *tc);
@@ -98,8 +99,9 @@ const MVMREPROps * MVM_repr_get_by_name(MVMThreadContext *tc, MVMString *name);
 #define MVM_REPR_ID_MVMCPPStruct            42
 #define MVM_REPR_ID_Decoder                 43
 #define MVM_REPR_ID_MVMStaticFrameSpesh     44
+#define MVM_REPR_ID_MVMSpeshPluginState     45
 
-#define MVM_REPR_CORE_COUNT                 45
+#define MVM_REPR_CORE_COUNT                 46
 #define MVM_REPR_MAX_COUNT                  64
 
 /* Default attribute functions for a REPR that lacks them. */

--- a/src/6model/reprs/MVMSpeshPluginState.c
+++ b/src/6model/reprs/MVMSpeshPluginState.c
@@ -1,0 +1,119 @@
+#include "moar.h"
+
+/* This representation's function pointer table. */
+static const MVMREPROps SpeshPluginState_this_repr;
+
+/* Creates a new type object of this representation, and associates it with
+ * the given HOW. */
+static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
+    MVMSTable *st  = MVM_gc_allocate_stable(tc, &SpeshPluginState_this_repr, HOW);
+
+    MVMROOT(tc, st, {
+        MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
+        MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
+        st->size = sizeof(MVMSpeshPluginState);
+    });
+
+    return st->WHAT;
+}
+
+/* Copies the body of one object to another. */
+static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *dest_root, void *dest) {
+    MVM_exception_throw_adhoc(tc, "Cannot copy object with representation SpeshPluginState");
+}
+
+/* Called by the VM to mark any GCable items. */
+static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorklist *worklist) {
+    MVMSpeshPluginStateBody *body = (MVMSpeshPluginStateBody *)data;
+    MVMuint32 i;
+    for (i = 0; i < body->num_positions; i++) {
+        MVMSpeshPluginGuardSet *gs = body->positions[i].guard_set;
+        MVM_spesh_plugin_guard_list_mark(tc, gs->guards, gs->num_guards, worklist);
+    }
+}
+
+/* Called by the VM in order to free memory associated with this object. */
+static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
+    MVMSpeshPluginState *sps = (MVMSpeshPluginState *)obj;
+    MVMuint32 i;
+    for (i = 0; i < sps->body.num_positions; i++) {
+        MVM_fixed_size_free(tc, tc->instance->fsa,
+                sps->body.positions[i].guard_set->num_guards * sizeof(MVMSpeshPluginGuard),
+                sps->body.positions[i].guard_set->guards);
+        MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMSpeshPluginGuardSet),
+                sps->body.positions[i].guard_set);
+    }
+    MVM_fixed_size_free(tc, tc->instance->fsa,
+            sps->body.num_positions * sizeof(MVMSpeshPluginPosition),
+            sps->body.positions);
+}
+
+static const MVMStorageSpec storage_spec = {
+    MVM_STORAGE_SPEC_REFERENCE, /* inlineable */
+    0,                          /* bits */
+    0,                          /* align */
+    MVM_STORAGE_SPEC_BP_NONE,   /* boxed_primitive */
+    0,                          /* can_box */
+    0,                          /* is_unsigned */
+};
+
+/* Gets the storage specification for this representation. */
+static const MVMStorageSpec * get_storage_spec(MVMThreadContext *tc, MVMSTable *st) {
+    return &storage_spec;
+}
+
+/* Compose the representation. */
+static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info) {
+    /* Nothing to do for this REPR. */
+}
+
+/* Set the size of the STable. */
+static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
+    st->size = sizeof(MVMSpeshPluginState);
+}
+
+/* Calculates the non-GC-managed memory we hold on to. */
+static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data) {
+    MVMSpeshPluginStateBody *body = (MVMSpeshPluginStateBody *)data;
+    MVMuint64 size = 0;
+    return size;
+}
+
+/* Initializes the representation. */
+const MVMREPROps * MVMSpeshPluginState_initialize(MVMThreadContext *tc) {
+    return &SpeshPluginState_this_repr;
+}
+
+static void describe_refs(MVMThreadContext *tc, MVMHeapSnapshotState *ss, MVMSTable *st, void *data) {
+    MVMSpeshPluginStateBody *body = (MVMSpeshPluginStateBody *)data;
+}
+
+static const MVMREPROps SpeshPluginState_this_repr = {
+    type_object_for,
+    MVM_gc_allocate_object,
+    NULL,
+    copy_to,
+    MVM_REPR_DEFAULT_ATTR_FUNCS,
+    MVM_REPR_DEFAULT_BOX_FUNCS,
+    MVM_REPR_DEFAULT_POS_FUNCS,
+    MVM_REPR_DEFAULT_ASS_FUNCS,
+    MVM_REPR_DEFAULT_ELEMS,
+    get_storage_spec,
+    NULL, /* change_type */
+    NULL, /* serialize */
+    NULL, /* deserialize */
+    NULL, /* serialize_repr_data */
+    NULL, /* deserialize_repr_data */
+    deserialize_stable_size,
+    gc_mark,
+    gc_free,
+    NULL, /* gc_cleanup */
+    NULL, /* gc_mark_repr_data */
+    NULL, /* gc_free_repr_data */
+    compose,
+    NULL, /* spesh */
+    "MVMSpeshPluginState", /* name */
+    MVM_REPR_ID_MVMSpeshPluginState,
+    unmanaged_size,
+    describe_refs
+};

--- a/src/6model/reprs/MVMSpeshPluginState.h
+++ b/src/6model/reprs/MVMSpeshPluginState.h
@@ -1,0 +1,20 @@
+/* Representation used for holding spesh plugin data. */
+/* Representation used for a data structure that hangs off a static frame's
+ * spesh state, holding the guard tree at each applicable bytecode position.
+ * Updated versions are installed using atomic operations. */
+
+struct MVMSpeshPluginStateBody {
+    /* Array of position states. Held in bytecode index order, which
+     * allows for binary searching. */
+    MVMSpeshPluginPosition *positions;
+
+    /* Number of bytecode positions we have state at. */
+    MVMuint32 num_positions;
+};
+struct MVMSpeshPluginState {
+    MVMObject common;
+    MVMSpeshPluginStateBody body;
+};
+
+/* Function for REPR setup. */
+const MVMREPROps * MVMSpeshPluginState_initialize(MVMThreadContext *tc);

--- a/src/6model/reprs/MVMStaticFrameSpesh.c
+++ b/src/6model/reprs/MVMStaticFrameSpesh.c
@@ -36,7 +36,7 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
                 MVM_gc_worklist_add(tc, worklist, &body->spesh_candidates[i]->inlines[j].sf);
         }
     }
-    MVM_spesh_plugin_state_mark(tc, body->plugin_state, worklist);
+    MVM_gc_worklist_add(tc, worklist, &body->plugin_state);
 }
 
 /* Called by the VM in order to free memory associated with this object. */
@@ -52,7 +52,6 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
         MVM_fixed_size_free(tc, tc->instance->fsa,
             sfs->body.num_spesh_candidates * sizeof(MVMSpeshCandidate *),
             sfs->body.spesh_candidates);
-    MVM_spesh_plugin_state_free(tc, sfs->body.plugin_state);
 }
 
 static const MVMStorageSpec storage_spec = {

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -449,6 +449,8 @@ struct MVMInstance {
     MVMObject *SpeshLog;
     MVMObject *StaticFrameSpesh;
 
+    MVMObject *SpeshPluginState;
+
     /* Set of bootstrapping types. */
     MVMBootTypes boot_types;
 

--- a/src/core/threadcontext.h
+++ b/src/core/threadcontext.h
@@ -265,6 +265,10 @@ struct MVMThreadContext {
     MVMObject *plugin_guard_args;
     MVMuint32 num_plugin_guards;
 
+    MVMSpeshPluginGuard *temp_plugin_guards;
+    MVMObject *temp_plugin_guard_args;
+    MVMuint32 temp_num_plugin_guards;
+
     /************************************************************************
      * Per-thread state held by assorted VM subsystems
      ************************************************************************/

--- a/src/gc/roots.c
+++ b/src/gc/roots.c
@@ -218,8 +218,13 @@ void MVM_gc_root_add_tc_roots_to_worklist(MVMThreadContext *tc, MVMGCWorklist *w
             MVM_spesh_graph_describe(tc, tc->spesh_active_graph, snapshot);
     }
     MVM_spesh_plugin_guard_list_mark(tc, tc->plugin_guards, tc->num_plugin_guards, worklist);
+    if (tc->temp_plugin_guards)
+        MVM_spesh_plugin_guard_list_mark(tc, tc->temp_plugin_guards, tc->temp_num_plugin_guards, worklist);
     add_collectable(tc, worklist, snapshot, tc->plugin_guard_args,
         "Plugin guard args");
+    if (tc->temp_plugin_guard_args)
+        add_collectable(tc, worklist, snapshot, tc->temp_plugin_guard_args,
+            "Temporary plugin guard args");
 
     if (tc->step_mode_frame)
         add_collectable(tc, worklist, snapshot, tc->step_mode_frame,

--- a/src/spesh/plugin.h
+++ b/src/spesh/plugin.h
@@ -1,17 +1,3 @@
-/* Data structure that hangs off a static frame's spesh state, holding the
- * guard tree at each applicable bytecode position. It is allocated using the
- * FSA, and freed using the safepointing mechanism; this allows, providing a
- * single read is done before operating, for safe concurrent use. Updated
- * versions are installed using atomic operations. */
-struct MVMSpeshPluginState {
-    /* Array of position states. Held in bytecode index order, which
-     * allows for binary searching. */
-    MVMSpeshPluginPosition *positions;
-
-    /* Number of bytecode positions we have state at. */
-    MVMuint32 num_positions;
-};
-
 /* Pairing of instruction position with the guard set at that position. */
 struct MVMSpeshPluginPosition {
     MVMSpeshPluginGuardSet *guard_set;
@@ -93,5 +79,3 @@ void MVM_spesh_plugin_rewrite_resolve(MVMThreadContext *tc, MVMSpeshGraph *g, MV
 /* Functions for dealing with spesh plugin state. */
 void MVM_spesh_plugin_guard_list_mark(MVMThreadContext *tc, MVMSpeshPluginGuard *guards,
     MVMuint32 num_guards, MVMGCWorklist *worklist);
-void MVM_spesh_plugin_state_mark(MVMThreadContext *tc, MVMSpeshPluginState *ps, MVMGCWorklist *worklist);
-void MVM_spesh_plugin_state_free(MVMThreadContext *tc, MVMSpeshPluginState *ps);

--- a/src/types.h
+++ b/src/types.h
@@ -207,6 +207,8 @@ typedef struct MVMSpeshPEAAllocation MVMSpeshPEAAllocation;
 typedef struct MVMSpeshPEADeopt MVMSpeshPEADeopt;
 typedef struct MVMSpeshPEAMaterializeInfo MVMSpeshPEAMaterializeInfo;
 typedef struct MVMSpeshPEADeoptPoint MVMSpeshPEADeoptPoint;
+typedef struct MVMSpeshPluginState MVMSpeshPluginState;
+typedef struct MVMSpeshPluginStateBody MVMSpeshPluginStateBody;
 typedef struct MVMConfigurationProgram MVMConfigurationProgram;
 typedef struct MVMSTable MVMSTable;
 typedef struct MVMStaticFrame MVMStaticFrame;


### PR DESCRIPTION
Commit acb04a448bd7b067f1a0943b6fd521e21057c96e fixed outdated pointers in the
guard set, but it was still possible that the guard set was freed while still
in use by resolve_using_guards as the next GC safe point may occur in
evaluate_guards. Fix this by turning SpeshPluginState into a 6model object, so
we can let the GC figure out whether the state is still in use somewhere or not