### PR TITLE
Make nqp::rand_I respect nqp::srand again

### DIFF
--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -1081,12 +1081,7 @@ MVMnum64 MVM_proc_randscale_n(MVMThreadContext *tc, MVMnum64 scale) {
 
 /* seed random number generator */
 void MVM_proc_seed(MVMThreadContext *tc, MVMint64 seed) {
-    /* Seed our one, plus the normal C srand for libtommath. */
     tinymt64_init(tc->rand_state, (MVMuint64)seed);
-/* do not call srand if we are not using rand */
-#ifndef MP_USE_ALT_RAND
-    srand((MVMuint32)seed);
-#endif
 }
 
 /* gets the system time since the epoch truncated to integral seconds */


### PR DESCRIPTION
The upgrade to libtommath v1.2.0 brought along a new version of mp_rand
that uses sources of randomness that aren't seeded with srand. So copy
their mp_rand, but modify to use tinymt64 as the source of randomness.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`. Fixes https://github.com/rakudo/rakudo/issues/3469, should also fix https://github.com/rakudo/rakudo/issues/3470.