### PR TITLE
Fix case insensitive string matching with an empty string

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1246,10 +1246,10 @@ static MVMint64 string_equal_at_ignore_case(MVMThreadContext *tc, MVMString *Hay
         if (H_offset < 0)
             H_offset = 0; /* XXX I think this is the right behavior here */
     }
-    /* If the offset is greater or equal to the number of Haystack graphemes
-     * return 0. Since size of graphemes could change under casefolding, we
+    /* If the offset is greater to the number of Haystack graphemes return 0.
+     * Since size of graphemes could change under casefolding, we
      * can't assume too much. If optimizing this be careful */
-    if (H_graphs <= H_offset)
+    if (H_graphs < H_offset)
         return 0;
     MVMROOT(tc, Haystack, {
         needle_fc = ignorecase ? MVM_string_fc(tc, needle) : needle;


### PR DESCRIPTION
Fixes `'' ~~ m:i/''/` in Rakudo. I did a spectest run with this.

This PR is related to respective tests in roast: <https://github.com/Raku/roast/pull/655> Does it matter which of these PRs is merged first?

Fixes rakudo/rakudo#3815.