### PR TITLE
JIT nextdispatcherfor

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1813,7 +1813,9 @@ start:
     case MVM_OP_getwhere:
     case MVM_OP_sp_getspeshslot:
     case MVM_OP_takedispatcher:
+    case MVM_OP_takenextdispatcher:
     case MVM_OP_setdispatcher:
+    case MVM_OP_nextdispatcherfor:
     case MVM_OP_ctx:
     case MVM_OP_ctxlexpad:
     case MVM_OP_ctxcallerskipthunks:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -980,6 +980,27 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         |3:
         break;
     }
+    case MVM_OP_nextdispatcherfor: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 src = ins->operands[1].reg.orig;
+        | mov TMP1, aword WORK[src];
+        | mov TMP2, aword WORK[dst];
+        | mov aword TC->next_dispatcher, TMP2;
+        | cmp_repr_id TMP1, TMP3, MVM_REPR_ID_MVMCode;
+        | je >2;
+        |1:
+        | mov ARG1, TC;
+        | mov ARG2, TMP1;
+        | xor ARG3, ARG3;
+        | callp &MVM_frame_find_invokee;
+        | mov aword TC->next_dispatcher_for, RV;
+        | jmp >3;
+        |2:
+        | mov aword TC->next_dispatcher_for, TMP1;
+        | jmp >3;
+        |3:
+        break;
+    }
     case MVM_OP_ctx: {
         MVMint16 dst = ins->operands[0].reg.orig;
         | mov ARG1, TC;


### PR DESCRIPTION
This was just cobbled together based on looking at its interpreter
implementation and the assembly for other ops.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

The numbers are too variable to tell if there's much of an improvement in the test-t benchmark, but it does get rid of two 'JIT: bailed completely because of <nextdispatcherfor>' in a spesh log of running it.