### PR TITLE
copy_to should call MVM_gc_write_barrier with the *new* key's address.

### DIFF
--- a/src/6model/reprs/HashAttrStore.c
+++ b/src/6model/reprs/HashAttrStore.c
@@ -37,7 +37,7 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
         MVMHashEntry *entry = MVM_str_hash_current_nocheck(tc, src_hashtable, iterator);
         MVMHashEntry *new_entry = MVM_str_hash_insert_nocheck(tc, dest_hashtable, entry->hash_handle.key);
         MVM_ASSIGN_REF(tc, &(dest_root->header), new_entry->value, entry->value);
-        MVM_gc_write_barrier(tc, &(dest_root->header), &(entry->hash_handle.key->common.header));
+        MVM_gc_write_barrier(tc, &(dest_root->header), &(new_entry->hash_handle.key->common.header));
         iterator = MVM_str_hash_next_nocheck(tc, src_hashtable, iterator);
     }
 }

--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -43,7 +43,7 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
         MVMHashEntry *entry = MVM_str_hash_current_nocheck(tc, src_hashtable, iterator);
         MVMHashEntry *new_entry = MVM_str_hash_insert_nocheck(tc, dest_hashtable, entry->hash_handle.key);
         MVM_ASSIGN_REF(tc, &(dest_root->header), new_entry->value, entry->value);
-        MVM_gc_write_barrier(tc, &(dest_root->header), &(entry->hash_handle.key->common.header));
+        MVM_gc_write_barrier(tc, &(dest_root->header), &(new_entry->hash_handle.key->common.header));
         iterator = MVM_str_hash_next_nocheck(tc, src_hashtable, iterator);
     }
 }


### PR DESCRIPTION
This is a regression introduced since the last release by commit 9d0f1b326d8d:
    Replace MVM_str_hash_bind_nt with MVM_str_hash_insert_nt.

(I think. Please can someone double check this)