### PR TITLE
Don't add placeholders such as "<control>" to the Unicode names lookup hash.

### DIFF
--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -748,13 +748,6 @@ MVMString * MVM_unicode_get_name(MVMThreadContext *tc, MVMint64 codepoint) {
         MVMint32 codepoint_row = MVM_codepoint_to_row_index(tc, codepoint);
         if (codepoint_row != -1) {
             name = codepoint_names[codepoint_row];
-            if (!name) {
-                while (codepoint_row && !codepoint_names[codepoint_row])
-                    codepoint_row--;
-                name = codepoint_names[codepoint_row];
-                if (name && name[0] != '<')
-                    name = NULL;
-            }
         }
         if (!name) {
             /* U+FDD0..U+FDEF and the last two codepoints of each block

--- a/tools/ucd2c.pl
+++ b/tools/ucd2c.pl
@@ -774,7 +774,7 @@ sub emit_codepoints_and_planes {
     # jnthn: Would it still use the same amount of memory to combine these tables? XXX
     $DB_SECTIONS->{BBB_codepoint_names} =
         "static const char *codepoint_names[$index] = {\n    ".
-            stack_lines(\@name_lines, ",", ",\n    ", 0, $WRAP_TO_COLUMNS).
+            stack_lines(\@name_lines, ",", ",\n    ", 0, 0).
             "\n};";
     $DB_SECTIONS->{BBB_codepoint_bitfield_indexes} =
         "static const MVMuint16 codepoint_bitfield_indexes[$index] = {\n    ".

--- a/tools/ucd2c.pl
+++ b/tools/ucd2c.pl
@@ -726,17 +726,10 @@ sub emit_codepoints_and_planes {
                 $toadd = $point;
                 $span_length = 0;
             }
-            my $usually = 1;  # occasionally change NULL to the name to cut name search time
             for (; 1 < $span_length; $span_length--) {
                 # catch up to last code
                 $last_point = $last_point->{next_point};
-                 # occasionally change NULL to the name to cut name search time
-                if ($last_point->{name} =~ / ^ [<] /x && $usually++ % 25) {
-                    ecap_push_name_line(\@name_lines, undef, $last_point, \@bitfield_index_lines, \$bytes, \$index, 1);
-                }
-                else {
-                    ecap_push_name_line(\@name_lines, $last_point->{name}, $last_point, \@bitfield_index_lines, \$bytes, \$index);
-                }
+                ecap_push_name_line(\@name_lines, $last_point->{name}, $last_point, \@bitfield_index_lines, \$bytes, \$index);
             }
             $span_length = 0;
         }

--- a/tools/ucd2c.pl
+++ b/tools/ucd2c.pl
@@ -1175,7 +1175,10 @@ static void generate_codepoints_by_name(MVMThreadContext *tc) {
                 for (; extent_span_index < length
                     && codepoint_table_index < MVM_CODEPOINT_NAMES_COUNT; extent_span_index++) {
                     const char *name = codepoint_names[codepoint_table_index];
-                    if (name) {
+                    /* We want to skip various placeholder names that are duplicated:
+                     * <control> <CJK UNIFIED IDEOGRAPH> <CJK COMPATIBILITY IDEOGRAPH>
+                     * <surrogate> <TANGUT IDEOGRAPH> <private-use> */
+                    if (name && *name != '<') {
                         MVMUnicodeNameRegistry *entry = MVM_malloc(sizeof(MVMUnicodeNameRegistry));
                         entry->name = (char *)name;
                         entry->codepoint = codepoint;
@@ -1195,7 +1198,7 @@ static void generate_codepoints_by_name(MVMThreadContext *tc) {
             /* Fate Span */
             case $FATE_SPAN: {
                 const char *name = codepoint_names[codepoint_table_index];
-                if (name) {
+                if (name && *name != '<') {
                     MVMUnicodeNameRegistry *entry = MVM_malloc(sizeof(MVMUnicodeNameRegistry));
                     entry->name = (char *)name;
                     entry->codepoint = codepoint;


### PR DESCRIPTION
@samcv , @jnthn  or *, could you check that I'm not doing anything stupid here?

~~I don't want to just push it, in case there was something I missed.~~

*Woah* I think I've done something stupid in the "fix" here (it's not in the right place). But is the reasoning sound? That we don't want these duplicates in the hash.

Rest of the commit message is the reasoning:

```
Including these make no sense - the hash is for a 1->1 mapping of name to
codepoint, but for each of these names we have multiple values.

The way our hashes are currently implemented (with "bind"), these duplicate
keys are not ignored - we add hundreds of duplicate entries to the same`
bucket chain (which will never successfully split to shorter chains).
This will cause performance degradation for other name lookups on the same
bucket chain - algorithmic pain, not merely memory bloat.

We *are* effectively executing a DOS attack against ourselves. Oops. :-)
```

For completeness, I should note that there are some duplicates in `unicode_property_value_keypairs`, such as `{"18-number",1258291201},{"18-number",1258291201}` but
 

1. there don't seem to be more than 2 entries with the same key duplicated
1. the values are indentical
1. I wasn't sure if it's safe to de-duplicate them in `ucd2.pl`, or if the array index they are at *also* matters.

so I don't think that it's a performance hit, or much memory bloat.

And I didn't want to try to experiment, as the way `UCD-download.p6` is written, it's awkward to do anything other than the most recent release of Unicode. `LATEST` is now on 13. We're on 12.1