### PR TITLE
Add JIT templates for return_(i|n|s)

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -137,6 +137,42 @@
       (carg $1   ptr)
       (carg (^caller) ptr))))
 
+(template: return_i
+  (dov
+    (callv (^func &MVM_args_set_result_int)
+      (arglist
+        (carg (tc) ptr)
+        (carg $0 int)
+        (carg (^zero) int)))
+    (callv (^func &MVM_frame_try_return)
+      (arglist
+        (carg (tc) ptr)))
+    (^exit)))
+
+(template: return_n
+  (dov
+    (callv (^func &MVM_args_set_result_num)
+      (arglist
+        (carg (tc) ptr)
+        (carg $0 num)
+        (carg (^zero) int)))
+    (callv (^func &MVM_frame_try_return)
+      (arglist
+        (carg (tc) ptr)))
+    (^exit)))
+
+(template: return_s
+  (dov
+    (callv (^func &MVM_args_set_result_str)
+      (arglist
+        (carg (tc) ptr)
+        (carg $0 ptr)
+        (carg (^zero) int)))
+    (callv (^func &MVM_frame_try_return)
+      (arglist
+        (carg (tc) ptr)))
+    (^exit)))
+
 (template: return_o
   (dov
     (callv (^func &MVM_args_set_result_obj)


### PR DESCRIPTION
Based off of the pre-existing one for return_o.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`. Removes some `expr bail: Cannot get template for: return_(i|n|s)` seen in some spesh logs.