### PR TITLE
Use correct encoding for deserializing strings

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2161,11 +2161,11 @@ static void resolve_dependencies(MVMThreadContext *tc, MVMSerializationReader *r
         sc = MVM_sc_find_by_handle(tc, handle);
         if (sc == NULL) {
             MVMString *desc = read_string_from_heap(tc, reader, read_int32(table_pos, 4));
-            char *cname = MVM_string_ascii_encode(tc, desc, NULL, 0);
+            char *cname = MVM_string_utf8_c8_encode_C_string(tc, desc);
             char *cdesc = NULL;
             char *waste[] = { cname, NULL, NULL };
             if (reader->root.sc->body->description) {
-                cdesc = MVM_string_ascii_encode(tc, reader->root.sc->body->description, NULL, 0);
+                cdesc = MVM_string_utf8_encode_C_string(tc, reader->root.sc->body->description);
                 waste[1] = cdesc;
             }
             else {


### PR DESCRIPTION
A string could be a filename, which are the classic example of something
that could have non-ASCII and/or non-UTF8 bytes, so use utf8-c8 to
encode them.

Also, every other use of an SC's body->description is via
MVM_string_utf8_encode_C_string, make that change also.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.