### PR TITLE
Add missing break statement

### DIFF
--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -482,6 +482,7 @@ static void optimize_iffy(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns *i
                 break;
             case MVM_OP_ifnonnull:
                 truthvalue = REPR(flag_facts->value.o)->ID != MVM_REPR_ID_MVMNull;
+                break;
             default:
                 return;
         }


### PR DESCRIPTION
For some reason the compiler didn't catch this. Change is spectest
clean. By adding this a dormant opt made by jnthn++ is enabled.