### PR TITLE
Fix utf8-c8 memory usage

### DIFF
--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -125,13 +125,6 @@ static MVMuint32 utf8_encode(MVMuint8 *bp, MVMCodepoint cp) {
 
 #define UTF8_MAXINC (32 * 1024 * 1024)
 
-static void ensure_buffer(MVMGrapheme32 **buffer, MVMint32 *bufsize, MVMint32 needed) {
-    while (needed >= *bufsize)
-        *buffer = MVM_realloc(*buffer, sizeof(MVMGrapheme32) * (
-            *bufsize >= UTF8_MAXINC ? (*bufsize += UTF8_MAXINC) : (*bufsize *= 2)
-        ));
-}
-
 static const MVMuint8 hex_chars[] = { '0', '1', '2', '3', '4', '5', '6', '7',
                                       '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 static MVMGrapheme32 synthetic_for(MVMThreadContext *tc, MVMuint8 invalid) {

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -555,8 +555,12 @@ MVMuint32 MVM_string_utf8_c8_decodestream(MVMThreadContext *tc, MVMDecodeStream 
 
         /* Attach what we successfully parsed as a result buffer, and trim away
          * what we chewed through. */
-        if (state.result_pos)
+        if (state.result_pos) {
+            /* Release memory we didn't use */
+            if ((bytes + 1) > state.result_pos)
+                state.result = MVM_realloc(state.result,sizeof(MVMGrapheme32) * state.result_pos);
             MVM_string_decodestream_add_chars(tc, ds, state.result, state.result_pos);
+        }
         else
             MVM_free(state.result);
         result_graphs += state.result_pos;

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -460,7 +460,7 @@ MVMuint32 MVM_string_utf8_c8_decodestream(MVMThreadContext *tc, MVMDecodeStream 
     reached_stopper = 0;
     while (cur_bytes && !reached_stopper) {
         /* Set up decode state for this buffer. */
-        MVMuint32 bytes = cur_bytes->length;
+        const MVMuint32 bytes = cur_bytes->length;
         /* Space for graphemes we have + 1 grapheme we receive from last buffer */
         state.result = MVM_malloc((bytes + 1) * sizeof(MVMGrapheme32));
         state.orig_codes = MVM_realloc(state.orig_codes,


### PR DESCRIPTION
MVM_string_utf8_c8_decodestream allocates 4x the size of it's input buffer for every string it spits out and never releases the excess. This means the size of every MVMString produced is directly tied to the size of the input file (for files up to 1MB). With a large input file, this results in each MVMString consuming 4MB of memory (on my machine). 

Consider something like this:
`for 'bigFileWithManyLines.txt'.IO.lines(:enc('utf8-c8')) {...}`

The GC can keep up if a single thread is consuming the decoder's output, though the memory usage is a bit high. However, multiple workers overwhelm it, and the OOM killer comes out.

This change reallocs the result buffer if it's larger than required. Since it can only request a smaller chunk, the call to realloc is cheap. 

This script demonstrates the issue.
```
#!/bin/env raku
my $words-done = 0;
class statm {
    has Int $.Vmsize;
    has Int $.VmRSS;
    has Int $.shared;
    has Int $.text;
    has Int $.lib;
    has Int $.data;
    has Int $.dt;
    method new($Vmsize,$VmRSS,$shared,$text,$lib,$data,$dt) {
        self.bless(:$Vmsize,:$VmRSS,:$shared,:$text,:$lib,:$data,:$dt);
    }
}
sub memstats() { return statm.new(|('/proc/self/statm'.IO.slurp.split(' ')>>.Int)); }

sub MAIN($wordlist) {
    signal(SIGINT).tap({ say 'words-done: '~ $words-done; exit 1;});
    say "lines\tVirt(GB)\tResident(GB)";
    my $s = memstats;
    for $wordlist.IO.lines(:enc('utf8-c8')) {
        $words-done++;
        if ($words-done % 1000 == 0) {
            $s = memstats;
            say $words-done~"\t"~
                Rat.new($s.Vmsize*4096,2**30).fmt('%.1f') ~ 
                "\t\t"~ Rat.new($s.VmRSS*4096,2**30).fmt('%.1f') ;
        }
        if $_ ~~ 'adsfjalks;dhjasdlfh;dsalfjkdlsajf' { say 'what are the odds' }
    }
}
```

Here are before and after runs using a readily available source file.

Before patch:
```
perl6 bughunt.pl6 MoarVM/src/strings/gb18030_codeindex.h
lines   Virt(GB)    Resident(GB)
1000    3.5         0.2
2000    6.6         0.4
3000    7.9         0.4
4000    7.9         0.9
5000    8.4         1.0
6000    11.5        1.1
7000    14.6        1.3
8000    17.7        1.4
9000    20.8        1.5
10000   23.9        1.7
```

After patch:
```
perl6 bughunt.pl6 MoarVM/src/strings/gb18030_codeindex.h
lines    Virt(GB)    Resident(GB)
10000    .4          0.1
20000    .4          0.1
30000    .4          0.1
40000    .4          0.1
50000    .4          0.1
60000    .4          0.1
70000    .4          0.1
80000    .4          0.1
90000    .4          0.1
100000   .4          0.1
```
