### PR TITLE
Fixarrays

### DIFF
--- a/src/6model/reprs/CArray.h
+++ b/src/6model/reprs/CArray.h
@@ -18,6 +18,9 @@ struct MVMCArrayBody {
     /* The number of elements we have, if known. Invalid if we
      * are not managing the array. */
     MVMint32 elems;
+
+    /* The number of elements for inlined/fixed-size arrays. == -1 if not inlined*/
+    MVMint32 fixed_cnt;
 };
 
 struct MVMCArray {

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -433,7 +433,6 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
         for (i = 0; repr_data->initialize_slots[i] >= 0; i++) {
             MVMint32 slot = repr_data->initialize_slots[i];
             MVMint32  offset = repr_data->struct_offsets[slot];
-            /*MVMSTable *st     = repr_data->flattened_stables[slot];*/
             MVMSTable *st     = repr_data->member_types[i]->st;
 
             //make the array
@@ -505,8 +504,6 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 if (!obj) {
                     /* No cached object. */
                     MVMROOT(tc, root, {
-                    /*do {*/
-                    /*MVM_gc_root_temp_push(tc, (MVMCollectable **)&(root));*/
                         //make it if it's inlined
                         if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED) {
                             if (type == MVM_CSTRUCT_ATTR_CARRAY) {
@@ -559,7 +556,6 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                             }
                         }
                     });
-                    /*} while (0);*/
                     MVM_ASSIGN_REF(tc, &(root->header), ((MVMCStruct*)root)->body.child_objs[real_slot], obj);
                     }
                 result_reg->o = obj;

--- a/src/6model/reprs/CStruct.h
+++ b/src/6model/reprs/CStruct.h
@@ -81,6 +81,9 @@ struct MVMCStructREPRData {
     /* Slots holding flattened objects that need another REPR to initialize
      * them; terminated with -1. */
     MVMint32 *initialize_slots;
+
+    /* Stores the number of elements in inlined arrays */
+    MVMint64 *dimensions;
 };
 
 /* Initializes the CStruct REPR. */


### PR DESCRIPTION
This is not a real pr and you shouldn't commit it.

This script should show what I'm talking about. 
```
use NativeCall;
my $offset = 0;
my $buf = 'putsomethinghere'.IO.slurp(:bin);
use BUILDPLAN;
class Elf64_Ehdr is repr('CStruct') {
    HAS uint8  @.e_ident[16] is CArray;
    has uint16 $.e_type;
    has uint16 $.e_machine;
    has uint32 $.e_version;
    has uint64 $.e_entry;
    has uint64 $.e_phoff;
    has uint64 $.e_shoff;
    has uint32 $.e_flags;
    has uint16 $.e_ehsize;
    has uint16 $.e_phentsize;
    has uint16 $.e_phnum;
    has uint16 $.e_shentsize;
    has uint16 $.e_shnum;
    has uint16 $.e_shstrndx;
    submethod TWEAK() {
        for ^16 { @!e_ident[$_] = $buf.read-uint8($offset); $offset += 1;}
        $!e_type = $buf.read-uint16($offset); $offset += 2;
        $!e_machine = $buf.read-uint16($offset); $offset += 2;
        $!e_version = $buf.read-uint32($offset); $offset += 4;
        $!e_entry = $buf.read-uint32($offset); $offset += 4;
        $!e_phoff = $buf.read-uint32($offset); $offset += 4;
        $!e_shoff = $buf.read-uint32($offset); $offset += 4;
        $!e_flags = $buf.read-uint32($offset); $offset += 4;
        $!e_ehsize = $buf.read-uint16($offset); $offset += 2;
        $!e_phentsize = $buf.read-uint16($offset); $offset += 2;
        $!e_phnum = $buf.read-uint16($offset); $offset += 2;
        $!e_shentsize = $buf.read-uint16($offset); $offset += 2;
        $!e_shnum = $buf.read-uint16($offset); $offset += 2;
        $!e_shstrndx = $buf.read-uint16($offset); $offset += 2;
    }
}

use BUILDPLAN Elf64_Ehdr;
for ^100 {
    my $t = Elf64_Ehdr.new();
    say $t.e_ident.perl;
    say $t.e_ident.elems;
    say $_~': '~$t.e_version;
}
say 'done';

```

