### PR TITLE
Revert "Dynamic library loading works with unicody paths on Windows"

### DIFF
--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -805,20 +805,3 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
     MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke");
     return result;
 }
-
-#ifdef _WIN32
-DLLib* MVM_nativecall_load_lib(const char* path) {
-    HMODULE module;
-    if (path != NULL) {
-        const int       len   = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
-        wchar_t * const wpath = (wchar_t *)MVM_malloc(len * sizeof(wchar_t));
-                                MultiByteToWideChar(CP_UTF8, 0, path, -1, (LPWSTR)wpath, len);
-        module = LoadLibraryW(wpath);
-        MVM_free(wpath);
-    }
-    else {
-        module = GetModuleHandle(NULL);
-    }
-    return (DLLib*)(module);
-}
-#endif

--- a/src/core/nativecall_dyncall.h
+++ b/src/core/nativecall_dyncall.h
@@ -1,9 +1,4 @@
 MVMint16 MVM_nativecall_get_calling_convention(MVMThreadContext *tc, MVMString *name);
-#ifdef _WIN32
-// Temporary hack until dyncall supports Unicode.
-DLLib* MVM_nativecall_load_lib(const char* path);
-#else
 #define MVM_nativecall_load_lib(path)       dlLoadLibrary(path)
-#endif
 #define MVM_nativecall_free_lib(lib)        dlFreeLibrary(lib)
 #define MVM_nativecall_find_sym(lib, name)  dlFindSymbol(lib, name)


### PR DESCRIPTION
This reverts commit efeec455e025f273eede110e099a8f8b21b5e108.
It's not needed anymore, because the fix has been pushed upstream and been
released with Dyncall 1.1 which we just bumped to.