### PR TITLE
make moar --dump use memmem to find "MOARVM\r\n" string

### DIFF
--- a/3rdparty/freebsd/memmem.c
+++ b/3rdparty/freebsd/memmem.c
@@ -1,3 +1,4 @@
+#if defined(_WIN32) || defined(__APPLE__) || defined(__Darwin__) || defined(__sun)
 /*-
  * Copyright (c) 2005-2014 Rich Felker, et al.
  *
@@ -179,3 +180,4 @@ void *memmem(const void *h0, size_t k, const void *n0, size_t l)
 
 	return twoway_memmem(h, h+k, n, l);
 }
+#endif

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -243,6 +243,7 @@ OBJECTS2 = src/6model/reprs/MVMDLLSym@obj@ \
           src/platform/sys@obj@ \
           src/platform/random@obj@ \
           src/platform/memmem32@obj@ \
+          3rdparty/freebsd/memmem@obj@ \
           src/platform/malloc_trim@obj@ \
           src/moar@obj@ \
           @platform@ \

--- a/src/moar.c
+++ b/src/moar.c
@@ -500,8 +500,11 @@ void MVM_vm_dump_file(MVMInstance *instance, const char *filename) {
     block = MVM_platform_map_file(fd, &handle, (size_t)size, 0);
 
     if (block == NULL) {
-        /* FIXME: check errno or GetLastError() */
-        MVM_exception_throw_adhoc(tc, "Could not map file '%s' into memory: %s", filename, "FIXME");
+#if defined(_WIN32)
+        MVM_exception_throw_adhoc(tc, "Could not map file '%s' into memory: %d", filename, GetLastError());
+#else
+        MVM_exception_throw_adhoc(tc, "Could not map file '%s' into memory: %s", filename, strerror(errno));
+#endif
     }
 
     /* Look for MOARVM magic string from the start of the file. */

--- a/src/platform/memmem.h
+++ b/src/platform/memmem.h
@@ -15,9 +15,7 @@
 #include <string.h>
 #endif
 
-void * MVM_memmem(const void *haystack, size_t haystacklen, const void *needle, size_t needlelen) {
-    return memmem(haystack, haystacklen, needle, needlelen);
-}
+#define MVM_memmem memmem
 
 /* Extended info:
  * In glibc, the Knuth-Morris-Pratt algorithm was added as of git tag glibc-2.8-44-g0caca71ac9 */

--- a/src/platform/memmem.h
+++ b/src/platform/memmem.h
@@ -7,7 +7,7 @@
  * Solaris doesn't seem to have memmem                                        */
 
 #if defined(_WIN32) || defined(__APPLE__) || defined(__Darwin__) || defined(__sun)
-#include "../3rdparty/freebsd/memmem.c"
+void *memmem(const void *h0, size_t k, const void *n0, size_t l);
 #else
 /* On systems that use glibc, you must define _GNU_SOURCE before including string.h
  * to get access to memmem. */

--- a/src/platform/memmem.h
+++ b/src/platform/memmem.h
@@ -7,6 +7,7 @@
  * Solaris doesn't seem to have memmem                                        */
 
 #if defined(_WIN32) || defined(__APPLE__) || defined(__Darwin__) || defined(__sun)
+#include <stdlib.h>
 void *memmem(const void *h0, size_t k, const void *n0, size_t l);
 #else
 /* On systems that use glibc, you must define _GNU_SOURCE before including string.h


### PR DESCRIPTION
this is the magic marker that starts a moarvm bytecode file.

precomp folders have a bit of information prepended to the
moar bytecode files, and having to manually cut it off can
be tedious. Since moar --dump is a user-facing and debugging
feature, it should be fine to have it do a skipping or
searching step first.

making this a pull request because i want an opinion on whether it's fine to turn the MVM_memmem function into a define.