### PR TITLE
Make the first page for some FSA bins bigger

### DIFF
--- a/src/core/fixedsizealloc.c
+++ b/src/core/fixedsizealloc.c
@@ -87,6 +87,34 @@ static void setup_bin(MVMFixedSizeAlloc *al, MVMuint32 bin) {
     /* Work out page size we want. */
     MVMuint32 page_size = MVM_FSA_PAGE_ITEMS * ((bin + 1) << MVM_FSA_BIN_BITS) + MVM_FSA_REDZONE_BYTES * 2 * MVM_FSA_PAGE_ITEMS;
 
+    /* The below numbers were determined by logging add_page() calls for `raku -e ''`.
+     * This makes the first page added the minumum size needed for any raku program,
+     * to reduce the number of mallocs and page adds when starting up. */
+    switch(bin) {
+        case  5:
+            page_size *= 315;
+            break;
+        case  6:
+        case 15:
+            page_size *= 38;
+            break;
+        case  1:
+        case  2:
+        case  3:
+        case  4:
+        case  7:
+            page_size *= 8;
+            break;
+        case  0:
+        case  8:
+        case 12:
+        case 17:
+            page_size *= 2;
+            break;
+        default:
+            break;
+    }
+
     /* We'll just allocate a single page to start off with. */
     al->size_classes[bin].num_pages = 1;
     al->size_classes[bin].pages     = MVM_malloc(sizeof(void *) * al->size_classes[bin].num_pages);


### PR DESCRIPTION
This means fewer calls to the slow FSA alloc path (which calls
`add_page()` and then mallocs). These specific numbers were based on just
calling `raku -e ''` and seeing how many `add_page()` calls there were for
each bin. Any modifications to the number or type of FSA allocations
could mean these defaults might need to be changed. Additionally, we
might decide to increase them assuming that most programs will actually
do more allocations than done by the empty program.

I did some testing with callgrind and time. I ran `MVM_SPESH_BLOCKING=1 valgrind --tool=callgrind raku -e ''` 100 times and stored the instruction count for both master and this branch. Master averaged 702,547,960 instructions and this branch averaged 702,285,088. I also ran each version 100 times with /usr/bin/time (but without using `MVM_SPESH_BLOCKING=1`), master averaged 0.945s elapsed and this branch averaged 0.947s.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.