### PR TITLE
Reset utf8 pointer to point at original string before using

### DIFF
--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -237,6 +237,7 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
                     break;
                 case UTF8_REJECT: {
                     size_t error_pos = orig_bytes - bytes;
+                    utf8 = orig_utf8;
                     MVM_free(buffer);
                     if (error_pos >= 3) {
                         unsigned char a = utf8[error_pos - 2], b = utf8[error_pos - 1], c = utf8[error_pos];


### PR DESCRIPTION
When an invalid utf8 sequence is found the original string
is parsed again in order to figure out where in the string
the problem occurs so that it will be possible to print
out the bytes surrounding the error in the exception msg.
The problem is that when trying to print out the bytes
around the parse error the 'utf8' pointer is used. This
pointer no longer points to the start of the erroneous
string since it has just been used in a loop where each
iteration increments it. Fixed by restoring it so that it
points to the start of the string once again.
This fixes #1208