### PR TITLE
Switch our libtommath to upstream's 1.2.0 tag

### DIFF
--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -12,7 +12,7 @@ static MVMint64 mp_get_int64(MVMThreadContext *tc, mp_int * a) {
 
     /* For 64-bit 2's complement numbers the positive max is 2**63-1, which is 63 bits,
      * but the negative max is -(2**63), which is 64 bits. */
-    if (MP_NEG == SIGN(a)) {
+    if (MP_NEG == a->sign) {
         if (bits > 64) {
             MVM_exception_throw_adhoc(tc, "Cannot unbox %d bit wide bigint into native integer", bits);
         }
@@ -31,7 +31,7 @@ static MVMint64 mp_get_int64(MVMThreadContext *tc, mp_int * a) {
         MVM_exception_throw_adhoc(tc, "Cannot unbox %d bit wide bigint into native integer", bits);
     }
 
-    return MP_NEG == SIGN(a) ? -res : res;
+    return MP_NEG == a->sign ? -res : res;
 }
 
 MVMint64 MVM_p6bigint_get_int64(MVMThreadContext *tc, MVMP6bigintBody *body) {
@@ -137,7 +137,7 @@ static MVMuint64 get_uint(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, 
     MVMP6bigintBody *body = (MVMP6bigintBody *)data;
     if (MVM_BIGINT_IS_BIG(body)) {
         mp_int *i = body->u.bigint;
-        if (MP_NEG == SIGN(i))
+        if (MP_NEG == i->sign)
             MVM_exception_throw_adhoc(tc, "Cannot unbox negative bigint into native unsigned integer");
         else
             return mp_get_uint64(tc, i);

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -202,7 +202,7 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
         MVMString *str;
         mp_radix_size(i, 10, &len);
         buf = (char *)MVM_malloc(len);
-        mp_toradix(i, buf, 10);
+        mp_to_decimal(i, buf, sizeof(buf));
 
         /* len - 1 because buf is \0-terminated */
         str = MVM_string_ascii_decode(tc, tc->instance->VMString, buf, len - 1);

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -24,7 +24,7 @@ static MVMint64 mp_get_int64(MVMThreadContext *tc, mp_int * a) {
         }
     }
 
-    res = mp_get_long_long(a);
+    res = mp_get_ull(a);
 
     if (res > signed_max) {
         /* The mp_int was bigger than a signed result could be. */
@@ -46,7 +46,7 @@ static MVMuint64 mp_get_uint64(MVMThreadContext *tc, mp_int * a) {
         MVM_exception_throw_adhoc(tc, "Cannot unbox %d bit wide bigint into native integer", bits);
     }
 
-    return mp_get_long_long(a);
+    return mp_get_ull(a);
 }
 
 /* This representation's function pointer table. */

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -216,7 +216,7 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
             MVM_exception_throw_adhoc(tc, "Error calculating the size of a big integer: %s", mp_error_to_string(err));
         }
         buf = (char *)MVM_malloc(len);
-        if ((err = mp_to_decimal(i, buf, sizeof(buf))) != MP_OKAY) {
+        if ((err = mp_to_decimal(i, buf, len)) != MP_OKAY) {
             MVM_exception_throw_adhoc(tc, "Error converting a big integer to a string: %s", mp_error_to_string(err));
         }
 

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -18,13 +18,13 @@ static MVMint64 mp_get_int64(MVMThreadContext *tc, mp_int * a) {
         }
         ++signed_max;
     }
-	else {
+    else {
         if (bits > 63) {
             MVM_exception_throw_adhoc(tc, "Cannot unbox %d bit wide bigint into native integer", bits);
         }
     }
 
-    res = mp_get_ull(a);
+    res = mp_get_mag_ull(a);
 
     if (res > signed_max) {
         /* The mp_int was bigger than a signed result could be. */
@@ -46,7 +46,7 @@ static MVMuint64 mp_get_uint64(MVMThreadContext *tc, mp_int * a) {
         MVM_exception_throw_adhoc(tc, "Cannot unbox %d bit wide bigint into native integer", bits);
     }
 
-    return mp_get_ull(a);
+    return mp_get_mag_ull(a);
 }
 
 /* This representation's function pointer table. */

--- a/src/6model/reprs/P6bigint.h
+++ b/src/6model/reprs/P6bigint.h
@@ -35,4 +35,4 @@ struct MVMP6bigint {
 const MVMREPROps * MVMP6bigint_initialize(MVMThreadContext *tc);
 
 MVMint64 MVM_p6bigint_get_int64(MVMThreadContext *tc, MVMP6bigintBody *body);
-void MVM_p6bigint_store_as_mp_int(MVMP6bigintBody *body, MVMint64 value);
+void MVM_p6bigint_store_as_mp_int(MVMThreadContext *tc, MVMP6bigintBody *body, MVMint64 value);

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -6236,7 +6236,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     body->u.smallint.flag = MVM_BIGINT_32_FLAG;
                 }
                 else {
-                    MVM_p6bigint_store_as_mp_int(body, value);
+                    MVM_p6bigint_store_as_mp_int(tc, body, value);
                 }
                 GET_REG(cur_op, 0).o = obj;
                 cur_op += 10;
@@ -6270,7 +6270,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                         body->u.smallint.flag = MVM_BIGINT_32_FLAG;
                     }
                     else {
-                        MVM_p6bigint_store_as_mp_int(body, value);
+                        MVM_p6bigint_store_as_mp_int(tc, body, value);
                     }
                     GET_REG(cur_op, 0).o = obj;
                 }

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -43,7 +43,10 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
     /* Allocate temporary big integers. */
     for (i = 0; i < MVM_NUM_TEMP_BIGINTS; i++) {
         tc->temp_bigints[i] = MVM_malloc(sizeof(mp_int));
-        mp_init(tc->temp_bigints[i]);
+        mp_err err;
+        if ((err = mp_init(tc->temp_bigints[i])) != MP_OKAY) {
+            MVM_exception_throw_adhoc(tc, "Error creating a temporary big integer: %s", mp_error_to_string(err));
+        }
     }
 
     /* Initialize frame sequence numbers */

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2448,9 +2448,10 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
             | mov dword [RV+val_offset], TMP3d
             | jmp >4
             |3:
-            | mov ARG1, RV
-            | add ARG1, offset
-            | mov ARG2, TMP3
+            | mov ARG1, TC
+            | mov ARG2, RV
+            | add ARG2, offset
+            | mov ARG3, TMP3
             | callp &MVM_p6bigint_store_as_mp_int;
             |4:
         }

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -1162,15 +1162,11 @@ MVMObject * MVM_bigint_rand(MVMThreadContext *tc, MVMObject *type, MVMObject *b)
     if (use_small_arithmetic) {
         if (MP_GEN_RANDOM_MAX >= abs(smallint_max)) {
             mp_digit result_int;
-#ifdef MP_NEW_LTM_VERSION
-            mp_digit p = MP_GEN_RANDOM_MAX;
-            mp_rand_digit(&p);
-            result_int = p;
-#else
-            result_int = MP_GEN_RANDOM();
-#endif
+            if (MVM_getrandom(tc, &result_int, sizeof(mp_digit)) == 0) {
+                MVM_exception_throw_adhoc(tc, "Error getting a random int to put into a big integer");
+            }
             result_int = result_int % smallint_max;
-            if(have_to_negate)
+            if (have_to_negate)
                 result_int *= -1;
 
             MVMROOT2(tc, type, b, {

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -707,7 +707,7 @@ MVMObject *MVM_bigint_div(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
             if ((err = mp_init_multi(&remainder, &intermediate, NULL)) != MP_OKAY) {
                 MVM_exception_throw_adhoc(tc, "Error creating big integers: %s", mp_error_to_string(err));
             }
-            if ((err = mp_div(ia, ib, &remainder, &intermediate)) != MP_OKAY) {
+            if ((err = mp_div(ia, ib, &intermediate, &remainder)) != MP_OKAY) {
                 mp_clear_multi(&remainder, &intermediate, NULL);
                 MVM_exception_throw_adhoc(tc, "Error dividing big integers: %s", mp_error_to_string(err));
             }

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -696,7 +696,7 @@ MVMObject * MVM_bigint_pow(MVMThreadContext *tc, MVMObject *a, MVMObject *b,
             MVMP6bigintBody *resbody;
             mp_init(ic);
             MVM_gc_mark_thread_blocked(tc);
-            mp_expt_d(base, exponent_d, ic);
+            mp_expt_u32(base, exponent_d, ic);
             MVM_gc_mark_thread_unblocked(tc);
             r = MVM_repr_alloc_init(tc, int_type);
             resbody = get_bigint_body(tc, r);

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -346,7 +346,7 @@ MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MV
                 MVM_exception_throw_adhoc(tc, "Error initializing a big integer: %s", mp_error_to_string(err)); \
             } \
             if ((err = mp_##opname(ia, ib)) != MP_OKAY) { \
-                MVM_exception_throw_adhoc(tc, "Error performing ##opname with a big integer: %s", mp_error_to_string(err)); \
+                MVM_exception_throw_adhoc(tc, "Error performing %s with a big integer: %s", #opname, mp_error_to_string(err)); \
             } \
             store_bigint_result(bb, ib); \
             adjust_nursery(tc, bb); \
@@ -380,7 +380,7 @@ MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MV
         MVM_exception_throw_adhoc(tc, "Error initializing a big integer: %s", mp_error_to_string(err)); \
     } \
     if ((err = mp_##opname(ia, ib, ic)) != MP_OKAY) { \
-        MVM_exception_throw_adhoc(tc, "Error performing ##opname with big integers: %s", mp_error_to_string(err)); \
+        MVM_exception_throw_adhoc(tc, "Error performing %s with big integers: %s", #opname, mp_error_to_string(err)); \
     } \
     store_bigint_result(bc, ic); \
     adjust_nursery(tc, bc); \
@@ -399,7 +399,7 @@ void MVM_bigint_fallback_##opname(MVMThreadContext *tc, MVMP6bigintBody *ba, MVM
         MVM_exception_throw_adhoc(tc, "Error initializing a big integer: %s", mp_error_to_string(err)); \
     } \
     if ((err = mp_##opname(ia, ib, ic)) != MP_OKAY) { \
-        MVM_exception_throw_adhoc(tc, "Error performing ##opname with big integers: %s", mp_error_to_string(err)); \
+        MVM_exception_throw_adhoc(tc, "Error performing %s with big integers: %s", #opname, mp_error_to_string(err)); \
     } \
     store_bigint_result(bc, ic); \
     adjust_nursery(tc, bc); \
@@ -425,7 +425,7 @@ MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MV
             MVM_exception_throw_adhoc(tc, "Error initializing a big integer: %s", mp_error_to_string(err)); \
         } \
         if ((err = mp_##opname(ia, ib, ic)) != MP_OKAY) { \
-            MVM_exception_throw_adhoc(tc, "Error performing ##opname with big integers: %s", mp_error_to_string(err)); \
+            MVM_exception_throw_adhoc(tc, "Error performing %s with big integers: %s", #opname, mp_error_to_string(err)); \
         } \
         store_bigint_result(bc, ic); \
         adjust_nursery(tc, bc); \

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -769,7 +769,7 @@ MVMObject * MVM_bigint_pow(MVMThreadContext *tc, MVMObject *a, MVMObject *b,
             if (mp_iszero(base)) {
                 r = MVM_repr_box_int(tc, int_type, 0);
             }
-            else if (mp_get_i32(base) == 1) {
+            else if (mp_get_i32(base) == 1 || mp_get_i32(base) == -1) {
                 r = MVM_repr_box_int(tc, int_type, MP_ZPOS == base->sign || mp_iseven(exponent) ? 1 : -1);
             }
             else {

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -1301,7 +1301,7 @@ MVMObject * MVM_bigint_rand(MVMThreadContext *tc, MVMObject *type, MVMObject *b)
     }
 
     if (use_small_arithmetic) {
-        if (MP_GEN_RANDOM_MAX >= abs(smallint_max)) {
+        if (MP_GEN_RANDOM_MAX >= (unsigned long)abs(smallint_max)) {
             mp_digit result_int;
             if (MVM_getrandom(tc, &result_int, sizeof(mp_digit)) == 0) {
                 MVM_exception_throw_adhoc(tc, "Error getting a random int to put into a big integer");

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -185,10 +185,10 @@ static mp_int * force_bigint(MVMThreadContext *tc, const MVMP6bigintBody *body, 
             MVMint32 value = body->u.smallint.value;
             mp_int *i = tc->temp_bigints[idx];
             if (value >= 0) {
-                mp_set_int(i, value);
+                mp_set_i32(i, value);
             }
             else {
-                mp_set_int(i, -value);
+                mp_set_i32(i, -value);
                 mp_neg(i, i);
             }
             return i;
@@ -672,12 +672,12 @@ MVMObject * MVM_bigint_pow(MVMThreadContext *tc, MVMObject *a, MVMObject *b,
         r = MVM_repr_box_int(tc, int_type, 1);
     }
     else if (SIGN(exponent) == MP_ZPOS) {
-        exponent_d = mp_get_int(exponent);
+        exponent_d = mp_get_u32(exponent);
         if ((MP_GT == mp_cmp_d(exponent, exponent_d))) {
             if (mp_iszero(base)) {
                 r = MVM_repr_box_int(tc, int_type, 0);
             }
-            else if (mp_get_int(base) == 1) {
+            else if (mp_get_i32(base) == 1) {
                 r = MVM_repr_box_int(tc, int_type, MP_ZPOS == SIGN(base) || mp_iseven(exponent) ? 1 : -1);
             }
             else {
@@ -1041,10 +1041,10 @@ MVMString * MVM_bigint_to_str(MVMThreadContext *tc, MVMObject *a, int base) {
             MVMint64 value = body->u.smallint.value;
             mp_init(&i);
             if (value >= 0) {
-                mp_set_long(&i, value);
+                mp_set_ul(&i, value);
             }
             else {
-                mp_set_long(&i, -value);
+                mp_set_ul(&i, -value);
                 mp_neg(&i, &i);
             }
 
@@ -1266,7 +1266,7 @@ MVMObject * MVM_bigint_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *st
 
     mp_init(&zvalue);
     mp_init(&zbase);
-    mp_set_int(&zbase, 1);
+    mp_set_ul(&zbase, 1);
 
     value_obj = MVM_repr_alloc_init(tc, type);
     MVM_repr_push_o(tc, result, value_obj);
@@ -1284,7 +1284,7 @@ MVMObject * MVM_bigint_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *st
     mp_init(value);
     mp_init(base);
 
-    mp_set_int(base, 1);
+    mp_set_ul(base, 1);
 
     ch = (offset < chars) ? MVM_string_get_grapheme_at_nocheck(tc, str, offset) : 0;
     if ((flag & 0x02) && (ch == '+' || ch == '-' || ch == 0x2212)) {  /* MINUS SIGN */


### PR DESCRIPTION
Their new release incorporates or removes the need for all the commits
we added to our fork, so the intent of this commit is to switch to
using just their release tag.

Assuming I did everything correctly, NQP built ok and passed `make m-test` and Rakudo built ok and passes `make m-test m-spectest`.