### PR TITLE
[IP6NS Grant] Resolve hostnames given a socket type, protocol, and passivity

### DIFF
--- a/src/io/asyncsocket.c
+++ b/src/io/asyncsocket.c
@@ -654,7 +654,7 @@ MVMObject * MVM_io_socket_connect_async(MVMThreadContext *tc, MVMObject *queue,
 
     /* Resolve hostname. (Could be done asynchronously too.) */
     MVMROOT3(tc, queue, schedulee, async_type, {
-        dest = MVM_io_resolve_host_name(tc, host, port, SOCKET_FAMILY_UNSPEC);
+        dest = MVM_io_resolve_host_name(tc, host, port, MVM_SOCKET_FAMILY_UNSPEC, MVM_SOCKET_TYPE_STREAM, MVM_SOCKET_PROTOCOL_ANY, 0);
     });
 
     /* Create async task handle. */
@@ -877,7 +877,7 @@ MVMObject * MVM_io_socket_listen_async(MVMThreadContext *tc, MVMObject *queue,
 
     /* Resolve hostname. (Could be done asynchronously too.) */
     MVMROOT3(tc, queue, schedulee, async_type, {
-        dest = MVM_io_resolve_host_name(tc, host, port, SOCKET_FAMILY_UNSPEC);
+        dest = MVM_io_resolve_host_name(tc, host, port, MVM_SOCKET_FAMILY_UNSPEC, MVM_SOCKET_TYPE_STREAM, MVM_SOCKET_PROTOCOL_ANY, 1);
     });
 
     /* Create async task handle. */

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -388,7 +388,7 @@ static MVMAsyncTask * write_bytes_to(MVMThreadContext *tc, MVMOSHandle *h, MVMOb
     /* Resolve destination and create async task handle. */
     MVMROOT4(tc, queue, schedulee, h, buffer, {
         MVMROOT(tc, async_type, {
-            dest_addr = MVM_io_resolve_host_name(tc, host, port, SOCKET_FAMILY_UNSPEC);
+            dest_addr = MVM_io_resolve_host_name(tc, host, port, MVM_SOCKET_FAMILY_UNSPEC, MVM_SOCKET_TYPE_DGRAM, MVM_SOCKET_PROTOCOL_ANY, 0);
         });
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc, async_type);
     });
@@ -580,7 +580,7 @@ MVMObject * MVM_io_socket_udp_async(MVMThreadContext *tc, MVMObject *queue,
     /* Resolve hostname. (Could be done asynchronously too.) */
     if (host && IS_CONCRETE(host)) {
         MVMROOT3(tc, queue, schedulee, async_type, {
-            bind_addr = MVM_io_resolve_host_name(tc, host, port, SOCKET_FAMILY_UNSPEC);
+            bind_addr = MVM_io_resolve_host_name(tc, host, port, MVM_SOCKET_FAMILY_UNSPEC, MVM_SOCKET_TYPE_DGRAM, MVM_SOCKET_PROTOCOL_ANY, 1);
         });
     }
 

--- a/src/io/syncsocket.h
+++ b/src/io/syncsocket.h
@@ -1,10 +1,26 @@
-typedef enum {
-    SOCKET_FAMILY_UNSPEC,
-    SOCKET_FAMILY_INET,
-    SOCKET_FAMILY_INET6,
-    SOCKET_FAMILY_UNIX
-} MVMSocketFamily;
+#define MVM_SOCKET_FAMILY_UNSPEC 0
+#define MVM_SOCKET_FAMILY_INET   1
+#define MVM_SOCKET_FAMILY_INET6  2
+#define MVM_SOCKET_FAMILY_UNIX   3
+
+#define MVM_SOCKET_TYPE_ANY       0
+#define MVM_SOCKET_TYPE_STREAM    1
+#define MVM_SOCKET_TYPE_DGRAM     2
+#define MVM_SOCKET_TYPE_RAW       3
+#define MVM_SOCKET_TYPE_RDM       4
+#define MVM_SOCKET_TYPE_SEQPACKET 5
+
+#define MVM_SOCKET_PROTOCOL_ANY 0
+#define MVM_SOCKET_PROTOCOL_TCP 1
+#define MVM_SOCKET_PROTOCOL_UDP 2
 
 MVMObject * MVM_io_socket_create(MVMThreadContext *tc, MVMint64 listen);
-struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc, MVMString *host, MVMint64 port, MVMuint16 family);
+/* TODO: MVMuint16 can be too small for the machine's value for the
+ *       given family, which this function doesn't use anymore in the
+ *       first place and can be any Int from Raku land; it should be an
+ *       MVMint64 instead. */
+struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc,
+        MVMString *host, MVMint64 port,
+        MVMuint16 family, MVMint64 type, MVMint64 protocol,
+        MVMint32 passive);
 MVMString * MVM_io_get_hostname(MVMThreadContext *tc);


### PR DESCRIPTION
This was part of the changes to hostname resolution that were reverted,
and will be necessary for upcoming support for UDP/UNIX/raw sockets.

Passes `make test` and `make spectest`.