### PR TITLE
Remove Perl 5.10 directive from Travi config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: "perl"
 os:
   - linux
   - osx
-perl:
-  - "5.10"
 # Do a full clone to be sure we get the tags and can properly retrieve version
 git:
   depth: false


### PR DESCRIPTION
The download and subsequent using of it with perlbrew fails and Travis
just uses the system Perl 5.(22 with 16.04, or 26 with 18.04).