### PR TITLE
Fix SEGV in MVM_spesh_plugin_guard_list_mark

### DIFF
--- a/src/gc/roots.c
+++ b/src/gc/roots.c
@@ -215,7 +215,8 @@ void MVM_gc_root_add_tc_roots_to_worklist(MVMThreadContext *tc, MVMGCWorklist *w
         else
             MVM_spesh_graph_describe(tc, tc->spesh_active_graph, snapshot);
     }
-    MVM_spesh_plugin_guard_list_mark(tc, tc->plugin_guards, tc->num_plugin_guards, worklist);
+    if (worklist)
+        MVM_spesh_plugin_guard_list_mark(tc, tc->plugin_guards, tc->num_plugin_guards, worklist);
     if (tc->temp_plugin_guards)
         MVM_spesh_plugin_guard_list_mark(tc, tc->temp_plugin_guards, tc->temp_num_plugin_guards, worklist);
     add_collectable(tc, worklist, snapshot, tc->plugin_guard_args,


### PR DESCRIPTION
MVM_spesh_plugin_guard_list_mark contains several tests checking that
the worklist parameter is not NULL. Unfortunately one call, to
MVM_spesh_plugin_guard_list_mark, had slipped through the cracks.
This could lead to a SEGV when running the heap profiler since it
can call MVM_gc_root_add_tc_roots_to_worklist with a NULL worklist
which in turn was used when calling MVM_spesh_plugin_guard_list_mark.
Fixed by adding a check which ensures that worklist is not NULL
before calling MVM_spesh_plugin_guard_list_mark.