### PR TITLE
Fix build with gcc 4.8

### DIFF
--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -68,7 +68,8 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
         memcpy(lexical_names_list, src_body->lexical_names_list,
                sizeof(MVMLexicalRegistry *) * src_body->num_lexicals);
 
-        for (MVMuint32 j = 0; j < num_lexicals; j++) {
+        MVMuint32 j;
+        for (j = 0; j < num_lexicals; j++) {
             MVMLexicalRegistry *current = lexical_names_list[j];
 
             MVMLexicalRegistry *new_entry = MVM_malloc(sizeof(MVMLexicalRegistry));
@@ -150,7 +151,8 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
     MVMuint32 num_lexicals = body->num_lexicals;
     MVMLexicalRegistry **lexical_names_list = body->lexical_names_list;
 
-    for (MVMuint32 j = 0; j < num_lexicals; j++) {
+    MVMuint32 j;
+    for (j = 0; j < num_lexicals; j++) {
         MVMLexicalRegistry *current = lexical_names_list[j];
         MVM_gc_worklist_add(tc, worklist, &current->hash_handle.key);
         MVM_gc_worklist_add(tc, worklist, &current->key);
@@ -292,7 +294,8 @@ static void describe_refs(MVMThreadContext *tc, MVMHeapSnapshotState *ss, MVMSTa
     MVMuint32 num_lexicals = body->num_lexicals;
     MVMLexicalRegistry **lexical_names_list = body->lexical_names_list;
 
-    for (MVMuint32 j = 0; j < num_lexicals; j++) {
+    MVMuint32 j;
+    for (j = 0; j < num_lexicals; j++) {
         MVMLexicalRegistry *current = lexical_names_list[j];
         MVM_profile_heap_add_collectable_rel_const_cstr_cached(tc, ss,
             (MVMCollectable *)current->key, "Lexical name", &nonstatic_cache_1);
@@ -382,7 +385,8 @@ MVMLexicalRegistry *MVM_get_lexical_by_name(MVMThreadContext *tc, MVMStaticFrame
 
     MVMLexicalRegistry **lexical_names_list = sf->body.lexical_names_list;
     MVMuint32 num_lexicals = sf->body.num_lexicals;
-    for (MVMuint32 j = 0; j < num_lexicals; j++) {
+    MVMuint32 j;
+    for (j = 0; j < num_lexicals; j++) {
         entry = lexical_names_list[j];
         if (MVM_string_equal(tc, name, entry->key))
             return entry;

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1453,7 +1453,8 @@ static MVMint32 request_context_lexicals(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
 
         MVMLexicalRegistry **lexical_names_list = static_info->body.lexical_names_list;
 
-        for (MVMuint32 j = 0; j < num_lexicals; j++) {
+        MVMuint32 j;
+        for (j = 0; j < num_lexicals; j++) {
             MVMLexicalRegistry *entry = lexical_names_list[j];
             MVMuint16 lextype = static_info->body.lexical_types[j];
             MVMRegister *result = &frame->env[j];


### PR DESCRIPTION
Build with gcc 4.8 is broken since version 2020.06 and commit c70587551ab093368e041a65f4a4a8b49d78ce73:

```
src/debug/debugserver.c: In function 'request_context_lexicals':
src/debug/debugserver.c:1456:9: error: 'for' loop initial declarations are only allowed in C99 mode
         for (MVMuint32 j = 0; j < num_lexicals; j++) {
         ^
```
Fixes:
 - http://autobuild.buildroot.org/results/179/1799769c531f9f26ff191b1adcd5e5b17dc3b244/build-end.log

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>