### PR TITLE
Free compunits loaded from bytecode upon dealloc

### DIFF
--- a/src/core/loadbytecode.c
+++ b/src/core/loadbytecode.c
@@ -71,6 +71,7 @@ void MVM_load_bytecode_buffer_to_cu(MVMThreadContext *tc, MVMObject *buf, MVMReg
     memcpy(data_start, (MVMuint8 *)(((MVMArray *)buf)->body.slots.i8 + ((MVMArray *)buf)->body.start), data_size);
 
     cu = MVM_cu_from_bytes(tc, data_start, data_size);
+    cu->body.deallocate = MVM_DEALLOCATE_FREE;
     res->o = (MVMObject *)cu;
 
     if (cu->body.deserialize_frame) {


### PR DESCRIPTION
Before this, `MVM_SPESH_DISABLE=1 valgrind --leak-check=full raku
--full-cleanup -e ''` would report 'definitely lost: 1,560 bytes in 2 blocks', after it reports 'definitely lost: 32 bytes in 1 blocks'.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.