### PR TITLE
Split `flags` in struct MVMCollectable to avoid data races when setting `MVM_CF_HAS_OBJECT_ID` and `MVM_CF_REF_FROM_GEN2`

### DIFF
--- a/src/6model/6model.c
+++ b/src/6model/6model.c
@@ -475,7 +475,7 @@ MVMuint64 MVM_6model_next_type_cache_id(MVMThreadContext *tc) {
  * instances, marks the individual ojbect as never repossessable. */
 void MVM_6model_never_repossess(MVMThreadContext *tc, MVMObject *obj) {
     if (IS_CONCRETE(obj))
-        obj->header.flags |= MVM_CF_NEVER_REPOSSESS;
+        obj->header.flags1 |= MVM_CF_NEVER_REPOSSESS;
     else
         obj->st->mode_flags |= MVM_NEVER_REPOSSESS_TYPE;
 }

--- a/src/6model/6model.h
+++ b/src/6model/6model.h
@@ -125,43 +125,43 @@ typedef enum {
     MVM_CF_FRAME = 4,
 
     /* Have we allocated memory to store a serialization index? */
-    MVM_CF_SERIALZATION_INDEX_ALLOCATED = 256,
+    MVM_CF_SERIALZATION_INDEX_ALLOCATED = 8,
 
     /* Have we arranged a persistent object ID for this object? */
-    MVM_CF_HAS_OBJECT_ID = 512,
+    MVM_CF_HAS_OBJECT_ID = 16,
 
     /* Have we flagged this object as something we must never repossess? */
     /* Note: if you're hunting for a flag, some day in the future when we
      * have used them all, this one is easy enough to eliminate by having the
      * tiny number of objects marked this way in a remembered set. */
-    MVM_CF_NEVER_REPOSSESS = 1024
+    MVM_CF_NEVER_REPOSSESS = 32
 } MVMCollectableFlags1;
 
 typedef enum {
     /* Has already been seen once in GC nursery. */
-    MVM_CF_NURSERY_SEEN = 8,
+    MVM_CF_NURSERY_SEEN = 1,
 
     /* Has been promoted to the old generation. */
-    MVM_CF_SECOND_GEN = 16,
+    MVM_CF_SECOND_GEN = 2,
 
     /* Has already been added to the gen2 aggregates pointing to nursery
      * objects list. */
-    MVM_CF_IN_GEN2_ROOT_LIST = 32,
+    MVM_CF_IN_GEN2_ROOT_LIST = 4,
 
     /* A full GC run has found this object to be live. */
-    MVM_CF_GEN2_LIVE = 64,
+    MVM_CF_GEN2_LIVE = 8,
 
     /* This object in fromspace is live with a valid forwarder. */
     /* TODO - should be possible to use the same bit for this and GEN2_LIVE. */
-    MVM_CF_FORWARDER_VALID = 128,
+    MVM_CF_FORWARDER_VALID = 16,
 
     /* Is this object a nursery object that has been referenced from gen2?
      * Used to promote it earlier. */
-    MVM_CF_REF_FROM_GEN2 = 2048,
+    MVM_CF_REF_FROM_GEN2 = 32,
 
     /* Has this item been chained into a gen2 freelist? This is only used in
      * GC debug more. */
-    MVM_CF_DEBUG_IN_GEN2_FREE_LIST = 4096
+    MVM_CF_DEBUG_IN_GEN2_FREE_LIST = 64
 } MVMCollectableFlags2;
 
 #ifdef MVM_USE_OVERFLOW_SERIALIZATION_INDEX
@@ -211,8 +211,8 @@ struct MVMCollectable {
     MVMuint32 owner;
 
     /* Collectable flags (see MVMCollectableFlags). */
-    MVMuint16 flags1;
-    MVMuint16 flags2;
+    MVMuint8 flags1;
+    MVMuint8 flags2;
 
     /* Object size, in bytes. */
     MVMuint16 size;

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -810,7 +810,7 @@ static void copy_elements(MVMThreadContext *tc, MVMObject *src, MVMObject *dest,
     if (elems > 0) {
         MVMint64  i;
         MVMuint16 kind;
-        MVMuint8 d_needs_barrier = dest->header.flags & MVM_CF_SECOND_GEN;
+        MVMuint8 d_needs_barrier = dest->header.flags2 & MVM_CF_SECOND_GEN;
         if (s_repr_data && d_repr_data
                 && s_repr_data->slot_type == d_repr_data->slot_type
                 && s_repr_data->elem_size == d_repr_data->elem_size

--- a/src/6model/sc.c
+++ b/src/6model/sc.c
@@ -364,7 +364,7 @@ void MVM_sc_disclaim(MVMThreadContext *tc, MVMSerializationContext *sc) {
         obj = root_objects[i];
         col = &obj->header;
 #ifdef MVM_USE_OVERFLOW_SERIALIZATION_INDEX
-        if (col->flags & MVM_CF_SERIALZATION_INDEX_ALLOCATED) {
+        if (col->flags1 & MVM_CF_SERIALZATION_INDEX_ALLOCATED) {
             struct MVMSerializationIndex *const sci = col->sc_forward_u.sci;
             col->sc_forward_u.sci = NULL;
             MVM_free(sci);
@@ -401,7 +401,7 @@ void MVM_sc_disclaim(MVMThreadContext *tc, MVMSerializationContext *sc) {
 
 /* SC repossession barrier. */
 void MVM_SC_WB_OBJ(MVMThreadContext *tc, MVMObject *obj) {
-    assert(!(obj->header.flags & MVM_CF_FORWARDER_VALID));
+    assert(!(obj->header.flags2 & MVM_CF_FORWARDER_VALID));
     assert(MVM_sc_get_idx_of_sc(&obj->header) != (MVMuint32)~0);
     if (MVM_sc_get_idx_of_sc(&obj->header) > 0 && !(obj->st->mode_flags & MVM_NEVER_REPOSSESS_TYPE))
         MVM_sc_wb_hit_obj(tc, obj);
@@ -418,7 +418,7 @@ void MVM_sc_wb_hit_obj(MVMThreadContext *tc, MVMObject *obj) {
         return;
 
     /* Same if the object is flagged as one to never repossess. */
-    if (obj->header.flags & MVM_CF_NEVER_REPOSSESS)
+    if (obj->header.flags1 & MVM_CF_NEVER_REPOSSESS)
         return;
 
     /* Otherwise, check that the object's SC is different from the SC

--- a/src/6model/sc.h
+++ b/src/6model/sc.h
@@ -35,18 +35,18 @@ MVM_STATIC_INLINE MVMObject * MVM_sc_get_sc_object(MVMThreadContext *tc, MVMComp
 void MVM_sc_disclaim(MVMThreadContext *tc, MVMSerializationContext *sc);
 
 MVM_STATIC_INLINE MVMuint32 MVM_sc_get_idx_of_sc(MVMCollectable *col) {
-    assert(!(col->flags & MVM_CF_FORWARDER_VALID));
+    assert(!(col->flags2 & MVM_CF_FORWARDER_VALID));
 #ifdef MVM_USE_OVERFLOW_SERIALIZATION_INDEX
-    if (col->flags & MVM_CF_SERIALZATION_INDEX_ALLOCATED)
+    if (col->flags1 & MVM_CF_SERIALZATION_INDEX_ALLOCATED)
         return col->sc_forward_u.sci->sc_idx;
 #endif
     return col->sc_forward_u.sc.sc_idx;
 }
 
 MVM_STATIC_INLINE MVMuint32 MVM_sc_get_idx_in_sc(MVMCollectable *col) {
-    assert(!(col->flags & MVM_CF_FORWARDER_VALID));
+    assert(!(col->flags2 & MVM_CF_FORWARDER_VALID));
 #ifdef MVM_USE_OVERFLOW_SERIALIZATION_INDEX
-    if (col->flags & MVM_CF_SERIALZATION_INDEX_ALLOCATED)
+    if (col->flags1 & MVM_CF_SERIALZATION_INDEX_ALLOCATED)
         return col->sc_forward_u.sci->idx;
     if (col->sc_forward_u.sc.idx == MVM_DIRECT_SC_IDX_SENTINEL)
         return ~0;
@@ -55,9 +55,9 @@ MVM_STATIC_INLINE MVMuint32 MVM_sc_get_idx_in_sc(MVMCollectable *col) {
 }
 
 MVM_STATIC_INLINE void MVM_sc_set_idx_in_sc(MVMCollectable *col, MVMuint32 i) {
-    assert(!(col->flags & MVM_CF_FORWARDER_VALID));
+    assert(!(col->flags2 & MVM_CF_FORWARDER_VALID));
 #ifdef MVM_USE_OVERFLOW_SERIALIZATION_INDEX
-    if (col->flags & MVM_CF_SERIALZATION_INDEX_ALLOCATED) {
+    if (col->flags1 & MVM_CF_SERIALZATION_INDEX_ALLOCATED) {
         col->sc_forward_u.sci->idx = i;
     } else if (i >= MVM_DIRECT_SC_IDX_SENTINEL) {
         struct MVMSerializationIndex *const sci
@@ -65,7 +65,7 @@ MVM_STATIC_INLINE void MVM_sc_set_idx_in_sc(MVMCollectable *col, MVMuint32 i) {
         sci->sc_idx = col->sc_forward_u.sc.sc_idx;
         sci->idx = i;
         col->sc_forward_u.sci = sci;
-        col->flags |= MVM_CF_SERIALZATION_INDEX_ALLOCATED;
+        col->flags1 |= MVM_CF_SERIALZATION_INDEX_ALLOCATED;
     } else
 #endif
     {
@@ -76,7 +76,7 @@ MVM_STATIC_INLINE void MVM_sc_set_idx_in_sc(MVMCollectable *col, MVMuint32 i) {
 /* Gets a collectable's SC. */
 MVM_STATIC_INLINE MVMSerializationContext * MVM_sc_get_collectable_sc(MVMThreadContext *tc, MVMCollectable *col) {
     MVMuint32 sc_idx;
-    assert(!(col->flags & MVM_CF_FORWARDER_VALID));
+    assert(!(col->flags2 & MVM_CF_FORWARDER_VALID));
     sc_idx = MVM_sc_get_idx_of_sc(col);
     assert(sc_idx != ~(MVMuint32)0);
     return sc_idx > 0 ? tc->instance->all_scs[sc_idx]->sc : NULL;
@@ -99,9 +99,9 @@ MVM_STATIC_INLINE MVMSerializationContext * MVM_sc_get_stable_sc(MVMThreadContex
 
 /* Sets a collectable's SC. */
 MVM_STATIC_INLINE void MVM_sc_set_collectable_sc(MVMThreadContext *tc, MVMCollectable *col, MVMSerializationContext *sc) {
-    assert(!(col->flags & MVM_CF_FORWARDER_VALID));
+    assert(!(col->flags2 & MVM_CF_FORWARDER_VALID));
 #ifdef MVM_USE_OVERFLOW_SERIALIZATION_INDEX
-    if (col->flags & MVM_CF_SERIALZATION_INDEX_ALLOCATED) {
+    if (col->flags1 & MVM_CF_SERIALZATION_INDEX_ALLOCATED) {
         col->sc_forward_u.sci->sc_idx = sc->body->sc_idx;
         col->sc_forward_u.sci->idx    = ~0;
     } else
@@ -115,7 +115,7 @@ MVM_STATIC_INLINE void MVM_sc_set_collectable_sc(MVMThreadContext *tc, MVMCollec
             sci->sc_idx = sc->body->sc_idx;
             sci->idx = ~0;
             col->sc_forward_u.sci = sci;
-            col->flags |= MVM_CF_SERIALZATION_INDEX_ALLOCATED;
+            col->flags1 |= MVM_CF_SERIALZATION_INDEX_ALLOCATED;
         } else
 #endif
         {
@@ -172,7 +172,7 @@ void MVM_sc_wb_hit_st(MVMThreadContext *tc, MVMSTable *st);
 void MVM_SC_WB_OBJ(MVMThreadContext *tc, MVMObject *obj);
 
 MVM_STATIC_INLINE void MVM_SC_WB_ST(MVMThreadContext *tc, MVMSTable *st) {
-    assert(!(st->header.flags & MVM_CF_FORWARDER_VALID));
+    assert(!(st->header.flags2 & MVM_CF_FORWARDER_VALID));
     assert(MVM_sc_get_idx_of_sc(&st->header) != ~(MVMuint32)0);
     if (MVM_sc_get_idx_of_sc(&st->header) > 0)
         MVM_sc_wb_hit_st(tc, st);

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -281,7 +281,8 @@ static MVMFrame * allocate_frame(MVMThreadContext *tc, MVMStaticFrame *static_fr
 
         /* Ensure collectable header flags and owner are zeroed, which means we'll
          * never try to mark or root the frame. */
-        frame->header.flags = 0;
+        frame->header.flags1 = 0;
+        frame->header.flags2 = 0;
         frame->header.owner = 0;
 
         /* Current arguments callsite must be NULL as it's used in GC. Extra must

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -199,9 +199,9 @@ struct MVMInvocationSpec {
 
 /* Checks if a frame is allocated on a call stack or on the heap. If it is on
  * the call stack, then it will have zeroed flags (since heap-allocated frames
- * always have the "I'm a heap frame" bit set). */
+ * always have the "I'm a heap frame" bit set - MVM_CF_FRAME). */
 MVM_STATIC_INLINE MVMuint32 MVM_FRAME_IS_ON_CALLSTACK(MVMThreadContext *tc, MVMFrame *frame) {
-    return frame->header.flags == 0;
+    return frame->header.flags1 == 0;
 }
 
 /* Forces a frame to the callstack if needed. Done as a static inline to make

--- a/src/gc/allocation.c
+++ b/src/gc/allocation.c
@@ -62,7 +62,7 @@ MVMSTable * MVM_gc_allocate_stable(MVMThreadContext *tc, const MVMREPROps *repr,
     MVMSTable *st;
     MVMROOT(tc, how, {
         st                = MVM_gc_allocate_zeroed(tc, sizeof(MVMSTable));
-        st->header.flags |= MVM_CF_STABLE;
+        st->header.flags1 = MVM_CF_STABLE;
         st->header.size   = sizeof(MVMSTable);
         st->header.owner  = tc->thread_id;
         st->REPR          = repr;
@@ -79,7 +79,7 @@ MVMObject * MVM_gc_allocate_type_object(MVMThreadContext *tc, MVMSTable *st) {
     MVMObject *obj;
     MVMROOT(tc, st, {
         obj                = MVM_gc_allocate_zeroed(tc, sizeof(MVMObject));
-        obj->header.flags |= MVM_CF_TYPE_OBJECT;
+        obj->header.flags1 = MVM_CF_TYPE_OBJECT;
         obj->header.size   = sizeof(MVMObject);
         obj->header.owner  = tc->thread_id;
         MVM_ASSIGN_REF(tc, &(obj->header), obj->st, st);
@@ -104,7 +104,7 @@ MVMObject * MVM_gc_allocate_object(MVMThreadContext *tc, MVMSTable *st) {
 /* Allocates a new heap frame. */
 MVMFrame * MVM_gc_allocate_frame(MVMThreadContext *tc) {
     MVMFrame *f = MVM_gc_allocate_zeroed(tc, sizeof(MVMFrame));
-    f->header.flags |= MVM_CF_FRAME;
+    f->header.flags1 = MVM_CF_FRAME;
     f->header.size   = sizeof(MVMFrame);
     f->header.owner  = tc->thread_id;
     return f;

--- a/src/gc/debug.h
+++ b/src/gc/debug.h
@@ -19,7 +19,7 @@
                 MVM_panic(1, "Collectable %p in fromspace accessed", c); \
             cur_thread = cur_thread->body.next; \
         } \
-        if (((MVMCollectable *)c)->flags & MVM_CF_DEBUG_IN_GEN2_FREE_LIST) \
+        if (((MVMCollectable *)c)->flags2 & MVM_CF_DEBUG_IN_GEN2_FREE_LIST) \
             MVM_panic(1, "Collectable %p in a gen2 freelist accessed", c); \
     } \
 } while (0)
@@ -27,10 +27,10 @@
     MVMFrame *check = f; \
     while (check) { \
         MVM_ASSERT_NOT_FROMSPACE(tc, check); \
-        if ((check->header.flags & MVM_CF_SECOND_GEN) && \
+        if ((check->header.flags2 & MVM_CF_SECOND_GEN) && \
                 check->caller && \
-                !(check->caller->header.flags & MVM_CF_SECOND_GEN) && \
-                !(check->header.flags & MVM_CF_IN_GEN2_ROOT_LIST)) \
+                !(check->caller->header.flags2 & MVM_CF_SECOND_GEN) && \
+                !(check->header.flags2 & MVM_CF_IN_GEN2_ROOT_LIST)) \
             MVM_panic(1, "Illegal Gen2 -> Nursery in caller chain (not in inter-gen set)"); \
         check = check->caller; \
     } \

--- a/src/gc/finalize.c
+++ b/src/gc/finalize.c
@@ -82,7 +82,7 @@ static void walk_thread_finalize_queue(MVMThreadContext *tc, MVMuint8 gen) {
     for (i = 0; i < tc->num_finalize; i++) {
         /* See if it's dead, taking which generation we've marked into
          * account. */
-        MVMuint32 flags   = tc->finalize[i]->header.flags;
+        MVMuint32 flags   = tc->finalize[i]->header.flags2;
         MVMuint32 in_gen2 = flags & MVM_CF_SECOND_GEN;
         if (gen == MVMGCGenerations_Both || !in_gen2) {
             MVMuint32 live = flags & (MVM_CF_GEN2_LIVE | MVM_CF_FORWARDER_VALID);

--- a/src/gc/gen2.c
+++ b/src/gc/gen2.c
@@ -110,7 +110,7 @@ void * MVM_gc_gen2_allocate(MVMGen2Allocator *al, MVMuint32 size) {
 void * MVM_gc_gen2_allocate_zeroed(MVMGen2Allocator *al, MVMuint32 size) {
     void *a = MVM_gc_gen2_allocate(al, size);
     memset(a, 0, size);
-    ((MVMCollectable *)a)->flags = MVM_CF_SECOND_GEN;
+    ((MVMCollectable *)a)->flags2 = MVM_CF_SECOND_GEN;
     return a;
 }
 

--- a/src/gc/wb.c
+++ b/src/gc/wb.c
@@ -8,12 +8,12 @@
  * run - even a nursery only one - since somewhere it has references
  * to a nursery object. */
 void MVM_gc_write_barrier_hit(MVMThreadContext *tc, MVMCollectable *update_root) {
-    if (!(update_root->flags & MVM_CF_IN_GEN2_ROOT_LIST))
+    if (!(update_root->flags2 & MVM_CF_IN_GEN2_ROOT_LIST))
         MVM_gc_root_gen2_add(tc, update_root);
 }
 void MVM_gc_write_barrier_hit_by(MVMThreadContext *tc, MVMCollectable *update_root,
                                  MVMCollectable *referenced) {
-    if (!(update_root->flags & MVM_CF_IN_GEN2_ROOT_LIST))
+    if (!(update_root->flags2 & MVM_CF_IN_GEN2_ROOT_LIST))
         MVM_gc_root_gen2_add(tc, update_root);
-    referenced->flags |= MVM_CF_REF_FROM_GEN2;
+    referenced->flags2 |= MVM_CF_REF_FROM_GEN2;
 }

--- a/src/gc/wb.h
+++ b/src/gc/wb.h
@@ -7,11 +7,11 @@ MVM_PUBLIC void MVM_gc_write_barrier_hit_by(MVMThreadContext *tc, MVMCollectable
  * nursery object, then the generation 2 object becomes an inter-generational
  * root. */
 MVM_STATIC_INLINE void MVM_gc_write_barrier(MVMThreadContext *tc, MVMCollectable *update_root, MVMCollectable *referenced) {
-    if (((update_root->flags & MVM_CF_SECOND_GEN) && referenced && !(referenced->flags & MVM_CF_SECOND_GEN)))
+    if (((update_root->flags2 & MVM_CF_SECOND_GEN) && referenced && !(referenced->flags2 & MVM_CF_SECOND_GEN)))
         MVM_gc_write_barrier_hit_by(tc, update_root, referenced);
 }
 MVM_STATIC_INLINE void MVM_gc_write_barrier_no_update_referenced(MVMThreadContext *tc, MVMCollectable *update_root, MVMCollectable *referenced) {
-    if (((update_root->flags & MVM_CF_SECOND_GEN) && referenced && !(referenced->flags & MVM_CF_SECOND_GEN)))
+    if (((update_root->flags2 & MVM_CF_SECOND_GEN) && referenced && !(referenced->flags2 & MVM_CF_SECOND_GEN)))
         MVM_gc_write_barrier_hit(tc, update_root);
 }
 

--- a/src/gc/worklist.h
+++ b/src/gc/worklist.h
@@ -39,20 +39,20 @@ struct MVMGCWorklist {
                 MVM_panic(1, "Zeroed owner in item added to GC worklist"); \
             if ((*item_to_add)->owner > tc->instance->next_user_thread_id) \
                 MVM_panic(1, "Invalid owner in item added to GC worklist"); \
-            if ((*item_to_add)->flags & MVM_CF_DEBUG_IN_GEN2_FREE_LIST) \
+            if ((*item_to_add)->flags2 & MVM_CF_DEBUG_IN_GEN2_FREE_LIST) \
                 MVM_panic(1, "Adding item to worklist already freed in gen2\n"); \
-            if ((*item_to_add)->flags & MVM_CF_FRAME) {\
+            if ((*item_to_add)->flags1 & MVM_CF_FRAME) {\
                 if (!((MVMFrame *)(*item_to_add))->static_info) \
                     MVM_panic(1, "Frame with NULL static_info added to worklist"); \
             }\
-            else if (((*item_to_add)->flags & MVM_CF_STABLE) == 0 && !STABLE(*item_to_add)) \
+            else if (((*item_to_add)->flags1 & MVM_CF_STABLE) == 0 && !STABLE(*item_to_add)) \
                 MVM_panic(1, "NULL STable in item added to GC worklist"); \
             if ((char *)*item_to_add >= (char *)tc->nursery_alloc && \
                     (char *)*item_to_add < (char *)tc->nursery_alloc_limit) \
                 MVM_panic(1, "Adding pointer %p to past fromspace to GC worklist", \
                     *item_to_add); \
         } \
-        if (*item_to_add && (worklist->include_gen2 || !((*item_to_add)->flags & MVM_CF_SECOND_GEN))) { \
+        if (*item_to_add && (worklist->include_gen2 || !((*item_to_add)->flags2 & MVM_CF_SECOND_GEN))) { \
             if (worklist->items == worklist->alloc) \
                 MVM_gc_worklist_add_slow(tc, worklist, item_to_add); \
             else \
@@ -69,7 +69,7 @@ struct MVMGCWorklist {
 #define MVM_gc_worklist_add(tc, worklist, item) \
     do { \
         MVMCollectable **item_to_add = (MVMCollectable **)(item);\
-        if (*item_to_add && (worklist->include_gen2 || !((*item_to_add)->flags & MVM_CF_SECOND_GEN))) { \
+        if (*item_to_add && (worklist->include_gen2 || !((*item_to_add)->flags2 & MVM_CF_SECOND_GEN))) { \
             if (worklist->items == worklist->alloc) \
                 MVM_gc_worklist_add_slow(tc, worklist, item_to_add); \
             else \
@@ -90,13 +90,13 @@ do { \
  * is False before calling this macro. */
 #define MVM_gc_worklist_add_no_include_gen2_nocheck(tc, worklist, item) \
 do { \
-    if (*item && !( (*(MVMCollectable**)item)->flags & MVM_CF_SECOND_GEN)) { \
+    if (*item && !( (*(MVMCollectable**)item)->flags2 & MVM_CF_SECOND_GEN)) { \
         worklist->list[worklist->items++] = (MVMCollectable**)item; \
     } \
 } while (0)
 #define MVM_gc_worklist_add_object_no_include_gen2_nocheck(tc, worklist, object) \
 do { \
-    if (*object && !( (*object)->header.flags & MVM_CF_SECOND_GEN)) { \
+    if (*object && !( (*object)->header.flags2 & MVM_CF_SECOND_GEN)) { \
         worklist->list[worklist->items++] = (MVMCollectable**)object; \
     } \
 } while (0)

--- a/src/jit/macro.expr
+++ b/src/jit/macro.expr
@@ -69,12 +69,13 @@
 (macro: ^cu_string (,a)
     (^indirect_cu_string (cu) ,a))
 
-(macro: ^objflag (,cv) (const (&QUOTE ,cv) (&SIZEOF_MEMBER MVMObject header.flags)))
+(macro: ^objflag1 (,cv) (const (&QUOTE ,cv) (&SIZEOF_MEMBER MVMObject header.flags1)))
+(macro: ^objflag2 (,cv) (const (&QUOTE ,cv) (&SIZEOF_MEMBER MVMObject header.flags2)))
 
 (macro: ^write_barrier (,root ,obj)
-  (when (all (nz (and (^getf ,root MVMCollectable flags) (^objflag MVM_CF_SECOND_GEN)))
+  (when (all (nz (and (^getf ,root MVMCollectable flags2) (^objflag2 MVM_CF_SECOND_GEN)))
              (nz ,obj)
-             (zr (and (^getf ,obj MVMCollectable flags) (^objflag MVM_CF_SECOND_GEN))))
+             (zr (and (^getf ,obj MVMCollectable flags2) (^objflag2 MVM_CF_SECOND_GEN))))
     (callv (^func &MVM_gc_write_barrier_hit_by)
      (arglist (carg (tc) ptr)
               (carg ,root ptr)
@@ -92,9 +93,9 @@
 (macro: ^not_repr_id (,obj ,id) (ne (^repr_id ,obj) (const (&QUOTE ,id) (&SIZEOF_MEMBER MVMREPROps ID))))
 
 (macro: ^is_type_obj (,a)
-    (nz (and (^getf ,a MVMObject header.flags) (^objflag MVM_CF_TYPE_OBJECT))))
+    (nz (and (^getf ,a MVMObject header.flags1) (^objflag1 MVM_CF_TYPE_OBJECT))))
 (macro: ^is_conc_obj (,a)
-    (zr (and (^getf ,a MVMObject header.flags) (^objflag MVM_CF_TYPE_OBJECT))))
+    (zr (and (^getf ,a MVMObject header.flags1) (^objflag1 MVM_CF_TYPE_OBJECT))))
 
 (macro: ^bigint_is_smallint (,a)
     (eq (^getf ,a MVMP6bigintBody u.smallint.flag) (const (&QUOTE MVM_BIGINT_32_FLAG) 4)))

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -235,11 +235,11 @@ const unsigned char * MVM_jit_actions(void) {
 
 
 |.macro check_wb, root, ref, lbl;
-| test word COLLECTABLE:root->flags, MVM_CF_SECOND_GEN;
+| test word COLLECTABLE:root->flags2, MVM_CF_SECOND_GEN;
 | jz lbl;
 | test ref, ref;
 | jz lbl;
-| test word COLLECTABLE:ref->flags, MVM_CF_SECOND_GEN;
+| test word COLLECTABLE:ref->flags2, MVM_CF_SECOND_GEN;
 | jnz lbl;
 |.endmacro;
 
@@ -273,7 +273,7 @@ const unsigned char * MVM_jit_actions(void) {
 |.endmacro
 
 |.macro test_type_object, reg
-| test word OBJECT:reg->header.flags, MVM_CF_TYPE_OBJECT
+| test word OBJECT:reg->header.flags1, MVM_CF_TYPE_OBJECT
 |.endmacro
 
 |.macro gc_sync_point
@@ -364,7 +364,7 @@ void MVM_jit_emit_epilogue(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJi
 
 static MVMuint64 try_emit_gen2_ref(MVMThreadContext *tc, MVMJitCompiler *compiler,
                                    MVMJitGraph *jg, MVMObject *obj, MVMint16 reg) {
-    if (!(obj->header.flags & MVM_CF_SECOND_GEN))
+    if (!(obj->header.flags2 & MVM_CF_SECOND_GEN))
         return 0;
     | mov64 TMP1, (uintptr_t)obj;
     | mov WORK[reg], TMP1;
@@ -733,7 +733,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
             | jnz >4;
             /* if null, vivify as type object from spesh slot */
             | get_spesh_slot TMP3, spesh_idx;
-            if (!(spesh_value->flags & MVM_CF_SECOND_GEN)) {
+            if (!(spesh_value->flags2 & MVM_CF_SECOND_GEN)) {
                 /* need to hit write barrier? */
                 | check_wb TMP1, TMP3, >3;
                 | mov qword [rbp-0x28], TMP2; // address

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -276,15 +276,15 @@ static MVMuint64 get_collectable_idx(MVMThreadContext *tc,
         MVMHeapSnapshotState *ss, MVMCollectable *collectable) {
     MVMuint64 idx;
     if (!seen(tc, ss, collectable, &idx)) {
-        if (collectable->flags & MVM_CF_STABLE) {
+        if (collectable->flags1 & MVM_CF_STABLE) {
             idx = push_workitem(tc, ss, MVM_SNAPSHOT_COL_KIND_STABLE, collectable);
             ss->col->total_stables++;
         }
-        else if (collectable->flags & MVM_CF_TYPE_OBJECT) {
+        else if (collectable->flags1 & MVM_CF_TYPE_OBJECT) {
             idx = push_workitem(tc, ss, MVM_SNAPSHOT_COL_KIND_TYPE_OBJECT, collectable);
             ss->col->total_typeobjects++;
         }
-        else if (collectable->flags & MVM_CF_FRAME) {
+        else if (collectable->flags1 & MVM_CF_FRAME) {
             idx = push_workitem(tc, ss, MVM_SNAPSHOT_COL_KIND_FRAME, collectable);
             ss->col->total_frames++;
         }
@@ -383,8 +383,8 @@ static void set_static_frame_index(MVMThreadContext *tc, MVMHeapSnapshotState *s
        marked as live for this gc run. Do it here to prevent it from getting freed
        after taking this heap snapshot, while it's actually still referenced from the
        comp unit's strings list */
-    if (file_name && file_name->common.header.flags & MVM_CF_SECOND_GEN)
-        file_name->common.header.flags |= MVM_CF_GEN2_LIVE;
+    if (file_name && file_name->common.header.flags2 & MVM_CF_SECOND_GEN)
+        file_name->common.header.flags2 |= MVM_CF_GEN2_LIVE;
 
     MVMuint64 file_idx = get_vm_string_index(tc, ss, file_name);
 

--- a/src/profiler/log.c
+++ b/src/profiler/log.c
@@ -434,14 +434,14 @@ void MVM_profiler_log_gc_deallocate(MVMThreadContext *tc, MVMObject *object) {
 
         MVMuint8 dealloc_target = 0;
 
-        if (what->header.flags & MVM_CF_FORWARDER_VALID)
+        if (what->header.flags2 & MVM_CF_FORWARDER_VALID)
             what = (MVMObject *)what->header.sc_forward_u.forwarder;
 
         MVM_ASSERT_NOT_FROMSPACE(tc, what);
 
-        if (item->flags & MVM_CF_SECOND_GEN)
+        if (item->flags2 & MVM_CF_SECOND_GEN)
             dealloc_target = 2;
-        else if (item->flags & MVM_CF_NURSERY_SEEN)
+        else if (item->flags2 & MVM_CF_NURSERY_SEEN)
             dealloc_target = 1;
 
         /* See if there's an existing node to update. */

--- a/src/spesh/candidate.c
+++ b/src/spesh/candidate.c
@@ -179,7 +179,7 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
     spesh->body.spesh_candidates = new_candidate_list;
 
     /* May now be referencing nursery objects, so barrier just in case. */
-    if (spesh->common.header.flags & MVM_CF_SECOND_GEN)
+    if (spesh->common.header.flags2 & MVM_CF_SECOND_GEN)
         MVM_gc_write_barrier_hit(tc, (MVMCollectable *)spesh);
 
     /* Regenerate the guards, and bump the candidate count only after they

--- a/src/spesh/dump.c
+++ b/src/spesh/dump.c
@@ -380,7 +380,7 @@ static void dump_bb(MVMThreadContext *tc, DumpStr *ds, MVMSpeshGraph *g, MVMSpes
                 if (sc)
                     result = (MVMCollectable *)MVM_sc_try_get_object(tc, sc, idx);
                 if (result) {
-                    if (result->flags & MVM_CF_STABLE) {
+                    if (result->flags1 & MVM_CF_STABLE) {
                         debug_name = MVM_6model_get_stable_debug_name(tc, (MVMSTable *)result);
                         repr_name  = ((MVMSTable *)result)->REPR->name;
                     } else {
@@ -655,10 +655,10 @@ char * MVM_spesh_dump(MVMThreadContext *tc, MVMSpeshGraph *g) {
             MVMCollectable *value = g->spesh_slots[i];
             if (value == NULL)
                 appendf(&ds, "    %d = NULL\n", i);
-            else if (value->flags & MVM_CF_STABLE)
+            else if (value->flags1 & MVM_CF_STABLE)
                 appendf(&ds, "    %d = STable (%s)\n", i,
                     MVM_6model_get_stable_debug_name(tc, (MVMSTable *)value));
-            else if (value->flags & MVM_CF_TYPE_OBJECT)
+            else if (value->flags1 & MVM_CF_TYPE_OBJECT)
                 appendf(&ds, "    %d = Type Object (%s)\n", i,
                     MVM_6model_get_debug_name(tc, (MVMObject *)value));
             else {


### PR DESCRIPTION
"paranoia" checks added as part of work on the new hash tables reveal that there is a nasty data race when setting flag bits in `MVMCollectable`

Specifically, if one thread calls `MVM_gc_object_id` for an object that does not yet have an ID, and another thread calls `MVM_gc_write_barrier_hit_by` for the same object, then each function needs to perform a read, modify, write on the object's flags. If the data race is hit, then the setting of one of the flags bits is lost. If `MVM_CF_HAS_OBJECT_ID` fails to be set, then we simply leak a little memory in the gen2 pools. If `MVM_CF_REF_FROM_GEN2` fails to be set, then the GC doesn't function properly.

A solution to this is to split the flags from a single `MVMuint16` into two `MVMuint8`s and partition the flags bits across the two, so that these two hot flags are not in the same byte. This way, each can be updated without causing a data race with the other. The proposed split turns out to be quite easily memorable - other than `MVM_CF_HAS_OBJECT_ID`, all "gen2", "nursery" and GC related flags go into `flags2`, all others into `flags1`.

Unfortunately rakudo's extension ops have an unhealthy amount of tight coupling with MoarVM, including (ab)using a free bit in the flags for `FIRST` handling. Hence rakudo needs to be changed before it can build with these changes. The proposed patch to rakudo makes it build with both MoarVM `master` and this branch

Suggested actions

1. review this branch for sanity. test with NQP
2. review the necessary rakudo changes at https://github.com/nwc10/rakudo/tree/flags-split
3. push the **rakudo** changes to master
4. push the MoarVM changes to master

(intersperse with testing as necessary)(as expected, the automatic tests here fail currently, because Rakudo has not been patched)

Problem found by @dogbert17, cause diagnosed by @niner