### PR TITLE
Show correct values in encoding errors

### DIFF
--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -240,15 +240,15 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
                     MVM_free(buffer);
                     if (error_pos >= 3) {
                         unsigned char a = utf8[error_pos - 2], b = utf8[error_pos - 1], c = utf8[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x at line %u col %u", a, b, c, line, col);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02hhx %02hhx %02hhx at line %u col %u", a, b, c, line, col);
                     }
                     else if (error_pos == 2) {
                         unsigned char a = utf8[error_pos - 1], b = utf8[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x at line %u col %u", a, b, line, col);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02hhx %02hhx at line %u col %u", a, b, line, col);
                     }
                     else if (error_pos == 1) {
                         unsigned char a = utf8[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x at line %u col %u", a, line, col);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02hhx at line %u col %u", a, line, col);
                     }
                     else {
                         MVM_exception_throw_adhoc(tc, "Malformed UTF-8 at line %u col %u", line, col);
@@ -318,6 +318,24 @@ MVMString * MVM_string_utf8_decode_strip_bom(MVMThreadContext *tc, const MVMObje
         bytes -= 3;
     }
     return MVM_string_utf8_decode(tc, result_type, utf8, bytes);
+}
+
+static void encoding_error(MVMThreadContext *tc, char *bytes, int error_pos) {
+    if (error_pos >= 3) {
+        unsigned char a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
+        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02hhx %02hhx %02hhx", a, b, c);
+    }
+    else if (error_pos == 2) {
+        unsigned char a = bytes[error_pos - 1], b = bytes[error_pos];
+        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02hhx %02hhx", a, b);
+    }
+    else if (error_pos == 1) {
+        unsigned char a = bytes[error_pos];
+        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02hhx", a);
+    }
+    else {
+        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
+    }
 }
 
 /* Decodes using a decodestream. Decodes as far as it can with the input
@@ -401,23 +419,8 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT: {
-                    MVMint32 error_pos = pos - 1;
                     MVM_free(buffer);
-                    if (error_pos >= 3) {
-                        MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
-                    }
-                    else if (error_pos == 2) {
-                        MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
-                    }
-                    else if (error_pos == 1) {
-                        MVMGrapheme32 a = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
-                    }
-                    else {
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
-                    }
+                    encoding_error(tc, bytes, pos - 1);
                     break;
                 }
                 }
@@ -466,23 +469,8 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT: {
-                    MVMint32 error_pos = pos - 1;
                     MVM_free(buffer);
-                    if (error_pos >= 3) {
-                        MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
-                    }
-                    else if (error_pos == 2) {
-                        MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
-                    }
-                    else if (error_pos == 1) {
-                        MVMGrapheme32 a = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
-                    }
-                    else {
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
-                    }
+                    encoding_error(tc, bytes, pos - 1);
                     break;
                 }
                 }
@@ -536,23 +524,8 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT: {
-                    MVMint32 error_pos = pos - 1;
                     MVM_free(buffer);
-                    if (error_pos >= 3) {
-                        MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
-                    }
-                    else if (error_pos == 2) {
-                        MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
-                    }
-                    else if (error_pos == 1) {
-                        MVMGrapheme32 a = bytes[error_pos];
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
-                    }
-                    else {
-                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
-                    }
+                    encoding_error(tc, bytes, pos - 1);
                     break;
                 }
                 }

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -384,17 +384,18 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT: {
-                    char *waste[] = { (char *)buffer, NULL };
-                    if (bufsize >= 3) {
-                        MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
+                    MVMint32 error_pos = pos - 1;
+                    char *waste[] = { (char *)bytes, NULL };
+                    if (error_pos >= 3) {
+                        MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
-                    else if (bufsize == 2) {
-                        MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
+                    else if (error_pos == 2) {
+                        MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
-                    else if (bufsize == 1) {
-                        MVMGrapheme32 a = buffer[pos];
+                    else if (error_pos == 1) {
+                        MVMGrapheme32 a = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
@@ -448,17 +449,18 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT: {
-                    char *waste[] = { (char *)buffer, NULL };
-                    if (bufsize >= 3) {
-                        MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
+                    MVMint32 error_pos = pos - 1;
+                    char *waste[] = { (char *)bytes, NULL };
+                    if (error_pos >= 3) {
+                        MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
-                    else if (bufsize == 2) {
-                        MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
+                    else if (error_pos == 2) {
+                        MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
-                    else if (bufsize == 1) {
-                        MVMGrapheme32 a = buffer[pos];
+                    else if (error_pos == 1) {
+                        MVMGrapheme32 a = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
@@ -517,17 +519,18 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                     break;
                 }
                 case UTF8_REJECT: {
-                    char *waste[] = { (char *)buffer, NULL };
-                    if (bufsize >= 3) {
-                        MVMGrapheme32 a = buffer[pos - 2], b = buffer[pos - 1], c = buffer[pos];
+                    MVMint32 error_pos = pos - 1;
+                    char *waste[] = { (char *)bytes, NULL };
+                    if (error_pos >= 3) {
+                        MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
-                    else if (bufsize == 2) {
-                        MVMGrapheme32 a = buffer[pos - 1], b = buffer[pos];
+                    else if (error_pos == 2) {
+                        MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
-                    else if (bufsize == 1) {
-                        MVMGrapheme32 a = buffer[pos];
+                    else if (error_pos == 1) {
+                        MVMGrapheme32 a = bytes[error_pos];
                         MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -385,21 +385,21 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                 }
                 case UTF8_REJECT: {
                     MVMint32 error_pos = pos - 1;
-                    char *waste[] = { (char *)bytes, NULL };
+                    MVM_free(buffer);
                     if (error_pos >= 3) {
                         MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
                     else if (error_pos == 2) {
                         MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
                     else if (error_pos == 1) {
                         MVMGrapheme32 a = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8");
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
                     }
                     break;
                 }
@@ -450,21 +450,21 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                 }
                 case UTF8_REJECT: {
                     MVMint32 error_pos = pos - 1;
-                    char *waste[] = { (char *)bytes, NULL };
+                    MVM_free(buffer);
                     if (error_pos >= 3) {
                         MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
                     else if (error_pos == 2) {
                         MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
                     else if (error_pos == 1) {
                         MVMGrapheme32 a = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8");
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
                     }
                     break;
                 }
@@ -520,21 +520,21 @@ MVMuint32 MVM_string_utf8_decodestream(MVMThreadContext *tc, MVMDecodeStream *ds
                 }
                 case UTF8_REJECT: {
                     MVMint32 error_pos = pos - 1;
-                    char *waste[] = { (char *)bytes, NULL };
+                    MVM_free(buffer);
                     if (error_pos >= 3) {
                         MVMGrapheme32 a = bytes[error_pos - 2], b = bytes[error_pos - 1], c = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x %02x", a, b, c);
                     }
                     else if (error_pos == 2) {
                         MVMGrapheme32 a = bytes[error_pos - 1], b = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near bytes %02x %02x", a, b);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near bytes %02x %02x", a, b);
                     }
                     else if (error_pos == 1) {
                         MVMGrapheme32 a = bytes[error_pos];
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8 near byte %02x", a);
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8 near byte %02x", a);
                     }
                     else {
-                        MVM_exception_throw_adhoc_free(tc, waste, "Malformed UTF-8");
+                        MVM_exception_throw_adhoc(tc, "Malformed UTF-8");
                     }
                     break;
                 }


### PR DESCRIPTION
Fixes the valgrind errors @dogbert17++ found in t/spec/S17-procasync/encoding.t (https://gist.github.com/dogbert17/e4cb7b4d003f9f7177a70f73a49c7727). Also show chars near the bad bytes in another encoding error path.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.