### PR TITLE
Fix reading closed dir handles on Windows

### DIFF
--- a/src/io/dirops.c
+++ b/src/io/dirops.c
@@ -293,7 +293,10 @@ MVMString * MVM_dir_read(MVMThreadContext *tc, MVMObject *oshandle) {
     WIN32_FIND_DATAW ffd;
     char *dir_str;
 
-    if (data->dir_handle == INVALID_HANDLE_VALUE) {
+    if (!data->dir_handle) {
+        MVM_exception_throw_adhoc(tc, "Cannot read a closed dir handle.");
+    }
+    else if (data->dir_handle == INVALID_HANDLE_VALUE) {
         HANDLE hFind = FindFirstFileW(data->dir_name, &ffd);
 
         if (hFind == INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
We need to throw an exception when the handle is closed and not pass null
to `FindFirstFileW()` which resulted in a silent death of Moar. This makes
an NQP test pass that previously silently killed NQP during the test.