### PR TITLE
Ensure MoarVM includes the correct 3rdparty libuv objects on *BSD

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -470,16 +470,22 @@ UV_LINUX = 3rdparty/libuv/src/unix/linux-core@obj@ \
 UV_BSD = 3rdparty/libuv/src/unix/kqueue@obj@ \
          3rdparty/libuv/src/unix/posix-hrtime@obj@ \
          3rdparty/libuv/src/unix/bsd-proctitle@obj@ \
+         3rdparty/libuv/src/unix/bsd-ifaddrs@obj@ \
          $(UV_UNIX)
 
 UV_OPENBSD = 3rdparty/libuv/src/unix/openbsd@obj@ \
+             3rdparty/libuv/src/unix/random-getentropy@obj@ \
              $(UV_BSD)
 
 UV_NETBSD = 3rdparty/libuv/src/unix/netbsd@obj@ \
             $(UV_BSD)
 
 UV_FREEBSD = 3rdparty/libuv/src/unix/freebsd@obj@ \
+             3rdparty/libuv/src/unix/random-getrandom@obj@ \
              $(UV_BSD)
+
+UV_DRAGONFLYBSD = 3rdparty/libuv/src/unix/freebsd@obj@ \
+                  $(UV_BSD)
 
 UV_DARWIN = 3rdparty/libuv/src/unix/darwin@obj@ \
             3rdparty/libuv/src/unix/darwin-proctitle@obj@ \

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -547,7 +547,7 @@ our %OS_DRAGONFLY = (
     syslibs => [ @{$OS_POSIX{syslibs}}, qw( kvm ) ],
 
     -thirdparty => {
-        uv => { %TP_UVDUMMY, objects => '$(UV_FREEBSD)' },
+        uv => { %TP_UVDUMMY, objects => '$(UV_DRAGONFLYBSD)' },
     },
 );
 


### PR DESCRIPTION
3rdparty builds of libuv didn't include the same objects that libuv
itself does. This shouldn't affect MoarVM as it currently stands, but
may cause problems in the future should `uv_random` or
`uv_interface_addresses` ever be used.