### PR TITLE
Fix some possible double frees

### DIFF
--- a/src/6model/reprs/ConditionVariable.c
+++ b/src/6model/reprs/ConditionVariable.c
@@ -111,7 +111,7 @@ MVMObject * MVM_conditionvariable_from_lock(MVMThreadContext *tc, MVMReentrantMu
     });
     cv->body.condvar = MVM_malloc(sizeof(uv_cond_t));
     if ((init_stat = uv_cond_init(cv->body.condvar)) < 0) {
-        MVM_free(cv->body.condvar);
+        MVM_free_null(cv->body.condvar);
         MVM_exception_throw_adhoc(tc, "Failed to initialize condition variable: %s",
             uv_strerror(init_stat));
     }

--- a/src/6model/sc.c
+++ b/src/6model/sc.c
@@ -17,11 +17,12 @@ MVMObject * MVM_sc_create(MVMThreadContext *tc, MVMString *handle) {
             uv_mutex_lock(&tc->instance->mutex_sc_registry);
             MVM_HASH_GET(tc, tc->instance->sc_weakhash, handle, scb);
             if (!scb) {
-                sc->body = scb = MVM_calloc(1, sizeof(MVMSerializationContextBody));
+                scb = MVM_calloc(1, sizeof(MVMSerializationContextBody));
                 MVM_ASSIGN_REF(tc, &(sc->common.header), scb->handle, handle);
                 MVM_HASH_BIND_FREE(tc, tc->instance->sc_weakhash, handle, scb, {
-                    MVM_free_null(sc->body);
+                    MVM_free(scb);
                 });
+                sc->body = scb;
                 /* Calling repr_init will allocate, BUT if it does so, and we
                  * get unlucky, the GC will try to acquire mutex_sc_registry.
                  * This deadlocks. Thus, we force allocation in gen2, which

--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -3,27 +3,28 @@
 /* Decodes the specified number of bytes of ASCII into an NFG string, creating
  * a result of the specified type. The type must have the MVMString REPR. */
 MVMString * MVM_string_ascii_decode(MVMThreadContext *tc, const MVMObject *result_type, const char *ascii, size_t bytes) {
-    MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    MVMString *result;
+    MVMGrapheme32 *buffer = MVM_malloc(sizeof(MVMGrapheme32) * bytes);
     size_t i, result_graphs;
-
-    result->body.storage_type    = MVM_STRING_GRAPHEME_32;
-    result->body.storage.blob_32 = MVM_malloc(sizeof(MVMGrapheme32) * bytes);
 
     result_graphs = 0;
     for (i = 0; i < bytes; i++) {
         if (ascii[i] == '\r' && i + 1 < bytes && ascii[i + 1] == '\n') {
-            result->body.storage.blob_32[result_graphs++] = MVM_nfg_crlf_grapheme(tc);
+            buffer[result_graphs++] = MVM_nfg_crlf_grapheme(tc);
             i++;
         }
         else if (ascii[i] >= 0) {
-            result->body.storage.blob_32[result_graphs++] = ascii[i];
+            buffer[result_graphs++] = ascii[i];
         }
         else {
-            MVM_free(result->body.storage.blob_32);
+            MVM_free(buffer);
             MVM_exception_throw_adhoc(tc,
                 "Will not decode invalid ASCII (code point (%"PRId32") < 0 found)", ascii[i]);
         }
     }
+    result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    result->body.storage.blob_32 = buffer;
+    result->body.storage_type = MVM_STRING_GRAPHEME_32;
     result->body.num_graphs = result_graphs;
 
     return result;

--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -664,7 +664,7 @@ void MVM_string_decode_stream_sep_default(MVMThreadContext *tc, MVMDecodeStreamS
 void MVM_string_decode_stream_sep_from_strings(MVMThreadContext *tc, MVMDecodeStreamSeparators *sep_spec,
                                                MVMString **seps, MVMint32 num_seps) {
     MVMGraphemeIter gi;
-    MVMint32 i, graph_length, graph_pos;
+    MVMint32 i, graph_length, graph_pos, *sep_lengths;
 
     if (num_seps > 0xFFF)
         MVM_exception_throw_adhoc(tc, "Too many line separators (%"PRId32"), max allowed is 4095", num_seps);
@@ -674,17 +674,18 @@ void MVM_string_decode_stream_sep_from_strings(MVMThreadContext *tc, MVMDecodeSt
     MVM_free(sep_spec->final_graphemes);
 
     sep_spec->num_seps = num_seps;
-    sep_spec->sep_lengths = MVM_malloc(num_seps * sizeof(MVMint32));
+    sep_lengths = MVM_malloc(num_seps * sizeof(MVMint32));
     graph_length = 0;
     for (i = 0; i < num_seps; i++) {
         MVMuint32 num_graphs = MVM_string_graphs(tc, seps[i]);
         if (num_graphs > 0xFFFF) {
-            MVM_free(sep_spec->sep_lengths);
+            MVM_free(sep_lengths);
             MVM_exception_throw_adhoc(tc, "Line separator (%"PRIu32") too long, max allowed is 65535", num_graphs);
         }
-        sep_spec->sep_lengths[i] = num_graphs;
+        sep_lengths[i] = num_graphs;
         graph_length += num_graphs;
     }
+    sep_spec->sep_lengths = sep_lengths;
 
     sep_spec->sep_graphemes = MVM_malloc(graph_length * sizeof(MVMGrapheme32));
     graph_pos = 0;

--- a/src/strings/gb18030.c
+++ b/src/strings/gb18030.c
@@ -50,21 +50,19 @@ MVMString * MVM_string_gb18030_decode(MVMThreadContext *tc, const MVMObject *res
     MVMuint8 *gb18030 = (MVMuint8*)gb18030_char;
     size_t i, result_graphs;
 
-    MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
-
-    result->body.storage_type = MVM_STRING_GRAPHEME_32;
-    result->body.storage.blob_32 = MVM_malloc(sizeof(MVMGrapheme32) * bytes);
+    MVMString *result;
+    MVMGrapheme32 *buffer = MVM_malloc(sizeof(MVMGrapheme32) * bytes);
 
     result_graphs = 0;
 
     for (i = 0; i < bytes; i++) {
         if (gb18030[i] <= 127) {
             if (gb18030[i] == '\r' && i + 1 < bytes && gb18030[i + 1] == '\n') {
-                result->body.storage.blob_32[result_graphs++] = MVM_nfg_crlf_grapheme(tc);
+                buffer[result_graphs++] = MVM_nfg_crlf_grapheme(tc);
                 i++;
             }
             else {
-                result->body.storage.blob_32[result_graphs++] = gb18030[i];
+                buffer[result_graphs++] = gb18030[i];
             }
         }
         else {
@@ -75,7 +73,7 @@ MVMString * MVM_string_gb18030_decode(MVMThreadContext *tc, const MVMObject *res
                 if (gb18030_valid_check_len2(byte1, byte2)) {
                     MVMGrapheme32 index = gb18030_index_to_cp_len2(byte1, byte2);
                     if (index != GB18030_NULL) {
-                        result->body.storage.blob_32[result_graphs++] = index;
+                        buffer[result_graphs++] = index;
                         i++;
                         continue;
                     }
@@ -90,20 +88,23 @@ MVMString * MVM_string_gb18030_decode(MVMThreadContext *tc, const MVMObject *res
                 if (gb18030_valid_check_len4(byte1, byte2, byte3, byte4)) {
                     MVMGrapheme32 index = gb18030_index_to_cp_len4(byte1, byte2, byte3, byte4);
                     if (index != GB18030_NULL) {
-                        result->body.storage.blob_32[result_graphs++] = index;
+                        buffer[result_graphs++] = index;
                         i += 3;
                         continue;
                     }
                 }
             }
             
-            MVM_free(result->body.storage.blob_32);
+            MVM_free(buffer);
             MVM_exception_throw_adhoc(tc,
                 "Error decoding gb18030 string: invalid gb18030 format. Last byte seen was 0x%hhX\n",
                 (MVMuint8)gb18030[i]);
         }
     }
 
+    result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    result->body.storage.blob_32 = buffer;
+    result->body.storage_type = MVM_STRING_GRAPHEME_32;
     result->body.num_graphs = result_graphs;
 
     return result;

--- a/src/strings/gb2312.c
+++ b/src/strings/gb2312.c
@@ -5,10 +5,8 @@ MVMString * MVM_string_gb2312_decode(MVMThreadContext *tc, const MVMObject *resu
     MVMuint8 *gb2312 = (MVMuint8*)gb2312_char;
     size_t i, result_graphs;
 
-    MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
-
-    result->body.storage_type = MVM_STRING_GRAPHEME_32;
-    result->body.storage.blob_32 = MVM_malloc(sizeof(MVMGrapheme32) * bytes);
+    MVMString *result;
+    MVMGrapheme32 *buffer = MVM_malloc(sizeof(MVMGrapheme32) * bytes);
 
     result_graphs = 0;
 
@@ -16,11 +14,11 @@ MVMString * MVM_string_gb2312_decode(MVMThreadContext *tc, const MVMObject *resu
         if (gb2312[i] <= 127) {
             /* Ascii character */
             if (gb2312[i] == '\r' && i + 1 < bytes && gb2312[i + 1] == '\n') {
-                result->body.storage.blob_32[result_graphs++] = MVM_nfg_crlf_grapheme(tc);
+                buffer[result_graphs++] = MVM_nfg_crlf_grapheme(tc);
                 i++;
             }
             else {
-                result->body.storage.blob_32[result_graphs++] = gb2312[i];
+                buffer[result_graphs++] = gb2312[i];
             }
         }
         else {
@@ -30,16 +28,16 @@ MVMString * MVM_string_gb2312_decode(MVMThreadContext *tc, const MVMObject *resu
                 MVMuint16 codepoint = (MVMuint16)byte1 * 256 + byte2;
                 MVMGrapheme32 index = gb2312_index_to_cp(codepoint);
                 if (index != GB2312_NULL) {
-                    result->body.storage.blob_32[result_graphs++] = index;
+                    buffer[result_graphs++] = index;
                     i++;
                 }
                 else {
-                    MVM_free(result->body.storage.blob_32);
+                    MVM_free(buffer);
                     MVM_exception_throw_adhoc(tc, "Error decoding gb2312 string: could not decode codepoint 0x%x", codepoint);
                 }
             }
             else {
-                MVM_free(result->body.storage.blob_32);
+                MVM_free(buffer);
                 MVM_exception_throw_adhoc(tc, 
                     "Error decoding gb2312 string: invalid gb2312 format (two bytes for a gb2312 character). Last byte seen was 0x%hhX\n", 
                     (MVMuint8)gb2312[i]);
@@ -47,6 +45,9 @@ MVMString * MVM_string_gb2312_decode(MVMThreadContext *tc, const MVMObject *resu
         }
     }
 
+    result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    result->body.storage.blob_32 = buffer;
+    result->body.storage_type = MVM_STRING_GRAPHEME_32;
     result->body.num_graphs = result_graphs;
 
     return result;

--- a/src/strings/shiftjis.c
+++ b/src/strings/shiftjis.c
@@ -204,7 +204,7 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
         const MVMObject *result_type, char *windows125X_c, size_t num_bytes,
         MVMString *replacement, MVMint64 config) {
     MVMuint8 *bytes = (MVMuint8 *)windows125X_c;
-    MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    MVMString *result;
     size_t pos = 0, result_graphs;
     MVMStringIndex repl_length = replacement ? MVM_string_graphs(tc, replacement) : 0;
     MVMuint8 Shift_JIS_lead = 0x00;
@@ -217,9 +217,8 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
     int last_was_cr         = 0;
     MVMStringIndex result_size = num_bytes;
 
-    result->body.storage_type    = MVM_STRING_GRAPHEME_32;
     /* TODO allocate less? */
-    result->body.storage.blob_32 = MVM_malloc(sizeof(MVMGrapheme32) * result_size);
+    MVMGrapheme32 *buffer = MVM_malloc(sizeof(MVMGrapheme32) * result_size);
 
     result_graphs = 0;
     while (pos < num_bytes || repl_pos) {
@@ -260,7 +259,7 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
                     if (1 < repl_length) repl_pos++;
                 }
                 else {
-                    MVM_free(result->body.storage.blob_32);
+                    MVM_free(buffer);
                     /* Throw if it's unmapped */
                     MVM_exception_throw_adhoc(tc,
                         "Error decoding shiftjis string: could not decode byte 0x%hhX",
@@ -273,7 +272,7 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
                 continue;
             }
             else {
-                MVM_free(result->body.storage.blob_32);
+                MVM_free(buffer);
                 MVM_exception_throw_adhoc(tc, "shiftjis decoder encountered an internal error.\n");
             }
         }
@@ -293,20 +292,21 @@ MVMString * MVM_string_shiftjis_decode(MVMThreadContext *tc,
         }
         if (result_graphs == result_size) {
             result_size += repl_length;
-            result->body.storage.blob_32 = MVM_realloc(result->body.storage.blob_32,
-                result_size * sizeof(MVMGrapheme32));
+            buffer = MVM_realloc(buffer, result_size * sizeof(MVMGrapheme32));
         }
-        result->body.storage.blob_32[result_graphs++] = graph;
+        buffer[result_graphs++] = graph;
     }
     /* If we end up with Shift_JIS_lead still set, that means we're missing a byte
      * that should have followed it. */
     if (Shift_JIS_lead != 0x00) {
-        MVM_free(result->body.storage.blob_32);
+        MVM_free(buffer);
         MVM_exception_throw_adhoc(tc, "Error, ended decode of shiftjis expecting another byte. "
             "Last byte seen was 0x%hhX\n", Shift_JIS_lead);
     }
-    result->body.storage.blob_32 = MVM_realloc(result->body.storage.blob_32,
+    result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    result->body.storage.blob_32 = MVM_realloc(buffer,
         result_graphs * sizeof(MVMGrapheme32));
+    result->body.storage_type = MVM_STRING_GRAPHEME_32;
     result->body.num_graphs = result_graphs;
 
     return result;

--- a/src/strings/utf16.c
+++ b/src/strings/utf16.c
@@ -217,7 +217,8 @@ MVMString * MVM_string_utf16_decode(MVMThreadContext *tc,
  * a result of the specified type. The type must have the MVMString REPR. */
 static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
         const MVMObject *result_type, MVMuint8 *utf16_chars, size_t bytes, int endianess) {
-    MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    MVMString *result;
+    MVMGrapheme32 *buffer;
     size_t str_pos = 0;
     MVMuint8 *utf16 = (MVMuint8 *)utf16_chars;
     MVMuint8 *utf16_end = NULL;
@@ -244,7 +245,7 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
     utf16_end = utf16 + bytes;
 
     /* possibly allocating extra space; oh well */
-    result->body.storage.blob_32 = MVM_malloc(sizeof(MVMGrapheme32) * bytes / 2);
+    buffer = MVM_malloc(sizeof(MVMGrapheme32) * bytes / 2);
 
     /* Need to normalize to NFG as we decode. */
     MVM_unicode_normalizer_init(tc, &norm, MVM_NORMALIZE_NFG);
@@ -255,7 +256,7 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
         MVMGrapheme32 g;
 
         if ((value & 0xFC00) == 0xDC00) {
-            MVM_free(result->body.storage.blob_32);
+            MVM_free(buffer);
             MVM_unicode_normalizer_cleanup(tc, &norm);
             MVM_exception_throw_adhoc(tc, "Malformed UTF-16; unexpected low surrogate");
         }
@@ -263,13 +264,13 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
         if ((value & 0xFC00) == 0xD800) { /* high surrogate */
             utf16 += 2;
             if (utf16 == utf16_end) {
-                MVM_free(result->body.storage.blob_32);
+                MVM_free(buffer);
                 MVM_unicode_normalizer_cleanup(tc, &norm);
                 MVM_exception_throw_adhoc(tc, "Malformed UTF-16; incomplete surrogate pair");
             }
             value2 = (utf16[high] << 8) + utf16[low];
             if ((value2 & 0xFC00) != 0xDC00) {
-                MVM_free(result->body.storage.blob_32);
+                MVM_free(buffer);
                 MVM_unicode_normalizer_cleanup(tc, &norm);
                 MVM_exception_throw_adhoc(tc, "Malformed UTF-16; incomplete surrogate pair");
             }
@@ -279,9 +280,9 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
         /* TODO: check for invalid values */
         ready = MVM_unicode_normalizer_process_codepoint_to_grapheme(tc, &norm, value, &g);
         if (ready) {
-            result->body.storage.blob_32[str_pos++] = g;
+            buffer[str_pos++] = g;
             while (--ready > 0)
-                result->body.storage.blob_32[str_pos++] = MVM_unicode_normalizer_get_grapheme(tc, &norm);
+                buffer[str_pos++] = MVM_unicode_normalizer_get_grapheme(tc, &norm);
         }
     }
 
@@ -289,9 +290,11 @@ static MVMString * MVM_string_utf16_decode_main(MVMThreadContext *tc,
     MVM_unicode_normalizer_eof(tc, &norm);
     ready = MVM_unicode_normalizer_available(tc, &norm);
     while (ready--)
-        result->body.storage.blob_32[str_pos++] = MVM_unicode_normalizer_get_grapheme(tc, &norm);
+        buffer[str_pos++] = MVM_unicode_normalizer_get_grapheme(tc, &norm);
     MVM_unicode_normalizer_cleanup(tc, &norm);
 
+    result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    result->body.storage.blob_32 = buffer;
     result->body.storage_type = MVM_STRING_GRAPHEME_32;
     result->body.num_graphs   = str_pos;
 


### PR DESCRIPTION
These were introduced by https://github.com/MoarVM/MoarVM/pull/1291 in
an attempt to not leak data that had been alloced before a throw.
However, in some cases the alloced storage had already been attached to
GC-managed objects, so if the throw was caught and GC cleaned up the
parent object, the storage was freed twice. Fix by only attaching the
alloced storage to the parent object after the throw might have
happened, so it can be safely freed before the throw.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.