### PR TITLE
Destroy vectors that were previously init'ed

### DIFF
--- a/src/spesh/arg_guard.c
+++ b/src/spesh/arg_guard.c
@@ -285,6 +285,8 @@ static MVMuint32 add_nodes_for_typed_argument(MVMThreadContext *tc,
         }
         
         /* Clean up. */
+        for (i = 0; i < MVM_VECTOR_ELEMS(by_type); i++)
+            MVM_VECTOR_DESTROY(by_type[i].cand_idxs);
         MVM_VECTOR_DESTROY(by_type);
     }
 


### PR DESCRIPTION
Before this, `MVM_JIT_DISABLE=1 MVM_SPESH_BLOCKING=1 MVM_SPESH_NOELAY=1 valgrind --leak-check=full raku --full-cleanup -e ''` would report `definitely lost: 1,320 bytes in 30 blocks`, after it reports `definitely lost: 904 bytes in 2 blocks`.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.