### PR TITLE
Simplify some MVM_string_ascii_encode calls

### DIFF
--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -242,7 +242,7 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
         body->u.smallint.value = MVM_serialization_read_int(tc, reader);
     } else {  /* big int */
         mp_err err;
-        char *buf = MVM_string_ascii_encode(tc, MVM_serialization_read_str(tc, reader), NULL, 0);
+        char *buf = MVM_string_ascii_encode_any(tc, MVM_serialization_read_str(tc, reader));
         body->u.bigint = MVM_malloc(sizeof(mp_int));
         if ((err = mp_init(body->u.bigint)) != MP_OKAY) {
             MVM_free(body->u.bigint);

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -1991,7 +1991,7 @@ static void check_and_dissect_input(MVMThreadContext *tc,
     char   *data_end;
     if (data_str) {
         /* Grab data from string. */
-        char *data_b64 = (char *)MVM_string_ascii_encode(tc, data_str, NULL, 0);
+        char *data_b64 = (char *)MVM_string_ascii_encode_any(tc, data_str);
         data = (char *)base64_decode(data_b64, &data_len);
         MVM_free(data_b64);
         reader->data_needs_free = 1;
@@ -2666,7 +2666,7 @@ static void deserialize_stable(MVMThreadContext *tc, MVMSerializationReader *rea
         MVMString *name = MVM_serialization_read_str(tc, reader);
         const MVMContainerConfigurer *cc = MVM_6model_get_container_config(tc, name);
         if (!cc) {
-            char *cname = MVM_string_ascii_encode(tc, name, NULL, 0);
+            char *cname = MVM_string_ascii_encode_any(tc, name);
             char *waste[] = { cname, NULL };
             fail_deserialize(tc, waste, reader, "Could not look up the container config for '%s'",
                 cname);

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -325,7 +325,7 @@ void MVM_coerce_smart_stringify(MVMThreadContext *tc, MVMObject *obj, MVMRegiste
 }
 
 MVMint64 MVM_coerce_s_i(MVMThreadContext *tc, MVMString *s) {
-    char     *enc = MVM_string_ascii_encode(tc, s, NULL, 0);
+    char     *enc = MVM_string_ascii_encode_any(tc, s);
     MVMint64  i   = strtoll(enc, NULL, 10);
     MVM_free(enc);
     return i;


### PR DESCRIPTION
MVM_string_ascii_encode_any just calls MVM_string_ascii_encode with NULL
and 0 for the last two arguments, so use it.

Passes NQP and Rakudo tests.