### PR TITLE
Inlined CArray issues

### DIFF
--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -92,6 +92,16 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
     if (!repr_data)
         MVM_exception_throw_adhoc(tc, "CArray type must be composed before use");
 
+    /* This block handles inlined arrays. Everything else is already done */
+    if (body->fixed_cnt > 0) {
+        /* Don't need child_objs for numerics. */
+        if (repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_NUMERIC)
+            body->child_objs = NULL;
+        else
+            body->child_objs = (MVMObject **) MVM_calloc(body->fixed_cnt, sizeof(MVMObject *));
+        return;
+    }
+
     body->storage = MVM_calloc(4, repr_data->elem_size);
     body->managed = 1;
 
@@ -196,6 +206,10 @@ static void die_pos_nyi(MVMThreadContext *tc) {
 
 
 static void expand(MVMThreadContext *tc, MVMCArrayREPRData *repr_data, MVMCArrayBody *body, MVMint32 min_size) {
+    if (body->fixed_cnt > 0) {
+        MVM_exception_throw_adhoc(tc,
+        "Cannot expand CArray declared with fixed size.");
+    }
     MVMint8 is_complex;
     MVMint32 next_size = body->allocated? 2 * body->allocated: 4;
 
@@ -429,7 +443,7 @@ static void aslice(MVMThreadContext *tc, MVMSTable *st, MVMObject *src, void *da
 static MVMuint64 elems(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data) {
     MVMCArrayBody *body = (MVMCArrayBody *)data;
 
-    if (body->managed)
+    if (body->managed || body->fixed_cnt > 0)
         return body->elems;
 
     MVM_exception_throw_adhoc(tc,

--- a/src/6model/reprs/CArray.h
+++ b/src/6model/reprs/CArray.h
@@ -18,6 +18,9 @@ struct MVMCArrayBody {
     /* The number of elements we have, if known. Invalid if we
      * are not managing the array. */
     MVMint32 elems;
+
+    /* The number of elements for inlined/fixed-size arrays.*/
+    MVMint32 fixed_cnt;
 };
 
 struct MVMCArray {

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -148,6 +148,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
         repr_data->flattened_stables   = (MVMSTable **) MVM_calloc(info_alloc, sizeof(MVMObject *));
         repr_data->member_types        = (MVMObject **) MVM_calloc(info_alloc, sizeof(MVMObject *));
         repr_data->struct_align        = 0;
+        repr_data->dimensions          = (MVMint64 *)   MVM_calloc(info_alloc, sizeof(MVMint64));
 
         /* Go over the attributes and arrange their allocation. */
         for (i = 0; i < num_attrs; i++) {
@@ -167,7 +168,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
             if (num_dimensions > 1) {
                 MVM_gc_allocate_gen2_default_clear(tc);
                 MVM_exception_throw_adhoc(tc,
-                    "Only one dimensions supported in CStruct attribute");
+                    "Only one dimension supported in CStruct attributes");
             }
 
             if (!MVM_is_null(tc, type)) {
@@ -226,6 +227,8 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                         if (num_dimensions > 0) {
                             MVMint64 dim_one     =  MVM_repr_at_pos_i(tc, dimensions, 0);
                             MVMObject *elem_type = carray_repr_data->elem_type;
+                            // Saving array size so we can initialize it later
+                            repr_data->dimensions[i] = dim_one;
 
                             // How do we distinguish between these members:
                             // a) struct  foo [32] alias;
@@ -244,6 +247,10 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                                 bits  = bits * dim_one;
                             }
                         }
+                        if (!repr_data->initialize_slots)
+                            repr_data->initialize_slots = (MVMint32 *) MVM_calloc(info_alloc + 1, sizeof(MVMint32));
+                        repr_data->initialize_slots[cur_init_slot] = i;
+                        cur_init_slot++;
                     }
                 }
                 else if (type_id == MVM_REPR_ID_MVMCStruct) {
@@ -421,8 +428,25 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
     if (repr_data->initialize_slots) {
         MVMint32 i;
         for (i = 0; repr_data->initialize_slots[i] >= 0; i++) {
-            MVMint32  offset = repr_data->struct_offsets[repr_data->initialize_slots[i]];
-            MVMSTable *st     = repr_data->flattened_stables[repr_data->initialize_slots[i]];
+            MVMint32 slot = repr_data->initialize_slots[i];
+            MVMint32  offset = repr_data->struct_offsets[slot];
+            MVMSTable *st     = repr_data->member_types[i]->st;
+
+            //make the array
+            if (st->REPR->ID == MVM_REPR_ID_MVMCArray) {
+                if (repr_data->dimensions[slot]) {
+                    void* storage = (void*)((char *)body->cstruct + offset);
+                    MVMObject *typeobj = repr_data->member_types[slot];
+                    MVMCArray *result = (MVMCArray*)MVM_nativecall_make_carray(tc, typeobj, storage);
+                    body->child_objs[slot] = (MVMObject*)result;
+                    result->body.allocated = repr_data->dimensions[slot];
+                    result->body.elems = repr_data->dimensions[slot];
+                    result->body.fixed_cnt = repr_data->dimensions[slot];
+                    result->body.managed = 0;
+                    st->REPR->initialize(tc, st, root, (void*)&(result->body));
+                    continue;
+                }
+            }
             st->REPR->initialize(tc, st, root, (char *)body->cstruct + offset);
         }
     }
@@ -803,6 +827,7 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
     for(i = 0; i < repr_data->num_attributes; i++){
         MVM_serialization_write_int(tc, writer, repr_data->attribute_locations[i]);
         MVM_serialization_write_int(tc, writer, repr_data->struct_offsets[i]);
+        MVM_serialization_write_int(tc, writer, repr_data->dimensions[i]);
 
         MVM_serialization_write_int(tc, writer, repr_data->flattened_stables[i] != NULL);
         if (repr_data->flattened_stables[i])
@@ -847,10 +872,12 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     repr_data->struct_offsets      = (MVMint32 *)MVM_malloc(sizeof(MVMint32) * repr_data->num_attributes);
     repr_data->flattened_stables   = (MVMSTable **)MVM_malloc(repr_data->num_attributes * sizeof(MVMSTable *));
     repr_data->member_types        = (MVMObject **)MVM_malloc(repr_data->num_attributes * sizeof(MVMObject *));
+    repr_data->dimensions          = (MVMint64 *)   MVM_malloc(repr_data->num_attributes * sizeof(MVMint64));
 
     for(i = 0; i < repr_data->num_attributes; i++) {
         repr_data->attribute_locations[i] = MVM_serialization_read_int(tc, reader);
         repr_data->struct_offsets[i] = MVM_serialization_read_int(tc, reader);
+        repr_data->dimensions[i] = MVM_serialization_read_int(tc, reader);
 
         if(MVM_serialization_read_int(tc, reader)){
             MVM_ASSIGN_REF(tc, &(st->header), repr_data->flattened_stables[i], MVM_serialization_read_stable_ref(tc, reader));

--- a/src/6model/reprs/CStruct.h
+++ b/src/6model/reprs/CStruct.h
@@ -81,6 +81,9 @@ struct MVMCStructREPRData {
     /* Slots holding flattened objects that need another REPR to initialize
      * them; terminated with -1. */
     MVMint32 *initialize_slots;
+
+    /* Stores the number of elements in inlined arrays */
+    MVMint64 *dimensions;
 };
 
 /* Initializes the CStruct REPR. */


### PR DESCRIPTION
Apologies to niner for my poor git hygeine. 

This is my partial attempt at fixing an issue with inlined CArrays and CArray autoexpansion. The script below will crash. I recommend running it under asan as it clearly shows the root cause.  

When initialized in this fashion, the CArray knows nothing of it's shape and allocates space for 4 elements by default. It's also unaware that it's inlined. When you assign the third element, it auto expands. CArray:expand() calls realloc, and this eventually kills the process. 

CStruct:Compose() is the only place we have access to the shape of the inlined array, so my solution is to save that information in MVMCStructREPRData. When the outer CStruct is initialized, it initializes any inlined CArrays as if they were returned from C. 

I've also added a member 'fixed_cnt' to MVMCArrayBody for storing the fixed number of elements for inlined arrays. It serves as a flag for changing behavior in initialize(), expand(), and elems(). 

This all seems to work pretty well on its own, but it doesn't work well with rakudo. The buildplan generated by rakudo/src/Perl6/Metamodel/BUILDPLAN.nqp initializes the array for a second time, undoing all my hard work :(

I'm out of my element with rakudo,nqp, etc., so I humbly submit this pr in hopes that someone who knows about such things can help fix it. 

In the meantime, if inlined arrays are bringing you down, I've had good results replacing them with CStructs that do `Positional` and hardcoding the number of elements. 


```
use NativeCall;
my $offset = 0;
my $buf = 'putsomethinghere'.IO.slurp(:bin);
class Elf64_Ehdr is repr('CStruct') {
    HAS uint8  @.e_ident[16] is CArray;
    has uint16 $.e_type;
    has uint16 $.e_machine;
    has uint32 $.e_version;
    has uint64 $.e_entry;
    has uint64 $.e_phoff;
    has uint64 $.e_shoff;
    has uint32 $.e_flags;
    has uint16 $.e_ehsize;
    has uint16 $.e_phentsize;
    has uint16 $.e_phnum;
    has uint16 $.e_shentsize;
    has uint16 $.e_shnum;
    has uint16 $.e_shstrndx;
    submethod TWEAK() {
        for ^16 { @!e_ident[$_] = $buf.read-uint8($offset); $offset += 1;}
        $!e_type = $buf.read-uint16($offset); $offset += 2;
        $!e_machine = $buf.read-uint16($offset); $offset += 2;
        $!e_version = $buf.read-uint32($offset); $offset += 4;
        $!e_entry = $buf.read-uint32($offset); $offset += 4;
        $!e_phoff = $buf.read-uint32($offset); $offset += 4;
        $!e_shoff = $buf.read-uint32($offset); $offset += 4;
        $!e_flags = $buf.read-uint32($offset); $offset += 4;
        $!e_ehsize = $buf.read-uint16($offset); $offset += 2;
        $!e_phentsize = $buf.read-uint16($offset); $offset += 2;
        $!e_phnum = $buf.read-uint16($offset); $offset += 2;
        $!e_shentsize = $buf.read-uint16($offset); $offset += 2;
        $!e_shnum = $buf.read-uint16($offset); $offset += 2;
        $!e_shstrndx = $buf.read-uint16($offset); $offset += 2;
    }
}

use BUILDPLAN Elf64_Ehdr;
for ^100 {
    my $t = Elf64_Ehdr.new();
    #say $t.e_ident.perl;
    #say $t.e_ident.elems;
    say $_~': '~$t.e_version;
}
say 'done';
```
