### PR TITLE
Check if subtracting a successor's exclusive...

### DIFF
--- a/src/profiler/instrument.c
+++ b/src/profiler/instrument.c
@@ -420,7 +420,11 @@ static MVMObject * dump_call_graph_node_loop(ProfTcPdsStruct *tcpds, const MVMPr
             else
                 succ_exclusive_time -= succ_overhead;
 
-            exclusive_time -= succ_exclusive_time;
+            /* Subtract profiling overhead, unless that would underflow, in which case just clamp to 0. */
+            if (exclusive_time - succ_exclusive_time > exclusive_time)
+                exclusive_time = 0;
+            else
+                exclusive_time -= succ_exclusive_time;
         }
         MVM_repr_bind_key_o(tcpds->tc, node_hash, tcpds->pds->exclusive_time,
             box_i(tcpds->tc, exclusive_time / 1000));


### PR DESCRIPTION
time would cause the total exclusive time to underflow. If so, just set
it to 0 instead.

This fixes profiles sometimes having an exclusive time for a routine of e.g., 36893488147419.13ms.