### PR TITLE
Free some memory calloc'ed when making spesh plans

### DIFF
--- a/src/spesh/plan.c
+++ b/src/spesh/plan.c
@@ -220,6 +220,9 @@ static void plan_for_cs(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMStaticFrame
                 break;
             }
         }
+
+        /* Clean up allocated memory. */
+        MVM_free(tuples_used);
     }
 
     /* If we get here, and found no specializations to produce, we can add


### PR DESCRIPTION
Before this, `MVM_JIT_DISABLE=1 MVM_SPESH_BLOCKING=1 MVM_SPESH_NOELAY=1 valgrind --leak-check=full raku --full-cleanup -e ''` would report `definitely lost: 1,665 bytes in 50 blocks`, after it reports `definitely lost: 1,320 bytes in 30 blocks`.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.