### PR TITLE
Improve serialization of C types

### DIFF
--- a/src/6model/reprs/NativeCall.c
+++ b/src/6model/reprs/NativeCall.c
@@ -99,8 +99,8 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
     MVMNativeCallBody *body = (MVMNativeCallBody *)data;
     MVMint16 i = 0;
     if (reader->root.version >= 22) {
-        body->lib_name = MVM_serialization_read_cstr(tc, reader);
-        body->sym_name = MVM_serialization_read_cstr(tc, reader);
+        body->lib_name = MVM_serialization_read_cstr(tc, reader, NULL);
+        body->sym_name = MVM_serialization_read_cstr(tc, reader, NULL);
         body->convention = MVM_serialization_read_int(tc, reader);
         body->num_args = MVM_serialization_read_int(tc, reader);
         body->ret_type = MVM_serialization_read_int(tc, reader);

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -1739,8 +1739,8 @@ MVMString * MVM_serialization_read_str(MVMThreadContext *tc, MVMSerializationRea
 
 /* Reading function for arrays. */
 void * MVM_serialization_read_array(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *size) {
-    size_t  array_size = MVM_serialization_read_int(tc, reader);
-    void   *array      = NULL;
+    MVMint64  array_size = MVM_serialization_read_int(tc, reader);
+    void     *array      = NULL;
     if (array_size) {
         const MVMuint8 *read_at = (MVMuint8 *)*(reader->cur_read_buffer) + *(reader->cur_read_offset);
         assert_can_read(tc, reader, array_size);
@@ -1755,8 +1755,8 @@ void * MVM_serialization_read_array(MVMThreadContext *tc, MVMSerializationReader
 
 /* Reading function for null-terminated char array strings. */
 char * MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *len) {
-    size_t  string_len = MVM_serialization_read_int(tc, reader);
-    char   *string     = NULL;
+    MVMint64  string_len = MVM_serialization_read_int(tc, reader);
+    char     *string     = NULL;
     if (string_len) {
         if (string_len < SIZE_MAX) {
             const MVMuint8 *read_at = (MVMuint8 *)*(reader->cur_read_buffer) + *(reader->cur_read_offset);
@@ -1768,7 +1768,7 @@ char * MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader 
         }
         else
             fail_deserialize(tc, NULL, reader,
-                "Cannot read a C string with length %zu.",
+                "Cannot read a C string with length %"PRIi64".",
                 string_len);
     }
     if (len)

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -1768,7 +1768,7 @@ char * MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader 
         }
         else
             fail_deserialize(tc, NULL, reader,
-                "Cannot read a C string with length %"PRIi64".",
+                "Deserialized C string with out-of-range length (%"PRIi64")",
                 string_len);
     }
     if (len)

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -339,7 +339,7 @@ void MVM_serialization_write_array(MVMThreadContext *tc,
 
 /* Writing function for null-terminated char array strings. */
 void MVM_serialization_write_cstr(MVMThreadContext *tc, MVMSerializationWriter *writer, const char *string) {
-    MVM_serialization_write_array(tc, writer, string, string && strlen(string));
+    MVM_serialization_write_array(tc, writer, string, string ? strlen(string) : 0);
 }
 
 /* Writing function for variable sized integers. Writes out a 64 bit value

--- a/src/6model/serialization.h
+++ b/src/6model/serialization.h
@@ -190,6 +190,7 @@ MVMint64 MVM_serialization_read_int64(MVMThreadContext *tc, MVMSerializationRead
 MVMint64 MVM_serialization_read_int(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMnum64 MVM_serialization_read_num(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMString * MVM_serialization_read_str(MVMThreadContext *tc, MVMSerializationReader *reader);
+void * MVM_serialization_read_array(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *size);
 char *MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVM_PUBLIC MVMObject * MVM_serialization_read_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMSTable * MVM_serialization_read_stable_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
@@ -197,6 +198,8 @@ void MVM_serialization_force_stable(MVMThreadContext *tc, MVMSerializationReader
 void MVM_serialization_write_int(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value);
 void MVM_serialization_write_num(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMnum64 value);
 void MVM_serialization_write_str(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMString *value);
+void MVM_serialization_write_array(MVMThreadContext *tc,
+        MVMSerializationWriter *writer, const void *array, size_t size);
 void MVM_serialization_write_cstr(MVMThreadContext *tc, MVMSerializationWriter *writer, char *string);
 MVM_PUBLIC void MVM_serialization_write_ref(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMObject *ref);
 void MVM_serialization_write_stable_ref(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMSTable *st);

--- a/src/6model/serialization.h
+++ b/src/6model/serialization.h
@@ -191,7 +191,7 @@ MVMint64 MVM_serialization_read_int(MVMThreadContext *tc, MVMSerializationReader
 MVMnum64 MVM_serialization_read_num(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMString * MVM_serialization_read_str(MVMThreadContext *tc, MVMSerializationReader *reader);
 void * MVM_serialization_read_array(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *size);
-char *MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader *reader);
+char * MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *len);
 MVM_PUBLIC MVMObject * MVM_serialization_read_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMSTable * MVM_serialization_read_stable_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 void MVM_serialization_force_stable(MVMThreadContext *tc, MVMSerializationReader *reader, MVMSTable *st);
@@ -200,6 +200,6 @@ void MVM_serialization_write_num(MVMThreadContext *tc, MVMSerializationWriter *w
 void MVM_serialization_write_str(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMString *value);
 void MVM_serialization_write_array(MVMThreadContext *tc,
         MVMSerializationWriter *writer, const void *array, size_t size);
-void MVM_serialization_write_cstr(MVMThreadContext *tc, MVMSerializationWriter *writer, char *string);
+void MVM_serialization_write_cstr(MVMThreadContext *tc, MVMSerializationWriter *writer, const char *string);
 MVM_PUBLIC void MVM_serialization_write_ref(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMObject *ref);
 void MVM_serialization_write_stable_ref(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMSTable *st);

--- a/src/6model/serialization.h
+++ b/src/6model/serialization.h
@@ -190,7 +190,7 @@ MVMint64 MVM_serialization_read_int64(MVMThreadContext *tc, MVMSerializationRead
 MVMint64 MVM_serialization_read_int(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMnum64 MVM_serialization_read_num(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMString * MVM_serialization_read_str(MVMThreadContext *tc, MVMSerializationReader *reader);
-void * MVM_serialization_read_array(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *size);
+void * MVM_serialization_read_ptr(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *size);
 char * MVM_serialization_read_cstr(MVMThreadContext *tc, MVMSerializationReader *reader, size_t *len);
 MVM_PUBLIC MVMObject * MVM_serialization_read_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
 MVMSTable * MVM_serialization_read_stable_ref(MVMThreadContext *tc, MVMSerializationReader *reader);
@@ -198,8 +198,7 @@ void MVM_serialization_force_stable(MVMThreadContext *tc, MVMSerializationReader
 void MVM_serialization_write_int(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMint64 value);
 void MVM_serialization_write_num(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMnum64 value);
 void MVM_serialization_write_str(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMString *value);
-void MVM_serialization_write_array(MVMThreadContext *tc,
-        MVMSerializationWriter *writer, const void *array, size_t size);
-void MVM_serialization_write_cstr(MVMThreadContext *tc, MVMSerializationWriter *writer, const char *string);
+void MVM_serialization_write_ptr(MVMThreadContext *tc, MVMSerializationWriter *writer, const void *ptr, size_t size);
+void MVM_serialization_write_cstr(MVMThreadContext *tc, MVMSerializationWriter *writer, const char *cstr);
 MVM_PUBLIC void MVM_serialization_write_ref(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMObject *ref);
 void MVM_serialization_write_stable_ref(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMSTable *st);


### PR DESCRIPTION
This adds support for serializing C arrays and fixes a potential integer overflow in C string deserialization. The purpose of this is to make it possible for abstract UNIX socket addresses to be serialized in my solution for https://github.com/Raku/problem-solving/issues/111.