### PR TITLE
Returns "0.0" instead of "0" for a zero double

### DIFF
--- a/src/math/grisu.c
+++ b/src/math/grisu.c
@@ -341,7 +341,7 @@ int dtoa_grisu3(double v, char *dst, int size) {
         }
         // Prehandle zero.
         if (!u64) {
-            *s2++ = '0'; *s2 = '\0';
+            *s2++ = '0'; *s2++ = '.'; *s2++ = '0'; *s2 = '\0';
             return (int)(s2 - dst);
         }
         // Prehandle infinity.


### PR DESCRIPTION
so that a roundtrip thru stringification is a noop.

That is the following prints 1
nqp -e 'my $i := 0.0; say(nqp::eqaddr($i.WHAT, (+~$i).WHAT))'

I was unable to test it because I was not able to build nqp with the modified
moar on catalina.
perl Configure.pl --prefix=/usr --backends=moar --with-moar=/Users/cog/git/MoarVM/moar
make: *** No rule to make target `/Users/cog/git/MoarVM/../share/nqp/lib/MAST/Nodes.nqp', needed by `gen/moar/stage1/MASTNodes.nqp'.  Stop.