### PR TITLE
Use `make` exit status as own

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -677,7 +677,7 @@ available make targets.
 TERM2
 
 if (!$failed && $args{'make-install'}) {
-    system($config{make}, 'install');
+    $failed = system($config{make}, 'install') >> 8;
 }
 print $folder_to_delete if $folder_to_delete;
 exit $failed;


### PR DESCRIPTION
Propagade `make install` exit code for upstream NQP `Configure.pl`.
Otherwise NQP continues to build as if nothing happened and would
confuse a user with bizzare _'too old moar'_ error message if older moar
is already instaleld.

Resolves rakudo/rakudo#3266