### PR TITLE
Jit ordbaseat

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1854,6 +1854,7 @@ start:
     case MVM_OP_getstdout:
     case MVM_OP_getstdin:
     case MVM_OP_ordat:
+    case MVM_OP_ordbaseat:
     case MVM_OP_ordfirst:
     case MVM_OP_getcodename:
     case MVM_OP_setcodeobj:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2240,18 +2240,23 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         break;
     }
     case MVM_OP_ordat:
+    case MVM_OP_ordbaseat:
     case MVM_OP_ordfirst: {
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 str = ins->operands[1].reg.orig;
         | mov ARG1, TC;
         | mov ARG2, aword WORK[str];
-        if (op == MVM_OP_ordat) {
+        if (op == MVM_OP_ordat || op == MVM_OP_ordbaseat) {
             MVMint16 idx = ins->operands[2].reg.orig;
             | mov ARG3, qword WORK[idx];
         } else {
             | mov ARG3, 0;
         }
-        | callp &MVM_string_ord_at;
+        if (op == MVM_OP_ordbaseat) {
+            | callp &MVM_string_ord_basechar_at;
+        } else {
+            | callp &MVM_string_ord_at;
+        }
         | mov qword WORK[dst], RV;
         break;
     }


### PR DESCRIPTION
There was already a template, but no lego jit implementation.

NQP builds ok and passes `make m-test` and Rakudo build ok and passes `make m-test m-spectest`.