### PR TITLE
Explicitly state we use gnu99 on GCC

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -283,7 +283,7 @@ our %COMPILERS = (
         ld => undef,
         as => 'as',
 
-        ccmiscflags  => '-Wextra -Wall -Wno-unused-parameter -Wno-unused-function -Wno-missing-braces -Werror=pointer-arith',
+        ccmiscflags  => '-std=gnu99 -Wextra -Wall -Wno-unused-parameter -Wno-unused-function -Wno-missing-braces -Werror=pointer-arith',
         ccwarnflags  => '',
         ccoptiflags  => '-O%s -DNDEBUG',
         ccdebugflags => '-g%s',


### PR DESCRIPTION
This fixes building on older versions of GCC (< 5.0) that default to gnu89.
Using `-std=c99` instead of `-std=gnu99` breaks the build of libuv because
some pthread declarations are then left out. So it seems sensible to go
with the GCC default of using the `gnu99` variant instead of the `c99`
variant.

Explicitly stating the version of C we want to use is a sensible thing to
do irrespective of the above mentioned backwards compatibility reason. This
way we are not relying on the GCC default that changes from version to
version.

Fixes #1309