### PR TITLE
Fix interned callsites getting leaked when fixing up inlines

### DIFF
--- a/src/core/compunit.c
+++ b/src/core/compunit.c
@@ -116,7 +116,7 @@ MVMuint16 MVM_cu_callsite_add(MVMThreadContext *tc, MVMCompUnit *cu, MVMCallsite
         MVMCallsite **new_callsites = MVM_fixed_size_alloc(tc, tc->instance->fsa, new_size);
         memcpy(new_callsites, cu->body.callsites, orig_size);
         idx = cu->body.num_callsites;
-        new_callsites[idx] = MVM_callsite_copy(tc, cs);
+        new_callsites[idx] = cs->is_interned ? cs : MVM_callsite_copy(tc, cs);
         if (cu->body.callsites)
             MVM_fixed_size_free_at_safepoint(tc, tc->instance->fsa, orig_size,
                 cu->body.callsites);


### PR DESCRIPTION
Interned callsites are no longer owned by the comp unit but by the instance.
This means that we also do not free them when the comp unit gets garbage
collected. It also means that it should be safe to reuse the existing pointer
when adding an interned callsite to a comp unit (e.g. when inlining across
comp unit boundaries).