### PR TITLE
Use smaller buffer for native int to str coercion

### DIFF
--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -184,7 +184,6 @@ static char * u64toa_naive_worker(uint64_t value, char* buffer) {
         *buffer++ = *--p;
     } while (p != temp);
 
-    *buffer = '\0';
     return buffer;
 }
 static size_t i64toa_naive(int64_t value, char* buffer) {

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -201,7 +201,7 @@ static size_t u64toa_naive(uint64_t value, char* buffer) {
     return u64toa_naive_worker(value, buffer) - buffer;
 }
 MVMString * MVM_coerce_i_s(MVMThreadContext *tc, MVMint64 i) {
-    char buffer[64];
+    char buffer[20];
     int len;
     /* See if we can hit the cache. */
     int cache = 0 <= i && i < MVM_INT_TO_STR_CACHE_SIZE;
@@ -227,7 +227,7 @@ MVMString * MVM_coerce_i_s(MVMThreadContext *tc, MVMint64 i) {
 }
 
 MVMString * MVM_coerce_u_s(MVMThreadContext *tc, MVMuint64 i) {
-    char buffer[64];
+    char buffer[20];
     int len;
     /* See if we can hit the cache. */
     int cache = i < MVM_INT_TO_STR_CACHE_SIZE;


### PR DESCRIPTION
There can only be up to 20 chars, and the actual worker functions only
use 20 char arrays also.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.