### PR TITLE
Declare loop var before loop

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3313,7 +3313,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVMCompUnit *cu = (MVMCompUnit *)maybe_cu;
                     if (cu->body.mainline_frame) {
                         MVMObject *coderef;
-                        for (MVMuint32 i = 0; i < cu->body.num_frames; i++) {
+                        MVMuint32 i;
+                        for (i = 0; i < cu->body.num_frames; i++) {
                             if (((MVMCode*)cu->body.coderefs[i])->body.sf == cu->body.mainline_frame) {
                                 coderef = cu->body.coderefs[i];
                                 break;


### PR DESCRIPTION
Fixes broken builds on older versions of GCC, resolves #1309.