### PR TITLE
Add gcc plugin to check for missing free before throw

### DIFF
--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -748,11 +748,13 @@ void MVM_6model_add_container_config(MVMThreadContext *tc, MVMString *name,
 
     if (!entry) {
         entry = MVM_malloc(sizeof(MVMContainerRegistry));
+        MVM_HASH_BIND_FREE(tc, tc->instance->container_registry, name, entry, {
+            MVM_free(entry);
+        });
         entry->name = name;
         entry->configurer  = configurer;
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->name,
             "Container configuration name");
-        MVM_HASH_BIND(tc, tc->instance->container_registry, name, entry);
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->hash_handle.key,
             "Container configuration hash key");
     }

--- a/src/6model/reprs.c
+++ b/src/6model/reprs.c
@@ -187,12 +187,14 @@ static void register_repr(MVMThreadContext *tc, const MVMREPROps *repr, MVMStrin
 
     /* Fill a registry entry. */
     entry = MVM_malloc(sizeof(MVMReprRegistry));
+    MVM_HASH_BIND_FREE(tc, tc->instance->repr_hash, name, entry, {
+        MVM_free(entry);
+    });
     entry->name = name;
     entry->repr = repr;
 
     /* Enter into registry. */
     tc->instance->repr_list[repr->ID] = entry;
-    MVM_HASH_BIND(tc, tc->instance->repr_hash, name, entry);
 
     /* Name and hash key should become a permanent GC root. */
     MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->name, "REPR name");

--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -33,17 +33,23 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
         if (ss->boxed_primitive == MVM_STORAGE_SPEC_BP_INT) {
             if (ss->bits == 8 || ss->bits == 16 || ss->bits == 32 || ss->bits == 64)
                 repr_data->elem_size = ss->bits / 8;
-            else
+            else {
+                MVM_free(repr_data);
+                st->REPR_data = NULL;
                 MVM_exception_throw_adhoc(tc,
                     "CArray representation can only have 8, 16, 32 or 64 bit integer elements");
+            }
             repr_data->elem_kind = MVM_CARRAY_ELEM_KIND_NUMERIC;
         }
         else if (ss->boxed_primitive == MVM_STORAGE_SPEC_BP_NUM) {
             if (ss->bits == 32 || ss->bits == 64)
                 repr_data->elem_size = ss->bits / 8;
-            else
+            else {
+                MVM_free(repr_data);
+                st->REPR_data = NULL;
                 MVM_exception_throw_adhoc(tc,
                     "CArray representation can only have 32 or 64 bit floating point elements");
+            }
             repr_data->elem_kind = MVM_CARRAY_ELEM_KIND_NUMERIC;
         }
         else if (ss->can_box & MVM_STORAGE_SPEC_CAN_BOX_STR) {
@@ -71,6 +77,8 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
             repr_data->elem_size = sizeof(void *);
         }
         else {
+            MVM_free(repr_data);
+            st->REPR_data = NULL;
             MVM_exception_throw_adhoc(tc,
                 "CArray representation only handles attributes of type:\n"
                 "  (u)int8, (u)int16, (u)int32, (u)int64, (u)long, (u)longlong, num32, num64, (s)size_t, bool, Str\n"

--- a/src/6model/reprs/ConditionVariable.c
+++ b/src/6model/reprs/ConditionVariable.c
@@ -111,9 +111,11 @@ MVMObject * MVM_conditionvariable_from_lock(MVMThreadContext *tc, MVMReentrantMu
         cv = (MVMConditionVariable *)MVM_gc_allocate_object(tc, STABLE(type));
     });
     cv->body.condvar = MVM_malloc(sizeof(uv_cond_t));
-    if ((init_stat = uv_cond_init(cv->body.condvar)) < 0)
+    if ((init_stat = uv_cond_init(cv->body.condvar)) < 0) {
+        MVM_free(cv->body.condvar);
         MVM_exception_throw_adhoc(tc, "Failed to initialize condition variable: %s",
             uv_strerror(init_stat));
+    }
     MVM_ASSIGN_REF(tc, &(cv->common.header), cv->body.mutex, (MVMObject *)lock);
 
     return (MVMObject *)cv;

--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -65,10 +65,12 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
         /* NOTE: if we really wanted to, we could avoid rehashing... */
         HASH_ITER_FAST(tc, hash_handle, src_body->lexical_names, current, {
             MVMLexicalRegistry *new_entry = MVM_malloc(sizeof(MVMLexicalRegistry));
+            MVM_HASH_BIND_FREE(tc, dest_body->lexical_names, current->key, new_entry, {
+                MVM_free(new_entry);
+            });
             /* don't need to clone the string */
             MVM_ASSIGN_REF(tc, &(dest_root->header), new_entry->key, current->key);
             new_entry->value = current->value;
-            MVM_HASH_BIND(tc, dest_body->lexical_names, current->key, new_entry);
         });
     }
 

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -210,6 +210,7 @@ static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerial
         }
         buf = (char *)MVM_malloc(len);
         if ((err = mp_to_decimal(i, buf, len)) != MP_OKAY) {
+            MVM_free(buf);
             MVM_exception_throw_adhoc(tc, "Error converting a big integer to a string: %s", mp_error_to_string(err));
         }
 
@@ -246,11 +247,13 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
         body->u.bigint = MVM_malloc(sizeof(mp_int));
         if ((err = mp_init(body->u.bigint)) != MP_OKAY) {
             MVM_free(body->u.bigint);
+            MVM_free(buf);
             MVM_exception_throw_adhoc(tc, "Error initializing a big integer: %s", mp_error_to_string(err));
         }
         if ((err = mp_read_radix(body->u.bigint, buf, 10)) != MP_OKAY) {
             mp_clear(body->u.bigint);
             MVM_free(body->u.bigint);
+            MVM_free(buf);
             MVM_exception_throw_adhoc(tc, "Error converting a string to a big integer: %s", mp_error_to_string(err));
         }
         MVM_free(buf);

--- a/src/6model/reprs/P6int.c
+++ b/src/6model/reprs/P6int.c
@@ -183,8 +183,11 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->is_unsigned = MVM_serialization_read_int(tc, reader);
 
     if (repr_data->bits !=  1 && repr_data->bits !=  2 && repr_data->bits !=  4 && repr_data->bits != 8
-     && repr_data->bits != 16 && repr_data->bits != 32 && repr_data->bits != 64)
-        MVM_exception_throw_adhoc(tc, "MVMP6int: Unsupported int size (%dbit)", repr_data->bits);
+     && repr_data->bits != 16 && repr_data->bits != 32 && repr_data->bits != 64) {
+        MVMint16 bits = repr_data->bits;
+        MVM_free(repr_data);
+        MVM_exception_throw_adhoc(tc, "MVMP6int: Unsupported int size (%dbit)", bits);
+    }
 
     mk_storage_spec(tc, repr_data->bits, repr_data->is_unsigned, &repr_data->storage_spec);
 

--- a/src/6model/reprs/P6num.c
+++ b/src/6model/reprs/P6num.c
@@ -129,8 +129,11 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->bits        = MVM_serialization_read_int(tc, reader);
 
     if (repr_data->bits !=  1 && repr_data->bits !=  2 && repr_data->bits !=  4 && repr_data->bits != 8
-     && repr_data->bits != 16 && repr_data->bits != 32 && repr_data->bits != 64)
-        MVM_exception_throw_adhoc(tc, "MVMP6num: Unsupported int size (%dbit)", repr_data->bits);
+     && repr_data->bits != 16 && repr_data->bits != 32 && repr_data->bits != 64) {
+        MVMint16 bits = repr_data->bits;
+        MVM_free(repr_data);
+        MVM_exception_throw_adhoc(tc, "MVMP6num: Unsupported int size (%dbit)", bits);
+    }
 
     if (repr_data->bits)
         mk_storage_spec(tc, repr_data->bits, &repr_data->storage_spec);

--- a/src/6model/reprs/ReentrantMutex.c
+++ b/src/6model/reprs/ReentrantMutex.c
@@ -7,9 +7,11 @@ static const MVMREPROps ReentrantMutex_this_repr;
 static void initialize_mutex(MVMThreadContext *tc, MVMReentrantMutexBody *rm) {
     int init_stat;
     rm->mutex = MVM_malloc(sizeof(uv_mutex_t));
-    if ((init_stat = uv_mutex_init(rm->mutex)) < 0)
+    if ((init_stat = uv_mutex_init(rm->mutex)) < 0) {
+        MVM_free(rm->mutex);
         MVM_exception_throw_adhoc(tc, "Failed to initialize mutex: %s",
             uv_strerror(init_stat));
+    }
 }
 
 /* Creates a new type object of this representation, and associates it with

--- a/src/6model/sc.c
+++ b/src/6model/sc.c
@@ -19,7 +19,9 @@ MVMObject * MVM_sc_create(MVMThreadContext *tc, MVMString *handle) {
             if (!scb) {
                 sc->body = scb = MVM_calloc(1, sizeof(MVMSerializationContextBody));
                 MVM_ASSIGN_REF(tc, &(sc->common.header), scb->handle, handle);
-                MVM_HASH_BIND(tc, tc->instance->sc_weakhash, handle, scb);
+                MVM_HASH_BIND_FREE(tc, tc->instance->sc_weakhash, handle, scb, {
+                    MVM_free_null(sc->body);
+                });
                 /* Calling repr_init will allocate, BUT if it does so, and we
                  * get unlucky, the GC will try to acquire mutex_sc_registry.
                  * This deadlocks. Thus, we force allocation in gen2, which

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -852,6 +852,8 @@ static void flatten_args(MVMThreadContext *tc, MVMArgProcContext *ctx) {
             MVMStorageSpec  lss   = REPR(list)->pos_funcs.get_elem_storage_spec(tc, STABLE(list));
 
             if ((MVMint64)new_arg_pos + count > 0xFFFF) {
+                MVM_free(new_arg_flags);
+                MVM_free(new_args);
                 MVM_exception_throw_adhoc(tc, "Too many arguments (%"PRId64") in flattening array, only %"PRId32" allowed.", (MVMint64)new_arg_pos + count, 0xFFFF);
             }
 
@@ -929,6 +931,8 @@ static void flatten_args(MVMThreadContext *tc, MVMArgProcContext *ctx) {
                 });
             }
             else if (arg_info.arg.o) {
+                MVM_free(new_arg_flags);
+                MVM_free(new_args);
                 MVM_exception_throw_adhoc(tc, "flattening of other hash reprs NYI.");
             }
         }

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -914,8 +914,11 @@ void MVM_bytecode_unpack(MVMThreadContext *tc, MVMCompUnit *cu) {
     cu_body->num_callsites = rs->expected_callsites;
     cu_body->orig_callsites = rs->expected_callsites;
 
-    if (rs->hll_str_idx > rs->expected_strings)
+    if (rs->hll_str_idx > rs->expected_strings) {
+        MVM_free(cu_body->string_heap_fast_table);
+        MVM_fixed_size_free(tc, tc->instance->fsa, rs->expected_strings * sizeof(MVMString *), cu_body->strings);
         MVM_exception_throw_adhoc(tc, "Unpacking bytecode: HLL name string index out of range: %d > %d", rs->hll_str_idx, rs->expected_strings);
+    }
 
     /* Resolve HLL name. */
     MVM_ASSIGN_REF(tc, &(cu->common.header), cu_body->hll_name,

--- a/src/core/dll.c
+++ b/src/core/dll.c
@@ -32,12 +32,14 @@ int MVM_dll_load(MVMThreadContext *tc, MVMString *name, MVMString *path) {
 
     if (!entry) {
         entry = MVM_malloc(sizeof *entry);
+        MVM_HASH_BIND_FREE(tc, tc->instance->dll_registry, name, entry, {
+            MVM_free(entry);
+        });
         entry->name = name;
         entry->refcount = 0;
 
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->name,
             "DLL name");
-        MVM_HASH_BIND(tc, tc->instance->dll_registry, name, entry);
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->hash_handle.key,
             "DLL name hash key");
     }

--- a/src/core/ext.c
+++ b/src/core/ext.c
@@ -34,12 +34,14 @@ int MVM_ext_load(MVMThreadContext *tc, MVMString *lib, MVMString *ext) {
     }
 
     entry = MVM_malloc(sizeof *entry);
+    MVM_HASH_BIND_FREE(tc, tc->instance->ext_registry, name, entry, {
+        MVM_free(entry);
+    });
     entry->sym = sym;
     entry->name = name;
 
     MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->name,
         "Extension name");
-    MVM_HASH_BIND(tc, tc->instance->ext_registry, name, entry);
     MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->hash_handle.key,
         "Extension name hash key");
 
@@ -148,6 +150,9 @@ int MVM_ext_register_extop(MVMThreadContext *tc, const char *cname,
     }
 
     entry                    = MVM_malloc(sizeof *entry);
+    MVM_HASH_BIND_FREE(tc, tc->instance->extop_registry, name, entry, {
+        MVM_free(entry);
+    });
     entry->name              = name;
     entry->func              = func;
     entry->info.name         = cname;
@@ -171,7 +176,6 @@ int MVM_ext_register_extop(MVMThreadContext *tc, const char *cname,
 
     MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->name,
         "Extension op name");
-    MVM_HASH_BIND(tc, tc->instance->extop_registry, name, entry);
     MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->hash_handle.key,
         "Extension op name hash key");
 

--- a/src/core/fixedsizealloc.c
+++ b/src/core/fixedsizealloc.c
@@ -26,9 +26,12 @@ MVMFixedSizeAlloc * MVM_fixed_size_create(MVMThreadContext *tc) {
 #endif
     MVMFixedSizeAlloc *al = MVM_malloc(sizeof(MVMFixedSizeAlloc));
     al->size_classes = MVM_calloc(MVM_FSA_BINS, sizeof(MVMFixedSizeAllocSizeClass));
-    if ((init_stat = uv_mutex_init(&(al->complex_alloc_mutex))) < 0)
+    if ((init_stat = uv_mutex_init(&(al->complex_alloc_mutex))) < 0) {
+        MVM_free(al->size_classes);
+        MVM_free(al);
         MVM_exception_throw_adhoc(tc, "Failed to initialize mutex: %s",
             uv_strerror(init_stat));
+    }
     al->freelist_spin = 0;
     al->free_at_next_safepoint_overflows = NULL;
 

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1089,6 +1089,9 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
             MVMObject    *handler;
             MVMCallsite *two_args_callsite;
 
+            if (return_value)
+                MVM_exception_throw_adhoc(tc, "return_value + exit_handler case NYI");
+
             /* Force the frame onto the heap, since we'll reference it from the
              * unwind data. */
             MVMROOT3(tc, frame, cur_frame, return_value, {
@@ -1113,8 +1116,6 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
                 ud->abs_addr = abs_addr;
                 ud->rel_addr = rel_addr;
                 ud->jit_return_label = jit_return_label;
-                if (return_value)
-                    MVM_exception_throw_adhoc(tc, "return_value + exit_handler case NYI");
                 MVM_frame_special_return(tc, cur_frame, continue_unwind, NULL, ud,
                     mark_unwind_data);
             }

--- a/src/core/hll.c
+++ b/src/core/hll.c
@@ -14,6 +14,16 @@ MVMHLLConfig *MVM_hll_get_config_for(MVMThreadContext *tc, MVMString *name) {
 
     if (!entry) {
         entry = MVM_calloc(1, sizeof(MVMHLLConfig));
+        if (tc->instance->hll_compilee_depth) {
+            MVM_HASH_BIND_FREE(tc, tc->instance->compilee_hll_configs, name, entry, {
+                MVM_free(entry);
+            });
+        }
+        else {
+            MVM_HASH_BIND_FREE(tc, tc->instance->compiler_hll_configs, name, entry, {
+                MVM_free(entry);
+            });
+        }
         entry->name = name;
         entry->int_box_type = tc->instance->boot_types.BOOTInt;
         entry->num_box_type = tc->instance->boot_types.BOOTNum;
@@ -25,12 +35,6 @@ MVMHLLConfig *MVM_hll_get_config_for(MVMThreadContext *tc, MVMString *name) {
         entry->foreign_type_int = tc->instance->boot_types.BOOTInt;
         entry->foreign_type_num = tc->instance->boot_types.BOOTNum;
         entry->foreign_type_str = tc->instance->boot_types.BOOTStr;
-        if (tc->instance->hll_compilee_depth) {
-            MVM_HASH_BIND(tc, tc->instance->compilee_hll_configs, name, entry);
-        }
-        else {
-            MVM_HASH_BIND(tc, tc->instance->compiler_hll_configs, name, entry);
-        }
         entry->max_inline_size = MVM_SPESH_DEFAULT_MAX_INLINE_SIZE;
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->int_box_type, "HLL int_box_type");
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)&entry->num_box_type, "HLL num_box_type");

--- a/src/core/loadbytecode.c
+++ b/src/core/loadbytecode.c
@@ -114,8 +114,10 @@ void MVM_load_bytecode(MVMThreadContext *tc, MVMString *filename) {
         run_comp_unit(tc, cu);
 
         loaded_name = MVM_calloc(1, sizeof(MVMLoadedCompUnitName));
+        MVM_HASH_BIND_FREE(tc, tc->instance->loaded_compunits, filename, loaded_name, {
+            MVM_free(loaded_name);
+        });
         loaded_name->filename = filename;
-        MVM_HASH_BIND(tc, tc->instance->loaded_compunits, filename, loaded_name);
     });
 
 LEAVE:

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -93,9 +93,10 @@ static void * unmarshal_callback(MVMThreadContext *tc, MVMObject *callback, MVMO
 
     if (!callback_data_head) {
         callback_data_head = MVM_malloc(sizeof(MVMNativeCallbackCacheHead));
+        MVM_HASH_BIND_FREE(tc, tc->native_callback_cache, cuid, callback_data_head, {
+            MVM_free(callback_data_head);
+        });
         callback_data_head->head = NULL;
-
-        MVM_HASH_BIND(tc, tc->native_callback_cache, cuid, callback_data_head);
     }
 
     callback_data_handle = &(callback_data_head->head);

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -317,6 +317,7 @@ static char callback_handler(DCCallback *cb, DCArgs *cb_args, DCValue *cb_result
                 args[i - 1].i64 = dcbArgULongLong(cb_args);
                 break;
             default:
+                MVM_free(args);
                 MVM_telemetry_interval_stop(tc, interval_id, "nativecall callback handler failed");
                 MVM_exception_throw_adhoc(tc,
                     "Internal error: unhandled dyncall callback argument type");
@@ -402,6 +403,7 @@ static char callback_handler(DCCallback *cb, DCArgs *cb_args, DCValue *cb_result
             cb_result->l = MVM_nativecall_unmarshal_ulonglong(tc, res.o);
             break;
         default:
+            MVM_free(args);
             MVM_telemetry_interval_stop(tc, interval_id, "nativecall callback handler failed");
             MVM_exception_throw_adhoc(tc,
                 "Internal error: unhandled dyncall callback return type");

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -87,9 +87,10 @@ static void * unmarshal_callback(MVMThreadContext *tc, MVMObject *callback, MVMO
 
     if (!callback_data_head) {
         callback_data_head = MVM_malloc(sizeof(MVMNativeCallbackCacheHead));
+        MVM_HASH_BIND_FREE(tc, tc->native_callback_cache, cuid, callback_data_head, {
+            MVM_free(callback_data_head);
+        });
         callback_data_head->head = NULL;
-
-        MVM_HASH_BIND(tc, tc->native_callback_cache, cuid, callback_data_head);
     }
 
     callback_data_handle = &(callback_data_head->head);

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -45,7 +45,13 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
         tc->temp_bigints[i] = MVM_malloc(sizeof(mp_int));
         mp_err err;
         if ((err = mp_init(tc->temp_bigints[i])) != MP_OKAY) {
+            MVMint32 j;
+            for (j = 0; j < i; j++) {
+                mp_clear(tc->temp_bigints[j]);
+                MVM_free(tc->temp_bigints[j]);
+            }
             MVM_free(tc->temp_bigints[i]);
+            MVM_tc_destroy(tc);
             MVM_exception_throw_adhoc(tc, "Error creating a temporary big integer: %s", mp_error_to_string(err));
         }
     }

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1463,7 +1463,9 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
                  * there is no debug local override for it (which means the lexical
                  * was lowered into a local, but preserved for some reason). */
                 c_key_name = MVM_string_utf8_encode_C_string(dtc, entry->key);
-                MVM_HASH_GET(dtc, debug_locals, entry->key, debug_entry);
+                MVM_HASH_GET_FREE(dtc, debug_locals, entry->key, debug_entry, {
+                    MVM_free(c_key_name);
+                });
                 if (debug_entry && static_info->body.local_types[debug_entry->local_idx] == lextype) {
                     result = &frame->work[debug_entry->local_idx];
                     was_from_local = 1;

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -311,8 +311,10 @@ static void write_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
     wi->req->data     = data;
     handle_data       = (MVMIOAsyncUDPSocketData *)wi->handle->body.data;
 
-    if (uv_is_closing((uv_handle_t *)handle_data->handle))
+    if (uv_is_closing((uv_handle_t *)handle_data->handle)) {
+        MVM_free(wi->req);
         MVM_exception_throw_adhoc(tc, "cannot write to a closed socket");
+    }
 
     if ((r = uv_udp_send(wi->req, handle_data->handle, &(wi->buf), 1, wi->dest_addr, on_write)) < 0) {
         /* Error; need to notify. */

--- a/src/io/dirops.c
+++ b/src/io/dirops.c
@@ -230,6 +230,7 @@ MVMObject * MVM_dir_open(MVMThreadContext *tc, MVMString *dirname) {
              * relative paths are always limited to a total of MAX_PATH characters.
              * see http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx */
             if (!GetFullPathNameW(wname, 4096, abs_dirname, &lpp_part)) {
+                MVM_free(data);
                 MVM_free(wname);
                 MVM_exception_throw_adhoc(tc, "Directory path is wrong: %d", GetLastError());
             }
@@ -260,6 +261,7 @@ MVMObject * MVM_dir_open(MVMThreadContext *tc, MVMString *dirname) {
         MVM_free(dir_name);
 
         if (!dir_handle) {
+            MVM_free(data);
             MVM_exception_throw_adhoc(tc, "Failed to open dir: %s", strerror(opendir_error));
         }
 

--- a/src/io/filewatchers.c
+++ b/src/io/filewatchers.c
@@ -98,12 +98,16 @@ MVMObject * MVM_io_file_watch(MVMThreadContext *tc, MVMObject *queue,
     char *c_path = MVM_string_utf8_c8_encode_C_string(tc, path);
 
     /* Validate REPRs. */
-    if (REPR(queue)->ID != MVM_REPR_ID_ConcBlockingQueue)
+    if (REPR(queue)->ID != MVM_REPR_ID_ConcBlockingQueue) {
+        MVM_free(c_path);
         MVM_exception_throw_adhoc(tc,
             "file watch target queue must have ConcBlockingQueue REPR");
-    if (REPR(async_type)->ID != MVM_REPR_ID_MVMAsyncTask)
+    }
+    if (REPR(async_type)->ID != MVM_REPR_ID_MVMAsyncTask) {
+        MVM_free(c_path);
         MVM_exception_throw_adhoc(tc,
             "file watch result type must have REPR AsyncTask");
+    }
 
     /* Create async task handle. */
     MVMROOT2(tc, queue, schedulee, {

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -339,6 +339,7 @@ struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc,
 #endif
         }
         default:
+            MVM_free(host_cstr);
             MVM_exception_throw_adhoc(tc, "Unsupported socket family: %"PRIu16"", family);
             break;
     }
@@ -354,12 +355,16 @@ struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc,
             hints.ai_socktype = SOCK_DGRAM;
             break;
         case MVM_SOCKET_TYPE_RAW:
+            MVM_free(host_cstr);
             MVM_exception_throw_adhoc(tc, "Support for raw sockets NYI");
         case MVM_SOCKET_TYPE_RDM:
+            MVM_free(host_cstr);
             MVM_exception_throw_adhoc(tc, "Support for RDM sockets NYI");
         case MVM_SOCKET_TYPE_SEQPACKET:
+            MVM_free(host_cstr);
             MVM_exception_throw_adhoc(tc, "Support for seqpacket sockets NYI");
         default:
+            MVM_free(host_cstr);
             MVM_exception_throw_adhoc(tc, "Unsupported socket type: %"PRIi64"", type);
     }
 
@@ -374,6 +379,7 @@ struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc,
             hints.ai_protocol = IPPROTO_UDP;
             break;
         default:
+            MVM_free(host_cstr);
             MVM_exception_throw_adhoc(tc, "Unsupported socket protocol: %"PRIi64"", protocol);
     }
 

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -1065,6 +1065,7 @@ MVMString * MVM_bigint_to_str(MVMThreadContext *tc, MVMObject *a, int base) {
             is_malloced = 1;
         }
         if ((err = mp_to_radix(i, buf, len, NULL, base)) != MP_OKAY) {
+            if (is_malloced) MVM_free(buf);
             MVM_exception_throw_adhoc(tc, "Error getting the string representation of a big integer: %s", mp_error_to_string(err));
         }
         result = MVM_string_ascii_decode(tc, tc->instance->VMString, buf, len - 1);
@@ -1101,6 +1102,7 @@ MVMString * MVM_bigint_to_str(MVMThreadContext *tc, MVMObject *a, int base) {
                 is_malloced = 1;
             }
             if ((err = mp_to_radix(&i, buf, len, NULL, base)) != MP_OKAY) {
+                if (is_malloced) MVM_free(buf);
                 mp_clear(&i);
                 MVM_exception_throw_adhoc(tc, "Error getting the string representation of a big integer: %s", mp_error_to_string(err));
             }

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -51,6 +51,7 @@ void MVM_profile_heap_start(MVMThreadContext *tc, MVMObject *config) {
         MVM_repr_at_key_o(tc, config, tc->instance->str_consts.path));
 
     if (MVM_is_null(tc, (MVMObject*)path_str)) {
+        MVM_free(col);
         MVM_exception_throw_adhoc(tc, "Didn't specify a path for the heap snapshot profiler");
     }
 

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -59,6 +59,7 @@ void MVM_profile_heap_start(MVMThreadContext *tc, MVMObject *config) {
     col->fh = MVM_platform_fopen(path, "w");
 
     if (!col->fh) {
+        MVM_free(col);
         char *waste[2] = {path, NULL};
         MVM_exception_throw_adhoc_free(tc, waste, "Couldn't open heap snapshot target file %s: %s", path, strerror(errno));
     }

--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -19,6 +19,7 @@ MVMString * MVM_string_ascii_decode(MVMThreadContext *tc, const MVMObject *resul
             result->body.storage.blob_32[result_graphs++] = ascii[i];
         }
         else {
+            MVM_free(result->body.storage.blob_32);
             MVM_exception_throw_adhoc(tc,
                 "Will not decode invalid ASCII (code point (%"PRId32") < 0 found)", ascii[i]);
         }
@@ -70,9 +71,11 @@ MVMuint32 MVM_string_ascii_decodestream(MVMThreadContext *tc, MVMDecodeStream *d
         while (pos < cur_bytes->length) {
             MVMCodepoint codepoint = bytes[pos++];
             MVMGrapheme32 graph;
-            if (codepoint > 127)
+            if (codepoint > 127) {
+                MVM_free(buffer);
                 MVM_exception_throw_adhoc(tc,
                     "Will not decode invalid ASCII (code point (%"PRId32") > 127 found)", codepoint);
+            }
             if (last_was_cr) {
                 if (codepoint == '\n') {
                     graph = MVM_unicode_normalizer_translated_crlf(tc, &(ds->norm));

--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -678,8 +678,10 @@ void MVM_string_decode_stream_sep_from_strings(MVMThreadContext *tc, MVMDecodeSt
     graph_length = 0;
     for (i = 0; i < num_seps; i++) {
         MVMuint32 num_graphs = MVM_string_graphs(tc, seps[i]);
-        if (num_graphs > 0xFFFF)
+        if (num_graphs > 0xFFFF) {
+            MVM_free(sep_spec->sep_lengths);
             MVM_exception_throw_adhoc(tc, "Line separator (%"PRIu32") too long, max allowed is 65535", num_graphs);
+        }
         sep_spec->sep_lengths[i] = num_graphs;
         graph_length += num_graphs;
     }

--- a/src/strings/gb18030.c
+++ b/src/strings/gb18030.c
@@ -97,9 +97,10 @@ MVMString * MVM_string_gb18030_decode(MVMThreadContext *tc, const MVMObject *res
                 }
             }
             
-            MVM_exception_throw_adhoc(tc, 
-            "Error decoding gb18030 string: invalid gb18030 format. Last byte seen was 0x%hhX\n", 
-            (MVMuint8)gb18030[i]);
+            MVM_free(result->body.storage.blob_32);
+            MVM_exception_throw_adhoc(tc,
+                "Error decoding gb18030 string: invalid gb18030 format. Last byte seen was 0x%hhX\n",
+                (MVMuint8)gb18030[i]);
         }
     }
 
@@ -170,6 +171,7 @@ MVMuint32 MVM_string_gb18030_decodestream(MVMThreadContext *tc, MVMDecodeStream 
                         graph = gb18030_index_to_cp_len4(len4_byte1, len4_byte2, len4_byte3, len4_byte4);
                         is_len4 = 0;
                     } else {
+                        MVM_free(buffer);
                         MVM_exception_throw_adhoc(tc, 
                          "Error decoding gb18030 string: invalid gb18030 format. Last four bytes seen was 0x%x, 0x%x, 0x%x, 0x%x\n", 
                          len4_byte1, len4_byte2, len4_byte3, len4_byte4);
@@ -207,6 +209,7 @@ MVMuint32 MVM_string_gb18030_decodestream(MVMThreadContext *tc, MVMDecodeStream 
                     }
                     graph = gb18030_index_to_cp_len2(last_codepoint, codepoint);
                     if (graph == GB18030_NULL) {
+                        MVM_free(buffer);
                         MVM_exception_throw_adhoc(tc, 
                         "Error decoding gb18030 string: invalid gb18030 format. Last two bytes seen was 0x%x, 0x%x\n", 
                         last_codepoint, codepoint);

--- a/src/strings/gb2312.c
+++ b/src/strings/gb2312.c
@@ -34,13 +34,15 @@ MVMString * MVM_string_gb2312_decode(MVMThreadContext *tc, const MVMObject *resu
                     i++;
                 }
                 else {
+                    MVM_free(result->body.storage.blob_32);
                     MVM_exception_throw_adhoc(tc, "Error decoding gb2312 string: could not decode codepoint 0x%x", codepoint);
                 }
             }
             else {
+                MVM_free(result->body.storage.blob_32);
                 MVM_exception_throw_adhoc(tc, 
-                "Error decoding gb2312 string: invalid gb2312 format (two bytes for a gb2312 character). Last byte seen was 0x%hhX\n", 
-                (MVMuint8)gb2312[i]);
+                    "Error decoding gb2312 string: invalid gb2312 format (two bytes for a gb2312 character). Last byte seen was 0x%hhX\n", 
+                    (MVMuint8)gb2312[i]);
             }
         }
     }
@@ -128,13 +130,15 @@ MVMuint32 MVM_string_gb2312_decodestream(MVMThreadContext *tc, MVMDecodeStream *
             int handler_rtrn = gb2312_decode_handler(tc, last_was_first_byte, codepoint, last_codepoint, &graph);
 
             if (handler_rtrn == GB2312_DECODE_FORMAT_EXCEPTION) {
+                MVM_free(buffer);
                 MVM_exception_throw_adhoc(tc, 
-                "Error decoding gb2312 string: invalid gb2312 format (two bytes for a gb2312 character). Last byte seen was 0x%x\n", 
-                last_codepoint);
+                    "Error decoding gb2312 string: invalid gb2312 format (two bytes for a gb2312 character). Last byte seen was 0x%x\n", 
+                    last_codepoint);
             }
             else if (handler_rtrn == GB2312_DECODE_CODEPOINT_EXCEPTION) {
+                MVM_free(buffer);
                 MVM_exception_throw_adhoc(tc, "Error decoding gb2312 string: could not decode codepoint 0x%x", 
-                last_codepoint * 256 + codepoint);
+                    last_codepoint * 256 + codepoint);
             }
             else if (handler_rtrn == GB2312_DECODE_CONTINUE) {
                 last_codepoint = codepoint;

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -280,9 +280,11 @@ static void iterate_gi_into_string(MVMThreadContext *tc, MVMGraphemeIter *gi, MV
                 );
                 break;
             }
-            default:
+            default: {
+                MVM_free(result->body.storage.blob_8);
                 MVM_exception_throw_adhoc(tc,
                     "Internal error, string corruption in iterate_gi_into_string\n");
+            }
             }
             result_pos += to_copy;
             if (result_graphs <= result_pos || !MVM_string_gi_has_more_strands_rep(tc, gi)) {
@@ -322,9 +324,11 @@ static void iterate_gi_into_string(MVMThreadContext *tc, MVMGraphemeIter *gi, MV
                     );
                     break;
                 }
-                default:
+                default: {
+                    MVM_free(result->body.storage.blob_32);
                     MVM_exception_throw_adhoc(tc,
                         "Internal error, string corruption in iterate_gi_into_string\n");
+                }
             }
             result_pos += to_copy;
             if (result_graphs <= result_pos || !MVM_string_gi_has_more_strands_rep(tc, gi)) {

--- a/src/strings/shiftjis.c
+++ b/src/strings/shiftjis.c
@@ -260,6 +260,7 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
                     if (1 < repl_length) repl_pos++;
                 }
                 else {
+                    MVM_free(result->body.storage.blob_32);
                     /* Throw if it's unmapped */
                     MVM_exception_throw_adhoc(tc,
                         "Error decoding shiftjis string: could not decode byte 0x%hhX",
@@ -272,6 +273,7 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
                 continue;
             }
             else {
+                MVM_free(result->body.storage.blob_32);
                 MVM_exception_throw_adhoc(tc, "shiftjis decoder encountered an internal error.\n");
             }
         }
@@ -299,6 +301,7 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
     /* If we end up with Shift_JIS_lead still set, that means we're missing a byte
      * that should have followed it. */
     if (Shift_JIS_lead != 0x00) {
+        MVM_free(result->body.storage.blob_32);
         MVM_exception_throw_adhoc(tc, "Error, ended decode of shiftjis expecting another byte. "
             "Last byte seen was 0x%hhX\n", Shift_JIS_lead);
     }
@@ -397,6 +400,7 @@ MVMuint32 MVM_string_shiftjis_decodestream(MVMThreadContext *tc, MVMDecodeStream
                     continue;
                 }
                 else {
+                    MVM_free(buffer);
                     MVM_exception_throw_adhoc(tc, "shiftjis decoder encountered an internal error. This bug should be reported.\n");
                 }
             }

--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -255,6 +255,7 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
         MVMGrapheme32 g;
 
         if ((value & 0xFC00) == 0xDC00) {
+            MVM_free(result->body.storage.blob_32);
             MVM_unicode_normalizer_cleanup(tc, &norm);
             MVM_exception_throw_adhoc(tc, "Malformed UTF-16; unexpected low surrogate");
         }
@@ -262,11 +263,13 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
         if ((value & 0xFC00) == 0xD800) { /* high surrogate */
             utf16 += 2;
             if (utf16 == utf16_end) {
+                MVM_free(result->body.storage.blob_32);
                 MVM_unicode_normalizer_cleanup(tc, &norm);
                 MVM_exception_throw_adhoc(tc, "Malformed UTF-16; incomplete surrogate pair");
             }
             value2 = (utf16[high] << 8) + utf16[low];
             if ((value2 & 0xFC00) != 0xDC00) {
+                MVM_free(result->body.storage.blob_32);
                 MVM_unicode_normalizer_cleanup(tc, &norm);
                 MVM_exception_throw_adhoc(tc, "Malformed UTF-16; incomplete surrogate pair");
             }

--- a/src/strings/windows1252.c
+++ b/src/strings/windows1252.c
@@ -518,6 +518,7 @@ MVMString * MVM_string_windows125X_decode(MVMThreadContext *tc,
                     codepoint = MVM_string_get_grapheme_at(tc, replacement, i);
                 }
                 else if (MVM_ENCODING_CONFIG_STRICT(config)) {
+                    MVM_free(result->body.storage.blob_32);
                     /* Throw an exception if that codepoint has no mapping */
                     char *enc_name = codetable == windows1252_codepoints
                         ? "Windows-1252" : "Windows-1251";

--- a/tools/check-throw-without-free.py
+++ b/tools/check-throw-without-free.py
@@ -1,6 +1,8 @@
 import gcc
 from gccutils import get_src_for_loc, pformat, cfg_to_dot, invoke_dot
 
+# Need to add `-fplugin=python.so -fplugin-arg-python-script=tools/check-throw-without-free.py` to CFLAGS in the Makefile
+
 # We'll implement this as a custom pass, to be called directly after the
 # builtin 'cfg' pass, which generates the CFG:
 
@@ -23,7 +25,7 @@ def collect_control_flows(bb, path, seen):
 
 #alloc_funcs = {'MVM_string_utf8_c8_encode_C_string'} # currently adding this causes a segfault in gcc when compiling src/io/filewatchers.c
 alloc_funcs = {'MVM_malloc', 'MVM_calloc', 'MVM_fixed_size_allocate', 'MVM_fixed_size_allocate_zeroed', 'ANSIToUTF8', 'MVM_bytecode_dump', 'MVM_exception_backtrace_line', 'MVM_nativecall_unmarshal_string', 'MVM_serialization_read_cstr', 'MVM_spesh_dump', 'MVM_spesh_dump_arg_guard', 'MVM_spesh_dump_planned', 'MVM_spesh_dump_stats', 'MVM_staticframe_file_location', 'MVM_string_ascii_encode', 'MVM_string_ascii_encode_any', 'MVM_string_ascii_encode_substr', 'MVM_string_encode', 'MVM_string_gb18030_encode_substr', 'MVM_string_gb2312_encode_substr', 'MVM_string_latin1_encode', 'MVM_string_latin1_encode_substr', 'MVM_string_shiftjis_encode_substr', 'MVM_string_utf16_encode', 'MVM_string_utf16_encode_substr', 'MVM_string_utf16_encode_substr_main', 'MVM_string_utf16be_encode_substr', 'MVM_string_utf16le_encode_substr', 'MVM_string_utf8_c8_encode', 'MVM_string_utf8_c8_encode_substr', 'MVM_string_utf8_encode', 'MVM_string_utf8_encode_C_string', 'MVM_string_utf8_encode_substr', 'MVM_string_utf8_maybe_encode_C_string', 'MVM_string_windows1251_encode_substr', 'MVM_string_windows1252_encode_substr', 'MVM_string_windows125X_encode_substr', 'NFG_check_make_debug_string', 'NFG_checker', 'UnicodeToUTF8', 'UnicodeToUTF8', 'base64_encode', 'callback_handler', 'get_signature_char', 'twoway_memmem_uint32', 'u64toa_naive_worker'}
-free_funcs = {'MVM_free', 'MVM_free_null', 'MVM_fixed_size_free', 'MVM_fixed_size_free_at_safepoint'}
+free_funcs = {'MVM_free', 'MVM_free_null', 'MVM_fixed_size_free', 'MVM_fixed_size_free_at_safepoint', 'free_repr_data', 'cleanup_all', 'MVM_tc_destroy'}
 
 def check_code_for_throw_without_free(fun):
     for bb in fun.cfg.basic_blocks:

--- a/tools/check-throw-without-free.py
+++ b/tools/check-throw-without-free.py
@@ -1,107 +1,6 @@
 import gcc
 from gccutils import get_src_for_loc, pformat, cfg_to_dot, invoke_dot
 
-
-# The below diff is required to get any useful output, because otherwise MVM_exception_throw_adhoc
-# causes blocks to not point to the exit, so don't have a GimpleReturn and aren't processed.
-# Also, adding `-Wno-return-type -Wno-implicit-fallthrough` to CFLAGS in the Makefile helps reduce
-# compiler warnings (but isn't required).
-
-# diff --git a/src/core/exceptions.c b/src/core/exceptions.c
-# index f5429fbc1..567d29c01 100644
-# --- a/src/core/exceptions.c
-# +++ b/src/core/exceptions.c
-# @@ -873,7 +873,7 @@ MVM_NO_RETURN void MVM_oops(MVMThreadContext *tc, const char *messageFormat, ...
-#  }
-# 
-#  /* Throws an ad-hoc (untyped) exception. */
-# -MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) {
-# +void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) {
-#      va_list args;
-#      va_start(args, messageFormat);
-#      MVM_exception_throw_adhoc_free_va(tc, NULL, messageFormat, args);
-# @@ -881,13 +881,13 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *m
-#  }
-# 
-#  /* Throws an ad-hoc (untyped) exception. */
-# -MVM_NO_RETURN void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) {
-# +void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) {
-#      MVM_exception_throw_adhoc_free_va(tc, NULL, messageFormat, args);
-#  }
-# 
-#  /* Throws an ad-hoc (untyped) exception, taking a NULL-terminated array of
-#   * char pointers to deallocate after message construction. */
-# -MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) {
-# +void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) {
-#      va_list args;
-#      va_start(args, messageFormat);
-#      MVM_exception_throw_adhoc_free_va(tc, waste, messageFormat, args);
-# @@ -896,7 +896,7 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **w
-# 
-#  /* Throws an ad-hoc (untyped) exception, taking a NULL-terminated array of
-#   * char pointers to deallocate after message construction. */
-# -MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) {
-# +void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) {
-#      LocatedHandler lh;
-#      MVMException *ex;
-#      /* The current frame will be assigned as the thrower of the exception, so
-# @@ -944,11 +944,11 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char
-#              vfprintf(stderr, messageFormat, args);
-#              fwrite("\n", 1, 1, stderr);
-#              MVM_dump_backtrace(tc);
-# -            abort();
-# +            //abort();
-#          }
-#          else {
-#              /* No, just the usual panic. */
-# -            panic_unhandled_ex(tc, ex);
-# +            //panic_unhandled_ex(tc, ex);
-#          }
-#      }
-# 
-# @@ -962,7 +962,7 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char
-#      MVM_tc_release_ex_release_mutex(tc);
-# 
-#      /* Jump back into the interpreter. */
-# -    longjmp(tc->interp_jump, 1);
-# +    //longjmp(tc->interp_jump, 1);
-#  }
-# 
-#  void MVM_crash_on_error(void) {
-# diff --git a/src/core/exceptions.h b/src/core/exceptions.h
-# index 210075965..503434eb4 100644
-# --- a/src/core/exceptions.h
-# +++ b/src/core/exceptions.h
-# @@ -90,10 +90,10 @@ void MVM_exception_resume(MVMThreadContext *tc, MVMObject *exObj);
-#  MVM_PUBLIC MVM_NO_RETURN void MVM_panic_allocation_failed(size_t len) MVM_NO_RETURN_ATTRIBUTE;
-#  MVM_PUBLIC MVM_NO_RETURN void MVM_panic(MVMint32 exitCode, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
-#  MVM_PUBLIC MVM_NO_RETURN void MVM_oops(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
-# -MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
-# -MVM_NO_RETURN void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) MVM_NO_RETURN_ATTRIBUTE;
-# -MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 3, 4);
-# -MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) MVM_NO_RETURN_ATTRIBUTE;
-# +MVM_PUBLIC void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_FORMAT(printf, 2, 3);
-# +void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args);
-# +MVM_PUBLIC void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) MVM_FORMAT(printf, 3, 4);
-# +void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args);
-#  MVM_PUBLIC void MVM_crash_on_error(void);
-#  char * MVM_exception_backtrace_line(MVMThreadContext *tc, MVMFrame *cur_frame, MVMuint16 not_top, MVMuint8 *throw_address);
-#  MVMint32 MVM_get_exception_category(MVMThreadContext *tc, MVMObject *ex);
-# diff --git a/src/strings/uthash.h b/src/strings/uthash.h
-# index 7186c87e9..bbb3b4d34 100644
-# --- a/src/strings/uthash.h
-# +++ b/src/strings/uthash.h
-# @@ -223,7 +223,7 @@ MVM_STATIC_INLINE MVMuint32 ptr_hash_32_to_32(MVMuint32 u) {
-#  #ifndef ROTL
-#  #define ROTL(x, b) ( ((x) << (b)) | ( (x) >> ((sizeof(x)*8) - (b))) )
-#  #endif
-# -MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
-# +MVM_PUBLIC void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_FORMAT(printf, 2, 3);
-#  MVM_STATIC_INLINE void HASH_MAKE_TABLE(MVMThreadContext *tc, void *head, UT_hash_handle *head_hh) {
-#      head_hh->tbl = (UT_hash_table*)uthash_malloc_zeroed(tc, sizeof(UT_hash_table));
-#      head_hh->tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;
-
-
 # We'll implement this as a custom pass, to be called directly after the
 # builtin 'cfg' pass, which generates the CFG:
 
@@ -123,13 +22,13 @@ def collect_control_flows(bb, path, seen):
     return paths
 
 #alloc_funcs = {'MVM_string_utf8_c8_encode_C_string'} # currently adding this causes a segfault in gcc when compiling src/io/filewatchers.c
-alloc_funcs = {'MVM_malloc', 'MVM_calloc', 'MVM_fixed_size_allocate', 'MVM_fixed_size_allocate_zeroed', 'ANSIToUTF8', 'MVM_bytecode_dump', 'MVM_exception_backtrace_line', 'MVM_nativecall_unmarshal_string', 'MVM_reg_get_debug_name', 'MVM_serialization_read_cstr', 'MVM_spesh_dump', 'MVM_spesh_dump_arg_guard', 'MVM_spesh_dump_planned', 'MVM_spesh_dump_stats', 'MVM_staticframe_file_location', 'MVM_string_ascii_encode', 'MVM_string_ascii_encode_any', 'MVM_string_ascii_encode_substr', 'MVM_string_encode', 'MVM_string_encoding_cname', 'MVM_string_gb18030_encode_substr', 'MVM_string_gb2312_encode_substr', 'MVM_string_latin1_encode', 'MVM_string_latin1_encode_substr', 'MVM_string_shiftjis_encode_substr', 'MVM_string_utf16_encode', 'MVM_string_utf16_encode_substr', 'MVM_string_utf16_encode_substr_main', 'MVM_string_utf16be_encode_substr', 'MVM_string_utf16le_encode_substr', 'MVM_string_utf8_c8_encode', 'MVM_string_utf8_c8_encode_substr', 'MVM_string_utf8_encode', 'MVM_string_utf8_encode_C_string', 'MVM_string_utf8_encode_substr', 'MVM_string_utf8_maybe_encode_C_string', 'MVM_string_windows1251_encode_substr', 'MVM_string_windows1252_encode_substr', 'MVM_string_windows125X_encode_substr', 'NFG_check_make_debug_string', 'NFG_checker', 'UnicodeToUTF8', 'UnicodeToUTF8', 'base64_encode', 'callback_handler', 'get_signature_char', 'twoway_memmem_uint32', 'u64toa_naive_worker'}
+alloc_funcs = {'MVM_malloc', 'MVM_calloc', 'MVM_fixed_size_allocate', 'MVM_fixed_size_allocate_zeroed', 'ANSIToUTF8', 'MVM_bytecode_dump', 'MVM_exception_backtrace_line', 'MVM_nativecall_unmarshal_string', 'MVM_serialization_read_cstr', 'MVM_spesh_dump', 'MVM_spesh_dump_arg_guard', 'MVM_spesh_dump_planned', 'MVM_spesh_dump_stats', 'MVM_staticframe_file_location', 'MVM_string_ascii_encode', 'MVM_string_ascii_encode_any', 'MVM_string_ascii_encode_substr', 'MVM_string_encode', 'MVM_string_gb18030_encode_substr', 'MVM_string_gb2312_encode_substr', 'MVM_string_latin1_encode', 'MVM_string_latin1_encode_substr', 'MVM_string_shiftjis_encode_substr', 'MVM_string_utf16_encode', 'MVM_string_utf16_encode_substr', 'MVM_string_utf16_encode_substr_main', 'MVM_string_utf16be_encode_substr', 'MVM_string_utf16le_encode_substr', 'MVM_string_utf8_c8_encode', 'MVM_string_utf8_c8_encode_substr', 'MVM_string_utf8_encode', 'MVM_string_utf8_encode_C_string', 'MVM_string_utf8_encode_substr', 'MVM_string_utf8_maybe_encode_C_string', 'MVM_string_windows1251_encode_substr', 'MVM_string_windows1252_encode_substr', 'MVM_string_windows125X_encode_substr', 'NFG_check_make_debug_string', 'NFG_checker', 'UnicodeToUTF8', 'UnicodeToUTF8', 'base64_encode', 'callback_handler', 'get_signature_char', 'twoway_memmem_uint32', 'u64toa_naive_worker'}
 free_funcs = {'MVM_free', 'MVM_free_null', 'MVM_fixed_size_free', 'MVM_fixed_size_free_at_safepoint'}
 
 def check_code_for_throw_without_free(fun):
     for bb in fun.cfg.basic_blocks:
         for ins in bb.gimple:
-            if isinstance(ins, gcc.GimpleReturn):
+            if isinstance(ins, gcc.GimpleCall) and isinstance(ins.fn, gcc.AddrExpr) and ins.fn.operand.name == 'MVM_exception_throw_adhoc':
                 cfs = collect_control_flows(bb, [], {})
 
                 for cf in cfs:

--- a/tools/check-throw-without-free.py
+++ b/tools/check-throw-without-free.py
@@ -1,0 +1,158 @@
+import gcc
+from gccutils import get_src_for_loc, pformat, cfg_to_dot, invoke_dot
+
+
+# The below diff is required to get any useful output, because otherwise MVM_exception_throw_adhoc
+# causes blocks to not point to the exit, so don't have a GimpleReturn and aren't processed.
+# Also, adding `-Wno-return-type -Wno-implicit-fallthrough` to CFLAGS in the Makefile helps reduce
+# compiler warnings (but isn't required).
+
+# diff --git a/src/core/exceptions.c b/src/core/exceptions.c
+# index f5429fbc1..567d29c01 100644
+# --- a/src/core/exceptions.c
+# +++ b/src/core/exceptions.c
+# @@ -873,7 +873,7 @@ MVM_NO_RETURN void MVM_oops(MVMThreadContext *tc, const char *messageFormat, ...
+#  }
+# 
+#  /* Throws an ad-hoc (untyped) exception. */
+# -MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) {
+# +void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) {
+#      va_list args;
+#      va_start(args, messageFormat);
+#      MVM_exception_throw_adhoc_free_va(tc, NULL, messageFormat, args);
+# @@ -881,13 +881,13 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *m
+#  }
+# 
+#  /* Throws an ad-hoc (untyped) exception. */
+# -MVM_NO_RETURN void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) {
+# +void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) {
+#      MVM_exception_throw_adhoc_free_va(tc, NULL, messageFormat, args);
+#  }
+# 
+#  /* Throws an ad-hoc (untyped) exception, taking a NULL-terminated array of
+#   * char pointers to deallocate after message construction. */
+# -MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) {
+# +void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) {
+#      va_list args;
+#      va_start(args, messageFormat);
+#      MVM_exception_throw_adhoc_free_va(tc, waste, messageFormat, args);
+# @@ -896,7 +896,7 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **w
+# 
+#  /* Throws an ad-hoc (untyped) exception, taking a NULL-terminated array of
+#   * char pointers to deallocate after message construction. */
+# -MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) {
+# +void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) {
+#      LocatedHandler lh;
+#      MVMException *ex;
+#      /* The current frame will be assigned as the thrower of the exception, so
+# @@ -944,11 +944,11 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char
+#              vfprintf(stderr, messageFormat, args);
+#              fwrite("\n", 1, 1, stderr);
+#              MVM_dump_backtrace(tc);
+# -            abort();
+# +            //abort();
+#          }
+#          else {
+#              /* No, just the usual panic. */
+# -            panic_unhandled_ex(tc, ex);
+# +            //panic_unhandled_ex(tc, ex);
+#          }
+#      }
+# 
+# @@ -962,7 +962,7 @@ MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char
+#      MVM_tc_release_ex_release_mutex(tc);
+# 
+#      /* Jump back into the interpreter. */
+# -    longjmp(tc->interp_jump, 1);
+# +    //longjmp(tc->interp_jump, 1);
+#  }
+# 
+#  void MVM_crash_on_error(void) {
+# diff --git a/src/core/exceptions.h b/src/core/exceptions.h
+# index 210075965..503434eb4 100644
+# --- a/src/core/exceptions.h
+# +++ b/src/core/exceptions.h
+# @@ -90,10 +90,10 @@ void MVM_exception_resume(MVMThreadContext *tc, MVMObject *exObj);
+#  MVM_PUBLIC MVM_NO_RETURN void MVM_panic_allocation_failed(size_t len) MVM_NO_RETURN_ATTRIBUTE;
+#  MVM_PUBLIC MVM_NO_RETURN void MVM_panic(MVMint32 exitCode, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
+#  MVM_PUBLIC MVM_NO_RETURN void MVM_oops(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
+# -MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
+# -MVM_NO_RETURN void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) MVM_NO_RETURN_ATTRIBUTE;
+# -MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 3, 4);
+# -MVM_NO_RETURN void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args) MVM_NO_RETURN_ATTRIBUTE;
+# +MVM_PUBLIC void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_FORMAT(printf, 2, 3);
+# +void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args);
+# +MVM_PUBLIC void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) MVM_FORMAT(printf, 3, 4);
+# +void MVM_exception_throw_adhoc_free_va(MVMThreadContext *tc, char **waste, const char *messageFormat, va_list args);
+#  MVM_PUBLIC void MVM_crash_on_error(void);
+#  char * MVM_exception_backtrace_line(MVMThreadContext *tc, MVMFrame *cur_frame, MVMuint16 not_top, MVMuint8 *throw_address);
+#  MVMint32 MVM_get_exception_category(MVMThreadContext *tc, MVMObject *ex);
+# diff --git a/src/strings/uthash.h b/src/strings/uthash.h
+# index 7186c87e9..bbb3b4d34 100644
+# --- a/src/strings/uthash.h
+# +++ b/src/strings/uthash.h
+# @@ -223,7 +223,7 @@ MVM_STATIC_INLINE MVMuint32 ptr_hash_32_to_32(MVMuint32 u) {
+#  #ifndef ROTL
+#  #define ROTL(x, b) ( ((x) << (b)) | ( (x) >> ((sizeof(x)*8) - (b))) )
+#  #endif
+# -MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
+# +MVM_PUBLIC void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_FORMAT(printf, 2, 3);
+#  MVM_STATIC_INLINE void HASH_MAKE_TABLE(MVMThreadContext *tc, void *head, UT_hash_handle *head_hh) {
+#      head_hh->tbl = (UT_hash_table*)uthash_malloc_zeroed(tc, sizeof(UT_hash_table));
+#      head_hh->tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;
+
+
+# We'll implement this as a custom pass, to be called directly after the
+# builtin 'cfg' pass, which generates the CFG:
+
+def collect_control_flows(bb, path, seen):
+    if bb.index in seen:
+        seen[bb.index] = 2
+    else:
+        seen[bb.index] = 1
+    paths = []
+    new_path = [bb]
+    new_path.extend(path)
+    if not bb.preds:
+        paths.append(new_path)
+    for edge in bb.preds:
+        pred = edge.src
+        if pred.index in seen and seen[pred.index] > 1:
+            continue
+        paths.extend(collect_control_flows(pred, new_path, seen))
+    return paths
+
+#alloc_funcs = {'MVM_string_utf8_c8_encode_C_string'} # currently adding this causes a segfault in gcc when compiling src/io/filewatchers.c
+alloc_funcs = {'MVM_malloc', 'MVM_calloc', 'MVM_fixed_size_allocate', 'MVM_fixed_size_allocate_zeroed', 'ANSIToUTF8', 'MVM_bytecode_dump', 'MVM_exception_backtrace_line', 'MVM_nativecall_unmarshal_string', 'MVM_reg_get_debug_name', 'MVM_serialization_read_cstr', 'MVM_spesh_dump', 'MVM_spesh_dump_arg_guard', 'MVM_spesh_dump_planned', 'MVM_spesh_dump_stats', 'MVM_staticframe_file_location', 'MVM_string_ascii_encode', 'MVM_string_ascii_encode_any', 'MVM_string_ascii_encode_substr', 'MVM_string_encode', 'MVM_string_encoding_cname', 'MVM_string_gb18030_encode_substr', 'MVM_string_gb2312_encode_substr', 'MVM_string_latin1_encode', 'MVM_string_latin1_encode_substr', 'MVM_string_shiftjis_encode_substr', 'MVM_string_utf16_encode', 'MVM_string_utf16_encode_substr', 'MVM_string_utf16_encode_substr_main', 'MVM_string_utf16be_encode_substr', 'MVM_string_utf16le_encode_substr', 'MVM_string_utf8_c8_encode', 'MVM_string_utf8_c8_encode_substr', 'MVM_string_utf8_encode', 'MVM_string_utf8_encode_C_string', 'MVM_string_utf8_encode_substr', 'MVM_string_utf8_maybe_encode_C_string', 'MVM_string_windows1251_encode_substr', 'MVM_string_windows1252_encode_substr', 'MVM_string_windows125X_encode_substr', 'NFG_check_make_debug_string', 'NFG_checker', 'UnicodeToUTF8', 'UnicodeToUTF8', 'base64_encode', 'callback_handler', 'get_signature_char', 'twoway_memmem_uint32', 'u64toa_naive_worker'}
+free_funcs = {'MVM_free', 'MVM_free_null', 'MVM_fixed_size_free', 'MVM_fixed_size_free_at_safepoint'}
+
+def check_code_for_throw_without_free(fun):
+    for bb in fun.cfg.basic_blocks:
+        for ins in bb.gimple:
+            if isinstance(ins, gcc.GimpleReturn):
+                cfs = collect_control_flows(bb, [], {})
+
+                for cf in cfs:
+                    allocs = set()
+                    for bb in cf:
+                        for ins in bb.gimple:
+                            if isinstance(ins, gcc.GimpleCall):
+                                if isinstance(ins.fn, gcc.AddrExpr): # plain function call is AddrExpr, other things could be function pointers
+                                    if ins.fn.operand.name in alloc_funcs:
+                                        allocs.add(ins.lhs)
+                                    if ins.fn.operand.name in free_funcs:
+                                        if ins.args[0] in allocs: # there can be false positives because the lhs of the alloc and the argument to the free can get different temp names from gcc
+                                            allocs.remove(ins.args[0])
+                                    if ins.fn.operand.name == 'MVM_exception_throw_adhoc':
+                                        if allocs:
+                                            print('\nPossible missing free before a throw in ' + str(fun.decl.name) + ' at ' + str(cf[-2].gimple[-1].loc) + ', things that might need to be freed: ' + str(allocs) + '\n')
+
+class CheckThrowWithoutFree(gcc.GimplePass):
+    def execute(self, fun):
+        # (the CFG should be set up by this point, and the GIMPLE is not yet
+        # in SSA form)
+        if fun and fun.cfg:
+            check_code_for_throw_without_free(fun)
+
+ps = CheckThrowWithoutFree(name='check-throw-without-free')
+ps.register_after('cfg')


### PR DESCRIPTION
And fix the things it found.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.