### PR TITLE
Use more appropriate flags with getaddrinfo

### DIFF
--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -327,7 +327,7 @@ struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc, MVMString *host
     }
 
     hints.ai_socktype = 0;
-    hints.ai_flags = AI_PASSIVE;
+    hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICSERV | AI_PASSIVE;
     hints.ai_protocol = 0;
     hints.ai_addrlen = 0;
     hints.ai_addr = NULL;


### PR DESCRIPTION
This makes it so getaddrinfo doesn't try to use the port passed to
MVM_io_resolve_host_name like a service name, and only returns IPv4
or IPv6 addresses if any exist on the interface used.