### PR TITLE
Doing an mp_clear after a failed mp_init is UB

### DIFF
--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -45,6 +45,7 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
         tc->temp_bigints[i] = MVM_malloc(sizeof(mp_int));
         mp_err err;
         if ((err = mp_init(tc->temp_bigints[i])) != MP_OKAY) {
+            MVM_free(tc->temp_bigints[i]);
             MVM_exception_throw_adhoc(tc, "Error creating a temporary big integer: %s", mp_error_to_string(err));
         }
     }


### PR DESCRIPTION
I checked with jaeckel on #libtom and we shouldn't `mp_clear()` a variable if its `mp_init*()` failed.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.