### PR TITLE
[WIP] Sample code for stringification and printing of internal structures

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -113,6 +113,7 @@ OBJECTS1 = src/core/callsite@obj@ \
           src/core/fixedsizealloc@obj@ \
           src/core/regionalloc@obj@ \
           src/debug/debugserver@obj@ \
+          src/debug/stringify@obj@ \
           src/gen/config@obj@ \
           src/gc/orchestrate@obj@ \
           src/gc/allocation@obj@ \
@@ -283,6 +284,7 @@ HEADERS = src/moar.h \
           src/core/fixedsizealloc.h \
           src/core/regionalloc.h \
           src/debug/debugserver.h \
+          src/debug/stringify.h \
           src/io/io.h \
           src/io/eventloop.h \
           src/io/syncfile.h \
@@ -431,6 +433,7 @@ HEADERS = src/moar.h \
           src/instrument/line_coverage.h \
           src/gen/config.h \
           src/debug/debugserver.h \
+          src/debug/stringify.h \
           src/strings/siphash/csiphash.h \
           src/strings/uthash_types.h \
           src/strings/uthash.h \

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -61,6 +61,10 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
      * MVM_6model_bootstrap because VMNull doesn't exist yet when the very
      * first tc is created. */
 
+#if MVM_DEBUG
+    tc->debug = 0;
+#endif
+
     return tc;
 }
 

--- a/src/core/threadcontext.h
+++ b/src/core/threadcontext.h
@@ -333,6 +333,10 @@ struct MVMThreadContext {
 
     MVMuint32 cur_file_idx;
     MVMuint32 cur_line_no;
+
+#if MVM_DEBUG
+    MVMuint8 debug;
+#endif
 };
 
 MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance);

--- a/src/debug/stringify.c
+++ b/src/debug/stringify.c
@@ -1,0 +1,143 @@
+#include <moar.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+MVMuint8 _DEBUG_GLOBAL = 0;
+
+void MVM_string_printh(MVMThreadContext *tc, MVMOSHandle *handle, MVMString *a) {
+    MVMuint64 encoded_size;
+    char *encoded;
+    MVM_string_check_arg(tc, a, "print");
+    encoded = MVM_string_utf8_encode(tc, a, &encoded_size, MVM_TRANSLATE_NEWLINE_OUTPUT);
+    MVM_io_write_bytes_c(tc, tc->instance->stdout_handle, encoded, encoded_size);
+    MVM_free(encoded);
+}
+
+void MVM_string_note(MVMThreadContext *tc, MVMString *a) {
+    MVM_string_printh(tc, (MVMOSHandle *)tc->instance->stderr_handle,
+        MVM_string_concatenate(tc, a, tc->instance->str_consts.platform_newline)
+    );
+}
+
+void MVM_ascii_note(MVMThreadContext *tc, const char *note) {
+    MVM_string_note(tc, MVM_string_ascii_decode_nt(tc, tc->instance->VMString, note));
+}
+
+/*
+ * Returns MVM_malloc'ated string which must be MVM_free'd.
+ */
+char * MVM_ascii_vsprintf(const char *fmt, va_list args) {
+    MVMuint32 buf_len = strlen(fmt) * 2;
+    char * buf = NULL;
+    do {
+        MVMuint32 printed;
+        buf = MVM_malloc(buf_len);
+        printed = vsnprintf(buf, buf_len, fmt, args);
+        if (printed >= buf_len) {
+            buf_len = printed + 1;
+            MVM_free(buf);
+            buf = NULL;
+        }
+    } while (!buf);
+    return buf;
+}
+
+MVMString * MVM_string_vsprintf(MVMThreadContext *tc, const char *fmt, va_list args) {
+    char *buf = MVM_ascii_vsprintf(fmt, args);
+    MVMString *str = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, buf);
+    MVM_free(buf);
+    return str;
+}
+
+char * MVM_ascii_sprintf(MVMThreadContext *tc, const char *fmt, ...) {
+    va_list args;
+    char *str;
+    va_start(args, fmt);
+    str = MVM_ascii_vsprintf(fmt, args);
+    va_end(args);
+    return str;
+}
+
+MVMString * MVM_string_sprintf(MVMThreadContext *tc, const char *fmt, ...) {
+    va_list args;
+    char *buf;
+    MVMString *str;
+    va_start(args, fmt);
+    buf = MVM_ascii_vsprintf(fmt, args);
+    va_end(args);
+    str = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, buf);
+    MVM_free(buf);
+    return str;
+}
+
+MVMString *make_prefix(MVMThreadContext *tc, const char *prepend, MVMString *prefix) {
+    MVMString *prepend_str = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, prepend ? prepend : "| ");
+    MVMString *empty = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "");
+    return MVM_string_concatenate(tc, prepend_str, prefix ? prefix : empty);
+}
+
+MVMString *max_depth_str(MVMThreadContext *tc, MVMString *prefix) {
+    return MVM_string_concatenate(tc, prefix, MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "..."));
+}
+
+#define MVM_PUSH_TO_LINES(FMT, ...) MVM_repr_push_s(tc, lines, MVM_string_concatenate(tc, prefix, MVM_string_sprintf(FMT, __VA_ARGS__)))
+#define MVM_MAX_DEPTH(block) if (depth >= max_depth) { \
+        MVM_PUSH_TO_LINES("%s", "..."); \
+    } \
+    else block
+#define MVM_APPEND_TO_LINES(STR_LIST) MVMROOT(tc, STR_LIST, { \
+        MVMuint64 elems = MVM_repr_elems(tc, STR_LIST); \
+        MVMuint64 i; \
+        for (i = 0; i < elems; i++) { \
+            MVM_repr_push(tc, lines, MVM_repr_at_pos_s(tc, STR_LIST, i)); \
+        } \
+    });
+
+MVMArray * MVM_stringify_MVMObject(MVMThreadContext *tc, MVMString *prefix, MVMObject *obj, MVMuint32 max_depth, MVMuint32 depth) {
+    MVMArray *lines = (MVMArray *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTStrArray);
+    MVMROOT(tc, lines, {
+        MVM_MAX_DEPTH({
+            MVM_PUSH_TO_LINES("st\t:%p", obj->st);
+            MVMArray *stable_lines = MVM_stringify_MVMStable(tc, make_prefix(tc, NULL, prefix), obj->st, max_depth, depth+1);
+            MVM_APPEND_TO_LINES(stable_lines);
+        });
+    });
+    return lines;
+}
+
+MVMArray * MVM_stringify_MVMStable(MVMThreadContext *tc, MVMString *prefix, MVMSTable *st, MVMuint32 max_depth, MVMuint32 depth) {
+    MVMArray *lines = (MVMArray *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTStrArray);
+    MVMROOT(tc, lines, {
+        MVM_MAX_DEPTH({
+            MVM_PUSH_TO_LINES("%-20s: %p", "REPR_data", st->REPR_data);
+            MVM_PUSH_TO_LINES("%-20s: %lu", "size", st->size);
+            /* ... more fields are expected here ... */
+            MVMArray *method_cache = MVM_stringify_MVMObject(tc, make_prefix(tc, NULL, prefix), st->method_cache, max_depth, depth + 1);
+            MVM_APPEND_TO_LINES()
+        });
+    });
+    return lines;
+}
+
+#if MVM_DEBUG
+void MVM_debug_global(MVMuint8 on) {
+    _DEBUG_GLOBAL = on ? 1 : 0;
+}
+
+void MVM_debug_thread(MVMThreadContext *tc, MVMuint8 on) {
+    tc->debug = on ? 1 : 0;
+}
+
+void MVM_debug_printf(MVMThreadContext *tc, const char *env, const char *fmt, ...) {
+    MVMuint8 env_debug = 0;
+    if (env) {
+        env_debug = getenv(env) ? 1 : 0;
+    }
+    if (_DEBUG_GLOBAL || tc->debug || env_debug) {
+        va_list args;
+        va_start(args, fmt);
+        MVM_string_printh(tc, (MVMOSHandle *)tc->instance->stderr_handle, MVM_string_vsprintf(tc, fmt, args));
+        va_end(args);
+    }
+}
+#endif /* MVM_DEBUG */

--- a/src/debug/stringify.h
+++ b/src/debug/stringify.h
@@ -1,0 +1,22 @@
+
+MVM_PUBLIC void MVM_string_printh(MVMThreadContext *tc, MVMOSHandle *handle, MVMString *a);
+MVM_PUBLIC void MVM_string_note(MVMThreadContext *tc, MVMString *a);
+MVM_PUBLIC void MVM_ascii_note(MVMThreadContext *tc, const char *note);
+MVM_PUBLIC char * MVM_ascii_sprintf(MVMThreadContext *tc, const char *fmt, ...);
+MVM_PUBLIC MVMString * MVM_string_sprintf(MVMThreadContext *tc, const char *fmt, ...);
+
+MVM_PUBLIC MVMArray * MVM_make_string_table(MVMThreadContext *tc, MVMuint32 size);
+MVM_PUBLIC void MVM_dispose_string_table(MVMThreadContext *tc, MVMArray *stable);
+
+MVM_PUBLIC MVMArray * MVM_stringify_MVMObject(MVMThreadContext *tc, MVMString *prefix, MVMObject *o, MVMuint32 max_deph, MVMuint32 depth);
+MVM_PUBLIC MVMArray * MVM_stringify_MVMSTable(MVMThreadContext *tc, MVMString *prefix, MVMSTable *st, MVMuint32 max_depth, MVMuint32 depth);
+
+#if MVM_DEBUG
+MVM_PUBLIC void MVM_debug_global(MVMuint8 on);
+MVM_PUBLIC void MVM_debug_thread(MVMThreadContext *tc, MVMuint8 on);
+MVM_PUBLIC void MVM_debug_printf(MVMThreadContext *tc, const char *env, const char *fmt, ...);
+#else
+#define MVM_debug_global(ON) do {} while(0);
+#define MVM_debug_thread(ON) do {} while(0);
+#define MVM_debug_printf(TC, ENV, FMT, ...) do {} while(0);
+#endif

--- a/src/moar.h
+++ b/src/moar.h
@@ -4,6 +4,8 @@
 #include <setjmp.h>
 #include <stddef.h>
 
+#define MVM_DEBUG 1
+
 /* Configuration. */
 #include "gen/config.h"
 
@@ -125,6 +127,7 @@ MVM_PUBLIC const MVMint32 MVM_jit_support(void);
 #include "core/dll.h"
 #include "core/continuation.h"
 #include "debug/debugserver.h"
+#include "debug/stringify.h"
 #include "6model/reprs.h"
 #include "6model/reprconv.h"
 #include "6model/bootstrap.h"

--- a/src/types.h
+++ b/src/types.h
@@ -219,6 +219,7 @@ typedef struct MVMStaticFrameSpesh MVMStaticFrameSpesh;
 typedef struct MVMStaticFrameSpeshBody MVMStaticFrameSpeshBody;
 typedef struct MVMStorageSpec MVMStorageSpec;
 typedef struct MVMString MVMString;
+typedef struct MVMStringTable MVMStringTable;
 typedef struct MVMStringBody MVMStringBody;
 typedef struct MVMStringConsts MVMStringConsts;
 typedef struct MVMStringStrand MVMStringStrand;


### PR DESCRIPTION
While trying to resolve rakudo/rakudo#2897 I stumbled upon the necessity of tracing context serialization. Unfortunately, it is virtually impossible to distinguish one frame from another while debugging based on their objects in memory. `MVMString` complexity contributes to the problems of finding frame name when it exists and checking what lexicals frame contains.

What I'm trying to implement is support for stringification of objects from inside of MoarVM itself. The code is currently in 'skeleton' state, unstructured and doesn't even compile. It is purely for demoing of what approximately I'm trying to achieve. 

_NOTE_ There is some garbage left from very early experiments. It's too late to clean it up, so I leave it for a while. It includes `dump_ctx_info` function and declarations of two `*_string_table` functions.

# Debugging 

More or less centralized support for debug prints. Debug would be compiled in with `MVM_DEBUG` defined. Debug prints are activated if either of three is true:

- global debug is turned on
- thread-level debug is turned on
- a dedicated environment variable is set.

For the first two it could be useful to provide NQP ops to turn debugging on/off for the purpose of tracing specific areas of NQP code from MoarVM point of view.

# Output

- support for `printf` variants which produce `MVMString`
- support for printing into a file handle
- `MVM_string_note` – similar for `MVM_string_say`

# Stringification

Perhaps it should be part of REPR.