### PR TITLE
Fix CStruct handling of inlined attributes

### DIFF
--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -476,54 +476,60 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 MVMObject *obj     = body->child_objs[real_slot];
                 if (!obj) {
                     /* No cached object. */
-                    void *cobj = get_ptr_at_offset(body->cstruct, repr_data->struct_offsets[slot]);
-                    if (cobj) {
-                        MVMROOT(tc, root, {
+                    MVMROOT(tc, root, {
+                        //make it if it's inlined
+                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED) {
                             if (type == MVM_CSTRUCT_ATTR_CARRAY) {
-                                if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                    obj = MVM_nativecall_make_carray(tc, typeobj,
-                                        (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                                else
-                                    obj = MVM_nativecall_make_carray(tc, typeobj, cobj);
+                                obj = MVM_nativecall_make_carray(tc, typeobj,
+                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
                             }
-                            else if(type == MVM_CSTRUCT_ATTR_CSTRUCT) {
-                                if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                    obj = MVM_nativecall_make_cstruct(tc, typeobj,
-                                        (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                                else
-                                    obj = MVM_nativecall_make_cstruct(tc, typeobj, cobj);
+                            else if (type == MVM_CSTRUCT_ATTR_CSTRUCT) {
+                                obj = MVM_nativecall_make_cstruct(tc, typeobj,
+                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
                             }
-                            else if(type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
-                                if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                    obj = MVM_nativecall_make_cppstruct(tc, typeobj,
-                                        (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                                else
-                                    obj = MVM_nativecall_make_cppstruct(tc, typeobj, cobj);
+                            else if (type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
+                                obj = MVM_nativecall_make_cppstruct(tc, typeobj,
+                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
                             }
-                            else if(type == MVM_CSTRUCT_ATTR_CUNION) {
-                                if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                                    obj = MVM_nativecall_make_cunion(tc, typeobj,
-                                        (char *)body->cstruct + repr_data->struct_offsets[slot]);
-                                else
-                                    obj = MVM_nativecall_make_cunion(tc, typeobj, cobj);
+                            else if (type == MVM_CSTRUCT_ATTR_CUNION) {
+                                obj = MVM_nativecall_make_cunion(tc, typeobj,
+                                    (char *)body->cstruct + repr_data->struct_offsets[slot]);
                             }
-                            else if(type == MVM_CSTRUCT_ATTR_CPTR) {
-                                obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
+                        }
+                        else {
+                            void *cobj = get_ptr_at_offset(body->cstruct, repr_data->struct_offsets[slot]);
+                            //make it if it's not inlined
+                            if (cobj) {
+                                if (type == MVM_CSTRUCT_ATTR_CARRAY) {
+                                        obj = MVM_nativecall_make_carray(tc, typeobj, cobj);
+                                }
+                                else if(type == MVM_CSTRUCT_ATTR_CSTRUCT) {
+                                        obj = MVM_nativecall_make_cstruct(tc, typeobj, cobj);
+                                }
+                                else if(type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
+                                        obj = MVM_nativecall_make_cppstruct(tc, typeobj, cobj);
+                                }
+                                else if(type == MVM_CSTRUCT_ATTR_CUNION) {
+                                        obj = MVM_nativecall_make_cunion(tc, typeobj, cobj);
+                                }
+                                else if(type == MVM_CSTRUCT_ATTR_CPTR) {
+                                    obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
+                                }
+                                else if(type == MVM_CSTRUCT_ATTR_STRING) {
+                                    MVMROOT2(tc, typeobj, root, {
+                                        MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
+                                            cobj, strlen(cobj));
+                                        obj = MVM_repr_box_str(tc, typeobj, str);
+                                    });
+                                }
                             }
-                            else if(type == MVM_CSTRUCT_ATTR_STRING) {
-                                MVMROOT2(tc, typeobj, root, {
-                                    MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
-                                        cobj, strlen(cobj));
-                                    obj = MVM_repr_box_str(tc, typeobj, str);
-                                });
+                            else {
+                                obj = typeobj;
                             }
-                        });
-                        MVM_ASSIGN_REF(tc, &(root->header), ((MVMCStruct*)root)->body.child_objs[real_slot], obj);
+                        }
+                    });
+                    MVM_ASSIGN_REF(tc, &(root->header), ((MVMCStruct*)root)->body.child_objs[real_slot], obj);
                     }
-                    else {
-                        obj = typeobj;
-                    }
-                }
                 result_reg->o = obj;
             }
             break;


### PR DESCRIPTION
When calling CStruct.c:get_attribute, inlined attributes are mishandled and treated as pointers. This causes bizarre behavior like like returning type objects for defined attributes, returning incorrect integer values that are clearly pointers, etc. Cunions had an identical issue that was fixed some time ago. This change just adds the fix to CStructs, so there isn't really any "new" code here.

It passes rakudo and nqp test suites. Running them under asan doesn't add new issues. This change resolves at least the following open issues.

https://github.com/rakudo/rakudo/issues/3633
https://github.com/rakudo/rakudo/issues/3192

A summary:

In MVMCStructBody, `child_objs` is an array of pointers to MVMObjects (the struct's attributes). From the comments: /* GC-marked objects that our C structure points into. */

When `CStruct.c:get_attribute` is called, the relevant pointer in `child_objs` is checked, and the object is built if it's null. Inlined attributes should be handled differently, but they are not. The only difference in handling inlined vs non-inlined attributes is in the last argument passed to `MVM_nativecall_make_c*`. The last arg is a pointer to the actual content of whatever it's making. For inlined attributes, this should point somewhere inside the cstruct, and it should point somewhere else for non-inlined attributes. "Somewhere else" is `void *cobj = get_ptr_at_offset(body->cstruct, repr_data->struct_offsets[slot]);`.

Currently, that last argument always points somewhere else, which causes the issues mentioned in the first paragraph.

From looking at the source, CPPStruct.c has the same issue, though I've never experienced it as I've never used them. If this gets committed, I can test it and fix it there in another pr.