### PR TITLE
Always handle proc exec arguments verbatim on Windows

### DIFF
--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -749,7 +749,7 @@ static void spawn_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
     process_options.file        = si->prog;
     process_options.args        = si->args;
     process_options.cwd         = si->cwd;
-    process_options.flags       = UV_PROCESS_WINDOWS_HIDE;
+    process_options.flags       = UV_PROCESS_WINDOWS_HIDE | UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
     process_options.env         = si->env;
     process_options.stdio_count = 3;
     process_options.exit_cb     = async_spawn_on_exit;


### PR DESCRIPTION
Together with a change in Rakudo this fixes Raku/problem-solving#20.

This change is not backwards compatible. To work correctly it's necessary to use a Rakudo which has been respectively adapted.