### PR TITLE
Fix run-away CORE context on closures

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2355,6 +2355,10 @@ static void deserialize_context(MVMThreadContext *tc, MVMSerializationReader *re
         /* Attach it. */
         MVM_ASSIGN_REF(tc, &(f->header), f->outer, reader->contexts[outer_idx - 1]);
     }
+    else if (((MVMCode *)static_code)->body.outer == NULL) {
+        MVM_ASSIGN_REF(tc, &(f->header), f->outer, ((MVMCode *)static_code)->body.outer);
+    }
+
 }
 
 /* Deserializes a closure, though without attaching outer (that comes in a

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2355,7 +2355,7 @@ static void deserialize_context(MVMThreadContext *tc, MVMSerializationReader *re
         /* Attach it. */
         MVM_ASSIGN_REF(tc, &(f->header), f->outer, reader->contexts[outer_idx - 1]);
     }
-    else if (((MVMCode *)static_code)->body.outer == NULL) {
+    else if (((MVMCode *)f)->body.outer == NULL) {
         MVM_ASSIGN_REF(tc, &(f->header), f->outer, ((MVMCode *)static_code)->body.outer);
     }
 

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2355,7 +2355,7 @@ static void deserialize_context(MVMThreadContext *tc, MVMSerializationReader *re
         /* Attach it. */
         MVM_ASSIGN_REF(tc, &(f->header), f->outer, reader->contexts[outer_idx - 1]);
     }
-    else if (((MVMCode *)f)->body.outer == NULL) {
+    else if (((MVMCode *)static_code)->body.outer != NULL) {
         MVM_ASSIGN_REF(tc, &(f->header), f->outer, ((MVMCode *)static_code)->body.outer);
     }
 


### PR DESCRIPTION
The problem was caused by the fact that serialization strips off
contexts without static code effectively serializing only those
belonging to the closure's compunit. Upon deserialization only those
serialized contexts are restores and bound to the closure being
deserialized resulting in closures loosing their CORE outers.

To fix the problem I used the fact that new contexts are created as
clones of static code which actually has all its outers stacked up
properly. Therefore, if a context without deserialized outer is
encountered, I check if it's source static code has one and if it does
then use that outer for the new context.

Fixes rakudo/rakudo#2897 and a number of similar issues.