### PR TITLE
Revert "Declare loop var before loop"

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3313,8 +3313,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVMCompUnit *cu = (MVMCompUnit *)maybe_cu;
                     if (cu->body.mainline_frame) {
                         MVMObject *coderef;
-                        MVMuint32 i;
-                        for (i = 0; i < cu->body.num_frames; i++) {
+                        for (MVMuint32 i = 0; i < cu->body.num_frames; i++) {
                             if (((MVMCode*)cu->body.coderefs[i])->body.sf == cu->body.mainline_frame) {
                                 coderef = cu->body.coderefs[i];
                                 break;


### PR DESCRIPTION
This reverts commit fc092556b9c5a16970b9f92e25e87dc3e3027642.

Now that we are enforcing `-std=gnu99` (23dfde9) this is no longer
required.