### PR TITLE
Remove JIT template for prof_enter

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -2810,13 +2810,6 @@
       (carg (^spesh_slot_value $1) ptr)
       (carg $2 int)) ptr_sz))
 
-(template: prof_enter
-  (callv (^func MVM_profile_log_enter)
-    (arglist
-      (carg (tc) ptr)
-      (carg (^getf (^frame) MVMFrame static_info) ptr)
-      (carg (const (&QUOTE MVM_PROFILE_ENTER_NORMAL) int_sz) int))))
-
 (template: prof_enterspesh
   (callv (^func MVM_profile_log_enter)
     (arglist


### PR DESCRIPTION
The JIT probably won't (should never?) see `prof_enter`, but if it does,
mark the call to `MVM_profile_log_enter` as coming from the JIT.