### PR TITLE
Detect files that cannot be synched also on MacOS

### DIFF
--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -226,8 +226,8 @@ static void flush(MVMThreadContext *tc, MVMOSHandle *h, MVMint32 sync){
     flush_output_buffer(tc, data);
     if (sync) {
         if (MVM_platform_fsync(data->fd) == -1) {
-            /* If this is something that can't be flushed, we let that pass. */
-            if (errno != EROFS && errno != EINVAL
+            /* If this is something that can't be synched, we let that pass. */
+            if (errno != EROFS && errno != EINVAL && errno != ENOTSUP
 #ifdef WSL_BASH_ON_WIN
                && ! (errno == EIO && ! data->seekable)
                /* Bash on Win10 doesn't seem to handle TTYs right when flushing:


### PR DESCRIPTION
MacOS reports ENOTSUP as error code when trying to fsync a pipe.
After this commit, MoarVM detects this condition and ignores the error.

Fixes https://github.com/MoarVM/MoarVM/issues/1225
