### PR TITLE
Add missing gc_mark entry to setup_op_table

### DIFF
--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -621,12 +621,18 @@ static void setup_gc_free(MVMThreadContext *tc, MVMObject *t, void *data) {
     }
 }
 
+/* Marks async connect task. */
+static void setup_gc_mark(MVMThreadContext *tc, void *data, MVMGCWorklist *worklist) {
+    SocketSetupInfo *ssi = (SocketSetupInfo *)data;
+    MVM_gc_worklist_add(tc, worklist, &ssi->async_task);
+}
+
 /* Operations table for async connect task. */
 static const MVMAsyncTaskOps setup_op_table = {
     setup_setup,
     NULL,
     NULL,
-    NULL,
+    setup_gc_mark,
     setup_gc_free
 };
 


### PR DESCRIPTION
Given that a gc might happen during the lifetime of the async
connect task we need to add a gc_mark function to its ops table.
This fixes an intermittent fromspace error which could otherwise
occur.

nine++ for helping out with this