### PR TITLE
Maybe fix MVM_panic from entering GC during spesh

### DIFF
--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1325,7 +1325,6 @@ static void optimize_getcurhllsym(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpe
         else {
             hll_name = g->sf->body.cu->body.hll_name;
         }
-        MVM_gc_mark_thread_blocked(tc);
         uv_mutex_lock(&tc->instance->mutex_hll_syms);
         hash = MVM_repr_at_key_o(tc, syms, hll_name);
         /* `result = MVM_repr_at_key_o(tc, hash, sym)` from MVM_get_hll_sym,
@@ -1347,14 +1346,12 @@ static void optimize_getcurhllsym(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpe
                     ins->operands = new_operands;
                 }
                 ins->operands[1].lit_i64 = (MVMint64)entry;
-                sym_facts->value.i = (MVMint64)entry;
                 MVM_spesh_use_facts(tc, g, sym_facts);
             }
         }
         else {
             uv_mutex_unlock(&tc->instance->mutex_hll_syms);
         }
-        MVM_gc_mark_thread_unblocked(tc);
     }
 }
 


### PR DESCRIPTION
The `MVM_gc_mark_thread_(un)blocked(tc)` calls were incorrect and caused
`MoarVM panic: Must not GC when in the specializer/JIT` at random times.

However, just removing them changed to causing `MoarVM panic: Invalid
owner in item added to GC worklist`. Setting `MVM_GC_DEBUG` to `3` would
reliably trigger the panic when building NQP. Removing overwriting the
spesh facts fixed this, but I'm not 100% that the rest of the code is
100% correct.

NQP builds correctly and passes `make m-test` and Rakudo builds correcty and passes `make m-test m-spectest`.