### PR TITLE
Prefer lexical names list

### DIFF
--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -363,3 +363,9 @@ char * MVM_staticframe_file_location(MVMThreadContext *tc, MVMStaticFrame *sf) {
         MVM_free(filename_utf8);
     return result;
 }
+
+MVMLexicalRegistry *MVM_get_lexical_by_name(MVMThreadContext *tc, MVMStaticFrame *sf, MVMString *name) {
+    MVMLexicalRegistry *entry;
+    MVM_HASH_GET(tc, sf->body.lexical_names, name, entry);
+    return entry;
+}

--- a/src/6model/reprs/MVMStaticFrame.h
+++ b/src/6model/reprs/MVMStaticFrame.h
@@ -154,3 +154,5 @@ const MVMREPROps * MVMStaticFrame_initialize(MVMThreadContext *tc);
 
 /* Debugging help. */
 char * MVM_staticframe_file_location(MVMThreadContext *tc, MVMStaticFrame *sf);
+
+MVMLexicalRegistry *MVM_get_lexical_by_name(MVMThreadContext *tc, MVMStaticFrame *sf, MVMString *name);

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -274,37 +274,33 @@ MVMObject * MVM_nativeref_lex_s(MVMThreadContext *tc, MVMuint16 outers, MVMuint1
 static MVMObject * lexref_by_name(MVMThreadContext *tc, MVMObject *type, MVMString *name, MVMint16 kind) {
     MVMFrame *cur_frame = tc->cur_frame;
     while (cur_frame != NULL) {
-        MVMLexicalRegistry *lexical_names = cur_frame->static_info->body.lexical_names;
-        if (lexical_names) {
-            MVMLexicalRegistry *entry;
-            MVM_HASH_GET(tc, lexical_names, name, entry)
-            if (entry) {
-                MVMint16 lex_kind = cur_frame->static_info->body.lexical_types[entry->value];
-                if (lex_kind == kind) {
-                    return lex_ref(tc, type, cur_frame, entry->value, kind);
+        MVMLexicalRegistry *entry = MVM_get_lexical_by_name(tc, cur_frame->static_info, name);
+        if (entry) {
+            MVMint16 lex_kind = cur_frame->static_info->body.lexical_types[entry->value];
+            if (lex_kind == kind) {
+                return lex_ref(tc, type, cur_frame, entry->value, kind);
+            }
+            /* If kind == LEXREF_ANY_INT we will allow any of the native int
+             * types so we don't need functions for every single type. */
+            else if (kind == LEXREF_ANY_INT) {
+                switch (lex_kind) {
+                case MVM_reg_int8:
+                case MVM_reg_int16:
+                case MVM_reg_int32:
+                case MVM_reg_int64:
+                case MVM_reg_uint8:
+                case MVM_reg_uint16:
+                case MVM_reg_uint32:
+                case MVM_reg_uint64:
+                    return lex_ref(tc, type, cur_frame, entry->value, lex_kind);
                 }
-                /* If kind == LEXREF_ANY_INT we will allow any of the native int
-                 * types so we don't need functions for every single type. */
-                else if (kind == LEXREF_ANY_INT) {
-                    switch (lex_kind) {
-                        case MVM_reg_int8:
-                        case MVM_reg_int16:
-                        case MVM_reg_int32:
-                        case MVM_reg_int64:
-                        case MVM_reg_uint8:
-                        case MVM_reg_uint16:
-                        case MVM_reg_uint32:
-                        case MVM_reg_uint64:
-                            return lex_ref(tc, type, cur_frame, entry->value, lex_kind);
-                    }
-                }
-                {
-                    char *c_name = MVM_string_utf8_encode_C_string(tc, name);
-                    char *waste[] = { c_name, NULL };
-                    MVM_exception_throw_adhoc_free(tc, waste,
-                        "Lexical with name '%s' has wrong type. real type %i wanted type %i",
-                            c_name, cur_frame->static_info->body.lexical_types[entry->value], kind);
-                }
+            }
+            {
+                char *c_name = MVM_string_utf8_encode_C_string(tc, name);
+                char *waste[] = { c_name, NULL };
+                MVM_exception_throw_adhoc_free(tc, waste,
+                    "Lexical with name '%s' has wrong type. real type %i wanted type %i",
+                        c_name, cur_frame->static_info->body.lexical_types[entry->value], kind);
             }
         }
         cur_frame = cur_frame->outer;

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -496,9 +496,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVMuint8 found = 0;
                     if (!sf->body.fully_deserialized)
                         MVM_bytecode_finish_frame(tc, sf->body.cu, sf, 0);
-                    if (sf->body.lexical_names) {
-                        MVMLexicalRegistry *entry;
-                        MVM_HASH_GET(tc, sf->body.lexical_names, name, entry);
+                    if (sf->body.num_lexicals) {
+                        MVMLexicalRegistry *entry = MVM_get_lexical_by_name(tc, sf, name);
                         if (entry && sf->body.lexical_types[entry->value] == MVM_reg_obj) {
                             MVM_ASSIGN_REF(tc, &(sf->common.header), sf->body.static_env[entry->value].o, val);
                             sf->body.static_env_flags[entry->value] = (MVMuint8)flag;

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1423,21 +1423,19 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
     }
 
     static_info = frame->static_info;
-    lexical_names = static_info->body.lexical_names;
     MVMuint32 num_lexicals = static_info->body.num_lexicals;
     debug_locals = static_info->body.instrumentation
         ? static_info->body.instrumentation->debug_locals
         : NULL;
     if (num_lexicals || debug_locals) {
-        MVMLexicalRegistry *entry;
         MVMStaticFrameDebugLocal *debug_entry;
         MVMuint64 lexical_index = 0;
 
         /* Count up total number of symbols; that is, the lexicals plus the
          * debug names where the names to not overlap with the lexicals. */
-        MVMuint64 lexcount = static_info->body.num_lexicals;
+        MVMuint64 lexcount = num_lexicals;
         HASH_ITER(dtc, hash_handle, debug_locals, debug_entry, {
-            MVM_HASH_GET(dtc, lexical_names, debug_entry->name, entry);
+            MVMLexicalRegistry *entry = MVM_get_lexical_by_name(dtc, static_info, debug_entry->name);
             if (!entry)
                 lexcount++;
         });
@@ -1489,7 +1487,7 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
         };
 
         HASH_ITER(dtc, hash_handle, debug_locals, debug_entry, {
-            MVM_HASH_GET(dtc, lexical_names, debug_entry->name, entry);
+            MVMLexicalRegistry *entry = MVM_get_lexical_by_name(dtc, static_info, debug_entry->name);
             if (!entry) {
                 char *c_key_name = MVM_string_utf8_encode_C_string(dtc, debug_entry->name);
                 MVMRegister *result = &frame->work[debug_entry->local_idx];

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1424,10 +1424,11 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
 
     static_info = frame->static_info;
     lexical_names = static_info->body.lexical_names;
+    MVMuint32 num_lexicals = static_info->body.num_lexicals;
     debug_locals = static_info->body.instrumentation
         ? static_info->body.instrumentation->debug_locals
         : NULL;
-    if (lexical_names || debug_locals) {
+    if (num_lexicals || debug_locals) {
         MVMLexicalRegistry *entry;
         MVMStaticFrameDebugLocal *debug_entry;
         MVMuint64 lexical_index = 0;
@@ -1453,28 +1454,30 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
         if (dtc->instance->debugserver->debugspam_protocol)
             fprintf(stderr, "will write %"PRIu64" lexicals\n", lexcount);
 
-        HASH_ITER(dtc, hash_handle, lexical_names, entry, {
-            MVMuint16 lextype = static_info->body.lexical_types[entry->value];
-            MVMRegister *result = &frame->env[entry->value];
+        MVMLexicalRegistry **lexical_names_list = static_info->body.lexical_names_list;
+
+        for (MVMuint32 j = 0; j < num_lexicals; j++) {
+            MVMLexicalRegistry *entry = lexical_names_list[j];
+            MVMuint16 lextype = static_info->body.lexical_types[j];
+            MVMRegister *result = &frame->env[j];
             char *c_key_name;
             MVMint32 was_from_local = 0;
-            if (entry->key && IS_CONCRETE(entry->key)) {
-                /* Lexical has a name (should always be the case, really). Check
-                 * there is no debug local override for it (which means the lexical
-                 * was lowered into a local, but preserved for some reason). */
-                c_key_name = MVM_string_utf8_encode_C_string(dtc, entry->key);
-                MVM_HASH_GET_FREE(dtc, debug_locals, entry->key, debug_entry, {
-                    MVM_free(c_key_name);
-                });
-                if (debug_entry && static_info->body.local_types[debug_entry->local_idx] == lextype) {
-                    result = &frame->work[debug_entry->local_idx];
-                    was_from_local = 1;
-                }
+            /* Lexical has to have a name - to get here it has already been added
+               to the lookup hash, and that would have failed unless the key
+               exists and is a concrete MVMString. */
+            assert(entry->key);
+            assert(IS_CONCRETE(entry->key));
+            /* Check there is no debug local override for it (which means the lexical
+             * was lowered into a local, but preserved for some reason). */
+            c_key_name = MVM_string_utf8_encode_C_string(dtc, entry->key);
+            MVM_HASH_GET_FREE(dtc, debug_locals, entry->key, debug_entry, {
+                MVM_free(c_key_name);
+            });
+            if (debug_entry && static_info->body.local_types[debug_entry->local_idx] == lextype) {
+                result = &frame->work[debug_entry->local_idx];
+                was_from_local = 1;
             }
-            else {
-                c_key_name = MVM_malloc(12 + 16);
-                sprintf(c_key_name, "<lexical %"PRIu64">", lexical_index);
-            }
+
             if (!was_from_local && lextype == MVM_reg_obj && !result->o) {
                 /* XXX this can't allocate? */
                 MVM_frame_vivify_lexical(dtc, frame, entry->value);
@@ -1483,7 +1486,7 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
             if (dtc->instance->debugserver->debugspam_protocol)
                 fprintf(stderr, "wrote a lexical\n");
             lexical_index++;
-        });
+        };
 
         HASH_ITER(dtc, hash_handle, debug_locals, debug_entry, {
             MVM_HASH_GET(dtc, lexical_names, debug_entry->name, entry);


### PR DESCRIPTION
The three patches are related, but they all need a little different review.

The first eliminates 5 hash iterations, replacing them with array traversal. It would be a no-brainer, but it affects the debug server, and I don't know how to test that.

I believe that wrapping access to lexical_names makes sense, even if the next patch isn't wanted, but it makes more sense with it

The third patch, eliminating the lookup hash for small lists, should help performance slightly, but

1. I don't have a good way to benchmark this (it doesn't seem to noticeably change setting compilation in any direction)
1. I don't have any feel for what a good threshold is. Are there typically many small frames with just 3 named lexicals? How often do we even do named lexical lookup?
