### PR TITLE
sparc64 support

### DIFF
--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -999,10 +999,13 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
                 align_to(&cur_offset, (MVMuint32)ss->align);
                 cur_offset += ss->bits / 8;
             }
-            else
+            else {
+                align_to(&cur_offset, ALIGNOF(MVMObject *));
                 cur_offset += sizeof(MVMObject *);
+            }
         }
         else {
+            align_to(&cur_offset, ALIGNOF(MVMObject *));
             cur_offset += sizeof(MVMObject *);
         }
     }
@@ -1177,6 +1180,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     cur_gc_cleanup_slot = 0;
     for (i = 0; i < repr_data->num_attributes; i++) {
         if (repr_data->flattened_stables[i] == NULL) {
+            align_to(&cur_offset, ALIGNOF(MVMObject *));
             /* Store position. */
             repr_data->attribute_offsets[i] = cur_offset;
 
@@ -1212,6 +1216,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
             cur_offset += spec->bits / 8;
         }
     }
+    assert(cur_offset <= st->size + sizeof(MVMP6opaqueBody) - sizeof(MVMP6opaque));
     repr_data->initialize_slots[cur_initialize_slot] = -1;
     repr_data->gc_mark_slots[cur_gc_mark_slot] = -1;
     repr_data->gc_cleanup_slots[cur_gc_cleanup_slot] = -1;

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -37,9 +37,18 @@ MVM_STATIC_INLINE MVMuint16 check_lex(MVMThreadContext *tc, MVMFrame *f, MVMuint
 #endif
 #define GET_I16(pc, idx)    *((MVMint16 *)(pc + idx))
 #define GET_UI16(pc, idx)   *((MVMuint16 *)(pc + idx))
-#define GET_I32(pc, idx)    *((MVMint32 *)(pc + idx))
-#define GET_UI32(pc, idx)   *((MVMuint32 *)(pc + idx))
-#define GET_N32(pc, idx)    *((MVMnum32 *)(pc + idx))
+
+MVM_STATIC_INLINE MVMint32 GET_I32(const MVMuint8 *pc, MVMint32 idx) {
+    MVMint32 retval;
+    memcpy(&retval, pc + idx, sizeof(retval));
+    return retval;
+}
+
+MVM_STATIC_INLINE MVMuint32 GET_UI32(const MVMuint8 *pc, MVMint32 idx) {
+    MVMuint32 retval;
+    memcpy(&retval, pc + idx, sizeof(retval));
+    return retval;
+}
 
 #define NEXT_OP (op = *(MVMuint16 *)(cur_op), cur_op += 2, op)
 

--- a/src/core/validation.c
+++ b/src/core/validation.c
@@ -11,9 +11,12 @@
 #define GET_REG(pc, idx)    *((MVMuint16 *)(pc + idx))
 #define GET_I16(pc, idx)    *((MVMint16 *)(pc + idx))
 #define GET_UI16(pc, idx)   *((MVMuint16 *)(pc + idx))
-#define GET_I32(pc, idx)    *((MVMint32 *)(pc + idx))
-#define GET_UI32(pc, idx)   *((MVMuint32 *)(pc + idx))
-#define GET_N32(pc, idx)    *((MVMnum32 *)(pc + idx))
+
+MVM_STATIC_INLINE MVMuint32 GET_UI32(const MVMuint8 *pc, MVMint32 idx) {
+    MVMuint32 retval;
+    memcpy(&retval, pc + idx, sizeof(retval));
+    return retval;
+}
 
 #define MSG(val, msg) "Bytecode validation error at offset %" PRIu32 \
     ", instruction %" PRIu32 ":\n" msg, \

--- a/src/moar.h
+++ b/src/moar.h
@@ -259,7 +259,8 @@ MVM_PUBLIC void MVM_vm_event_subscription_configure(MVMThreadContext *tc, MVMObj
 /* Returns absolute executable path. */
 MVM_PUBLIC int MVM_exepath(char* buffer, size_t* size);
 
-#if defined(__s390__)
+/* Seems that both 32 and 64 bit sparc need this crutch */
+#if defined(__s390__) || defined(__sparc__)
 AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t new_val);
 # define AO_fetch_compare_and_swap_full(addr, old, newval) \
     AO_fetch_compare_and_swap_emulation(addr, old, newval)

--- a/src/spesh/codegen.c
+++ b/src/spesh/codegen.c
@@ -380,8 +380,8 @@ MVMSpeshCode * MVM_spesh_codegen(MVMThreadContext *tc, MVMSpeshGraph *g) {
 
     /* Fixup labels we were too early for. */
     for (i = 0; i < ws->num_fixups; i++)
-        *((MVMuint32 *)(ws->bytecode + ws->fixup_locations[i])) =
-            ws->bb_offsets[ws->fixup_bbs[i]->idx];
+        memcpy((ws->bytecode + ws->fixup_locations[i]),
+               ws->bb_offsets + ws->fixup_bbs[i]->idx, sizeof(MVMuint32));
 
     /* Ensure all handlers that are reachable got fixed up. */
     for (i = 0; i < g->num_handlers; i++) {

--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -10,9 +10,24 @@
 #define GET_UI8(pc, idx)    *((MVMuint8 *)((pc) + (idx)))
 #define GET_I16(pc, idx)    *((MVMint16 *)((pc) + (idx)))
 #define GET_UI16(pc, idx)   *((MVMuint16 *)((pc) + (idx)))
-#define GET_I32(pc, idx)    *((MVMint32 *)((pc) + (idx)))
-#define GET_UI32(pc, idx)   *((MVMuint32 *)((pc) + (idx)))
-#define GET_N32(pc, idx)    *((MVMnum32 *)((pc) + (idx)))
+
+MVM_STATIC_INLINE MVMint32 GET_I32(const MVMuint8 *pc, MVMint32 idx) {
+    MVMint32 retval;
+    memcpy(&retval, pc + idx, sizeof(retval));
+    return retval;
+}
+
+MVM_STATIC_INLINE MVMuint32 GET_UI32(const MVMuint8 *pc, MVMint32 idx) {
+    MVMuint32 retval;
+    memcpy(&retval, pc + idx, sizeof(retval));
+    return retval;
+}
+
+MVM_STATIC_INLINE MVMuint32 GET_N32(const MVMuint8 *pc, MVMint32 idx) {
+    MVMnum32 retval;
+    memcpy(&retval, pc + idx, sizeof(retval));
+    return retval;
+}
 
 /* Allocate a piece of memory from the spesh graph's region
  * allocator. Deallocated when the spesh graph is. */


### PR DESCRIPTION
With this MoarVM, NQP and Rakudo build on sparc64.

Rakudo fails `t/04-nativecall/06-struct` with a SIGBUS, and `t/04-nativecall/02-simple-args.t` with the same failure as PowerPC (have not yet investigated whether this is a big endian "issue", bad assumptions about char being signed always, or something else)

Some spectests fail:

```
t/spec/S02-types/native.rakudo.moar                             (Wstat: 768 Tests: 95 Failed: 3)
  Failed tests:  75, 79, 83
  Non-zero exit status: 3
t/spec/S02-types/int-uint.rakudo.moar                           (Wstat: 3072 Tests: 103 Failed: 12)
  Failed tests:  45, 48, 54, 56, 59, 65, 67, 70, 76, 89
                92, 98
  Non-zero exit status: 12
t/spec/S12-construction/BUILD.rakudo.moar                       (Wstat: 256 Tests: 7 Failed: 0)
  Non-zero exit status: 1
  Parse errors: Bad plan.  You planned 12 tests but ran 7.
t/spec/S09-typed-arrays/native-int.rakudo.moar                  (Wstat: 768 Tests: 1363 Failed: 3)
  Failed tests:  907, 1076, 1245
  Non-zero exit status: 3
t/spec/S32-io/utf16.t                                           (Wstat: 1536 Tests: 39 Failed: 6)
  Failed tests:  2, 13-15, 28, 32
  Non-zero exit status: 6
t/spec/integration/weird-errors.rakudo.moar                     (Wstat: 256 Tests: 35 Failed: 1)
  Failed test:  15
  Non-zero exit status: 1
```

These are the same as the tests that fail on pp64, other than `t/spec/integration/weird-errors.rakudo.moar`

Test 15 is _sorting method list does not segfault_

It doesn't SEGV, but it produces a lot of unexpected output:

```
not ok 15 - sorting method list does not segfault
# Failed test 'sorting method list does not segfault'
# at /home/nick/Perl/rakudo/t/spec/packages/Test-Helpers/lib/Test/Util.pm6 (Test::Util) line 163
#      got err: "Method object coerced to string (please use .gist or .raku to do that)\n  in block <unit> at /tmp/getout-3348851-415020.code line 1\nMethod object coerced to string (please use .gist or .raku to do that)\n  in block <unit> at /tmp/getout-3348851-415020.code line 1\nMethod object coerced to string (please use .gist or .raku to do that)\n  in block <unit> at /tmp/getout-3348851-415020.code line 1\nMethod object coerced to string (please use .gist or .raku to do that)\n  in block <unit> at /tmp/getout-3348851-415020.code line 1\nMethod object coerced to string (please use .gist or .raku to do that)\n  in block <unit> at /tmp/getout-3348851-415020.code line 1\nMethod object coerced to string (please use .gist or .raku to do that)\n  in block <unit> at /tmp/getout-3348851-415020.code line 1\nMethod object coerced to string (please use .gist or .raku to do that)\n  in block <unit> at /tmp/getout-3348851-415020.code line 1\n
```
_etc_ _etc_

I have not yet investigated this.

sparc32 passes but not out of the box. If I build with `-m32` then both nativecall and libtomath assume that it's still a 64 bit sparc platform (v9), and screw up. If I hack them to take their sparc v8 code choices then everything works. If I force things with -mcpu=v8 then they both work, but the gcc builtins for atomic operations break - `libgcc_s` is missing some support functions. I'm not sure where the blame is here. clang is even worse - if told to build `-m32` then it immediately reports itself as `__sparc_v8` but also tries to build with 8-byte `long doubles` (they should be 16), fails to link, and fails to even compile if I turn the optimiser on. (header file errors - WTF‽). There will be some bug reports once I figure out *how* many bugs there really are here. I can't be the first person to have hit any of these.

But I think that this branch (all 2 commits of it) is good, and might even buy us some more platforms if they are exacting about memory alignment.