### PR TITLE
Hash bits in metadata

### DIFF
--- a/src/6model/reprs/HashAttrStore.c
+++ b/src/6model/reprs/HashAttrStore.c
@@ -141,6 +141,12 @@ static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSeri
     st->size = sizeof(MVMHashAttrStore);
 }
 
+static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data) {
+    MVMHashBody *body = (MVMHashBody *)data;
+
+    return MVM_str_hash_allocated_size(tc, &(body->hashtable));
+}
+
 /* Initializes the representation. */
 const MVMREPROps * MVMHashAttrStore_initialize(MVMThreadContext *tc) {
     return &HashAttrStore_this_repr;
@@ -178,6 +184,6 @@ static const MVMREPROps HashAttrStore_this_repr = {
     NULL, /* spesh */
     "HashAttrStore", /* name */
     MVM_REPR_ID_HashAttrStore,
-    NULL, /* unmanaged_size */
+    unmanaged_size,
     NULL, /* describe_refs */
 };

--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -254,7 +254,7 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
 static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data) {
     MVMHashBody *body = (MVMHashBody *)data;
 
-    return sizeof(MVMHashEntry) * MVM_str_hash_count(tc, &(body->hashtable));
+    return MVM_str_hash_allocated_size(tc, &(body->hashtable));
 }
 
 /* Initializes the representation. */

--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -227,10 +227,7 @@ static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data)
 
         size += sizeof(MVMString *) * body->num_lexicals;
 
-        /* This isn't quite accurate. Should we try to be more accurate? */
-        if (MVM_index_hash_built(tc, &body->lexical_names)) {
-            size += sizeof(struct MVMIndexHashEntry) * body->num_lexicals;
-        }
+        size += MVM_index_hash_allocated_size(tc, &body->lexical_names);
 
         size += sizeof(MVMFrameHandler) * body->num_handlers;
 

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -66,7 +66,9 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = max_probe_distance_limit > (4 - 1) ? (4 - 1) : max_probe_distance_limit;
+    control->metadata_hash_bits = 0;
+    MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
+    control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
     control->entry_size = entry_size;
@@ -119,8 +121,8 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
                 MVMuint8 *find_me_a_gap = ls.metadata;
                 MVMuint8 old_probe_distance = *ls.metadata;
                 do {
-                    MVMuint8 new_probe_distance = 1 + old_probe_distance;
-                    if (new_probe_distance == control->max_probe_distance) {
+                    MVMuint32 new_probe_distance = ls.metadata_increment + old_probe_distance;
+                    if (new_probe_distance >> ls.probe_distance_shift == ls.max_probe_distance) {
                         /* Optimisation from Martin Ankerl's implementation:
                            setting this to zero forces a resize on any insert,
                            *before* the actual insert, so that we never end up
@@ -151,7 +153,7 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
              */
-            if (ls.probe_distance == control->max_probe_distance) {
+            if (ls.probe_distance >> ls.probe_distance_shift == control->max_probe_distance) {
                 control->max_items = 0;
             }
 
@@ -175,7 +177,7 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
                 return indirection;
             }
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
 
@@ -193,7 +195,7 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
+        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + MVM_fixkey_hash_max_items(control));
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }
@@ -208,6 +210,7 @@ static struct MVMFixKeyHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
     /* control->max_items may have been set to 0 to trigger a call into this
      * function. */
     MVMuint32 max_items = MVM_fixkey_hash_max_items(control);
+    MVMuint32 max_probe_distance = control->max_probe_distance;
     MVMuint32 max_probe_distance_limit = control->max_probe_distance_limit;
 
     /* We can hit both the probe limit and the max items on the same insertion.
@@ -216,10 +219,9 @@ static struct MVMFixKeyHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
      * then we don't have more space in the metadata, so we're going to have to
      * grow anyway. */
     if (control->cur_items < max_items
-        && control->max_probe_distance < max_probe_distance_limit) {
+        && max_probe_distance < max_probe_distance_limit) {
         /* We hit the probe limit, but not the max items count. */
-        MVMuint32 new_probe_distance
-            = 2 + 2 * (MVMuint32) control->max_probe_distance;
+        MVMuint32 new_probe_distance = 1 + 2 * max_probe_distance;
         if (new_probe_distance > max_probe_distance_limit) {
             new_probe_distance = max_probe_distance_limit;
         }

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -3,14 +3,14 @@
 #define FIXKEY_INITIAL_SIZE_LOG2 3
 #define FIXKEY_INITIAL_KEY_RIGHT_SHIFT (8 * sizeof(MVMuint64) - 3)
 
-MVM_STATIC_INLINE MVMuint32 hash_true_size(const struct MVMFixKeyHashTableControl *control) {
+MVM_STATIC_INLINE MVMuint32 calc_entries_in_use(const struct MVMFixKeyHashTableControl *control) {
     return MVM_fixkey_hash_official_size(control) + control->max_probe_distance;
 }
 
 void hash_demolish_internal(MVMThreadContext *tc,
                             struct MVMFixKeyHashTableControl *control) {
-    size_t actual_items = hash_true_size(control);
-    size_t entries_size = sizeof(MVMString ***) * actual_items;
+    size_t allocated_items = MVM_fixkey_hash_allocated_items(control);
+    size_t entries_size = sizeof(MVMString ***) * allocated_items;
     char *start = (char *)control - entries_size;
     MVM_free(start);
 }
@@ -22,11 +22,11 @@ void MVM_fixkey_hash_demolish(MVMThreadContext *tc, MVMFixKeyHashTable *hashtabl
     if (!control)
         return;
 
-    MVMuint32 true_size = hash_true_size(control);
+    MVMuint32 entries_in_use = calc_entries_in_use(control);
     MVMuint8 *entry_raw = MVM_fixkey_hash_entries(control);
     MVMuint8 *metadata = MVM_fixkey_hash_metadata(control);
     MVMuint32 bucket = 0;
-    while (bucket < true_size) {
+    while (bucket < entries_in_use) {
         if (*metadata) {
             MVMString ***indirection = (MVMString ***) entry_raw;
             MVM_fixed_size_free(tc, tc->instance->fsa, control->entry_size, *indirection);
@@ -48,7 +48,6 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
                                                                          MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_FIXKEY_HASH_LOAD_FACTOR;
-    MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
      * hence for a value whose ideal slot is the last bucket, it's *in* the
@@ -57,15 +56,15 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
      * allocation
      * probe distance of 255 is the 254th beyond the official allocation.
      */
-    MVMuint8 probe_overflow_size;
-    if (MVM_HASH_MAX_PROBE_DISTANCE < overflow_size) {
-        probe_overflow_size = MVM_HASH_MAX_PROBE_DISTANCE - 1;
+    MVMuint8 max_probe_distance_limit;
+    if ((MVM_HASH_MAX_PROBE_DISTANCE - 1) < (max_items - 1)) {
+        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE - 1;
     } else {
-        probe_overflow_size = overflow_size;
+        max_probe_distance_limit = max_items - 1;
     }
-    size_t actual_items = official_size + probe_overflow_size;
-    size_t entries_size = sizeof(MVMString ***) * actual_items;
-    size_t metadata_size = MVM_hash_round_size_up(actual_items + 1);
+    size_t allocated_items = official_size + max_probe_distance_limit;
+    size_t entries_size = sizeof(MVMString ***) * allocated_items;
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
         = entries_size + sizeof(struct MVMFixKeyHashTableControl) + metadata_size;
 
@@ -75,7 +74,8 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = probe_overflow_size;
+    control->max_probe_distance = max_probe_distance_limit;
+    control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
     control->entry_size = entry_size;
 
@@ -83,7 +83,7 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     memset(metadata, 0, metadata_size);
 
     /* A sentinel. This marks an occupied slot, at its ideal position. */
-    metadata[actual_items] = 1;
+    metadata[allocated_items] = 1;
 
     return control;
 }
@@ -215,7 +215,7 @@ void *MVM_fixkey_hash_lvalue_fetch_nocheck(MVMThreadContext *tc,
             return entry;
         }
 
-        MVMuint32 true_size =  hash_true_size(control);
+        MVMuint32 entries_in_use =  calc_entries_in_use(control);
         MVMuint8 *entry_raw_orig = MVM_fixkey_hash_entries(control);
         MVMuint8 *metadata_orig = MVM_fixkey_hash_metadata(control);
 
@@ -231,7 +231,7 @@ void *MVM_fixkey_hash_lvalue_fetch_nocheck(MVMThreadContext *tc,
         MVMuint8 *entry_raw = entry_raw_orig;
         MVMuint8 *metadata = metadata_orig;
         MVMHashNumItems bucket = 0;
-        while (bucket < true_size) {
+        while (bucket < entries_in_use) {
             if (*metadata) {
                 /* We need to "move" the pointer to entry from the old flat
                  * storage array storage to the new flat storage array.
@@ -297,12 +297,12 @@ MVMuint64 MVM_fixkey_hash_fsck(MVMThreadContext *tc, MVMFixKeyHashTable *hashtab
         return 0;
     }
 
-    MVMuint32 true_size = hash_true_size(control);
+    MVMuint32 entries_in_use = calc_entries_in_use(control);
     MVMuint8 *entry_raw = MVM_fixkey_hash_entries(control);
     MVMuint8 *metadata = MVM_fixkey_hash_metadata(control);
     MVMuint32 bucket = 0;
     MVMint64 prev_offset = 0;
-    while (bucket < true_size) {
+    while (bucket < entries_in_use) {
         if (!*metadata) {
             /* empty slot. */
             prev_offset = 0;

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -77,14 +77,6 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
-    /* A sentinel. This marks an occupied slot, at its ideal position.
-     * As long as we start with (no more than) 5 metadata hash bits, certainly
-     * for the load factor we currently have (0.75) we can't actually reach this
-     * sentinel even with long-at-a-time reprocessing of the metadata, for any
-     * size shorter than the full allocation (at which point we no longer
-     * reprocess). */
-    metadata[allocated_items] = 1;
-
     return control;
 }
 
@@ -233,7 +225,6 @@ static struct MVMFixKeyHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         }
 
         MVMuint8 *metadata = MVM_fixkey_hash_metadata(control);
-        assert(metadata[MVM_fixkey_hash_allocated_items(control)] == 1);
         MVMuint32 in_use_items = MVM_fixkey_hash_official_size(control) + max_probe_distance;
         /* not `in_use_items + 1` because because we don't need to shift the
          * sentinel. */
@@ -249,7 +240,6 @@ static struct MVMFixKeyHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
             *p = (*p >> 1) & (0x7F7F7F7FUL | (0x7F7F7F7FUL << (4 * sizeof(long))));
             ++p;
         } while (--loop_count);
-        assert(metadata[MVM_fixkey_hash_allocated_items(control)] == 1);
         assert(control->metadata_hash_bits);
         --control->metadata_hash_bits;
 

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -59,6 +59,7 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
         = entries_size + sizeof(struct MVMFixKeyHashTableControl) + metadata_size;
+    assert(total_size == MVM_hash_round_size_up(total_size));
 
     struct MVMFixKeyHashTableControl *control =
         (struct MVMFixKeyHashTableControl *) ((char *)MVM_malloc(total_size) + entries_size);

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -4,7 +4,7 @@
 #define FIXKEY_INITIAL_KEY_RIGHT_SHIFT (8 * sizeof(MVMuint64) - 3)
 
 MVM_STATIC_INLINE MVMuint32 calc_entries_in_use(const struct MVMFixKeyHashTableControl *control) {
-    return MVM_fixkey_hash_official_size(control) + control->max_probe_distance;
+    return MVM_fixkey_hash_official_size(control) + control->max_probe_distance - 1;
 }
 
 void hash_demolish_internal(MVMThreadContext *tc,
@@ -48,21 +48,13 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
                                                                          MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_FIXKEY_HASH_LOAD_FACTOR;
-    /* -1 because...
-     * probe distance of 1 is the correct bucket.
-     * hence for a value whose ideal slot is the last bucket, it's *in* the
-     * official allocation.
-     * probe distance of 2 is the first extra bucket beyond the official
-     * allocation
-     * probe distance of 255 is the 254th beyond the official allocation.
-     */
     MVMuint8 max_probe_distance_limit;
-    if ((MVM_HASH_MAX_PROBE_DISTANCE - 1) < (max_items - 1)) {
-        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE - 1;
+    if (MVM_HASH_MAX_PROBE_DISTANCE  < max_items) {
+        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE;
     } else {
-        max_probe_distance_limit = max_items - 1;
+        max_probe_distance_limit = max_items;
     }
-    size_t allocated_items = official_size + max_probe_distance_limit;
+    size_t allocated_items = official_size + max_probe_distance_limit - 1;
     size_t entries_size = sizeof(MVMString ***) * allocated_items;
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
@@ -186,7 +178,22 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+
+        /* For insert, the loop must not iterate to any probe distance greater
+         * than the (current) maximum probe distance, because it must never
+         * insert an entry at a location beyond the maximum probe distance.
+         *
+         * For fetch and delete, the loop is permitted to reach (and read) one
+         * beyond the maximum probe distance (hence +1 in the seemingly
+         * analogous assertions) - but if so, it will always read from the
+         * metadata a probe distance which is lower than the current probe
+         * distance, and hence hit "not found" and terminate the loop.
+         *
+         * This is how the loop terminates when the max probe distance is
+         * reached without needing an explicit test for it, and why we need an
+         * initialised sentinel byte at the end of the metadata. */
+
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + MVM_fixkey_hash_max_items(control));
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -163,8 +163,7 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
             *indirection = NULL;
             return indirection;
         }
-
-        if (*ls.metadata == ls.probe_distance) {
+        else if (*ls.metadata == ls.probe_distance) {
             MVMString ***indirection = (MVMString ***) ls.entry_raw;
             MVMString **entry = *indirection;
             if (*entry == key

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -66,7 +66,8 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->metadata_hash_bits = 0;
+    control->metadata_hash_bits = MVM_HASH_INITIAL_BITS_IN_METADATA;
+    /* ie 7: */
     MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
     control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
@@ -76,7 +77,12 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
-    /* A sentinel. This marks an occupied slot, at its ideal position. */
+    /* A sentinel. This marks an occupied slot, at its ideal position.
+     * As long as we start with (no more than) 5 metadata hash bits, certainly
+     * for the load factor we currently have (0.75) we can't actually reach this
+     * sentinel even with long-at-a-time reprocessing of the metadata, for any
+     * size shorter than the full allocation (at which point we no longer
+     * reprocess). */
     metadata[allocated_items] = 1;
 
     return control;
@@ -225,6 +231,27 @@ static struct MVMFixKeyHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         if (new_probe_distance > max_probe_distance_limit) {
             new_probe_distance = max_probe_distance_limit;
         }
+
+        MVMuint8 *metadata = MVM_fixkey_hash_metadata(control);
+        assert(metadata[MVM_fixkey_hash_allocated_items(control)] == 1);
+        MVMuint32 in_use_items = MVM_fixkey_hash_official_size(control) + max_probe_distance;
+        /* not `in_use_items + 1` because because we don't need to shift the
+         * sentinel. */
+        size_t metadata_size = MVM_hash_round_size_up(in_use_items);
+        size_t loop_count = metadata_size / sizeof(unsigned long);
+        unsigned long *p = (unsigned long *) metadata;
+        /* right shift each byte by 1 bit, clearing the top bit. */
+        do {
+            /* 0x7F7F7F7F7F7F7F7F on 64 bit systems, 0x7F7F7F7F on 32 bit,
+             * but without using constants or shifts larger than 32 bits, or
+             * the preprocessor. (So the compiler checks all code everywhere.)
+             * Will break on a system with 128 bit longs. */
+            *p = (*p >> 1) & (0x7F7F7F7FUL | (0x7F7F7F7FUL << (4 * sizeof(long))));
+            ++p;
+        } while (--loop_count);
+        assert(metadata[MVM_fixkey_hash_allocated_items(control)] == 1);
+        assert(control->metadata_hash_bits);
+        --control->metadata_hash_bits;
 
         control->max_probe_distance = new_probe_distance;
         /* Reset this to its proper value. */

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -1,6 +1,5 @@
 #include "moar.h"
 
-#define FIXKEY_LOAD_FACTOR 0.75
 #define FIXKEY_INITIAL_SIZE_LOG2 3
 #define FIXKEY_INITIAL_KEY_RIGHT_SHIFT (8 * sizeof(MVMuint64) - 3)
 
@@ -48,7 +47,7 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
                                                                          MVMuint8 key_right_shift,
                                                                          MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
-    MVMuint32 max_items = official_size * FIXKEY_LOAD_FACTOR;
+    MVMuint32 max_items = official_size * MVM_FIXKEY_HASH_LOAD_FACTOR;
     MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
@@ -188,7 +187,7 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + MVM_fixkey_hash_max_items(control));
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }
 }

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -192,7 +192,7 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
          * insert an entry at a location beyond the maximum probe distance.
          *
          * For fetch and delete, the loop is permitted to reach (and read) one
-         * beyond the maximum probe distance (hence +1 in the seemingly
+         * beyond the maximum probe distance (hence +2 in the seemingly
          * analogous assertions) - but if so, it will always read from the
          * metadata a probe distance which is lower than the current probe
          * distance, and hence hit "not found" and terminate the loop.
@@ -201,7 +201,7 @@ MVM_STATIC_INLINE MVMString ***hash_insert_internal(MVMThreadContext *tc,
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + MVM_fixkey_hash_max_items(control));
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }

--- a/src/core/fixkey_hash_table.h
+++ b/src/core/fixkey_hash_table.h
@@ -57,6 +57,7 @@ struct MVMFixKeyHashTableControl {
      * We can (re)calcuate this from other values in the struct, but it's easier
      * to cache it as we have the space. */
     MVMuint8 max_probe_distance_limit;
+    MVMuint8 metadata_hash_bits;
 };
 
 struct MVMFixKeyHashTable {

--- a/src/core/fixkey_hash_table.h
+++ b/src/core/fixkey_hash_table.h
@@ -46,8 +46,8 @@ Not all the optimisations described above are in place yet. Starting with
 struct MVMFixKeyHashTableControl {
     MVMHashNumItems cur_items;
     MVMHashNumItems max_items; /* hit this and we grow */
-    MVMHashNumItems official_size;
     MVMuint16 entry_size;
+    MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
     MVMuint8 probe_overflow_size;
 };

--- a/src/core/fixkey_hash_table.h
+++ b/src/core/fixkey_hash_table.h
@@ -49,7 +49,14 @@ struct MVMFixKeyHashTableControl {
     MVMuint16 entry_size;
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
+    /* This is the maximum probe distance we can use without updating the
+     * metadata. It might not *yet* be the maximum probe distance possible for
+     * the official_size. */
     MVMuint8 max_probe_distance;
+    /* This is the maximum probe distance possible for the official size.
+     * We can (re)calcuate this from other values in the struct, but it's easier
+     * to cache it as we have the space. */
+    MVMuint8 max_probe_distance_limit;
 };
 
 struct MVMFixKeyHashTable {

--- a/src/core/fixkey_hash_table.h
+++ b/src/core/fixkey_hash_table.h
@@ -49,7 +49,7 @@ struct MVMFixKeyHashTableControl {
     MVMuint16 entry_size;
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
-    MVMuint8 probe_overflow_size;
+    MVMuint8 max_probe_distance;
 };
 
 struct MVMFixKeyHashTable {

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -64,16 +64,14 @@ MVM_fixkey_hash_create_loop_state(MVMThreadContext *tc,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    MVMHashNumItems bucket;
     unsigned int used_hash_bits
         = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
-    if (control->metadata_hash_bits) {
-        retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
-        bucket = used_hash_bits >> control->metadata_hash_bits;
-    } else {
-        /* metadata_increment is 1, metadata_hash_mask is 0 */
-        retval.probe_distance = 1;
-        bucket = used_hash_bits;
+    retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
+    MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
+    if (!control->metadata_hash_bits) {
+        assert(retval.probe_distance == 1);
+        assert(retval.metadata_hash_mask == 0);
+        assert(bucket == used_hash_bits);
     }
 
     retval.entry_raw = MVM_fixkey_hash_entries(control) - bucket * retval.entry_size;

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -4,6 +4,9 @@
 MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_official_size(const struct MVMFixKeyHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
 }
+MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_allocated_items(const struct MVMFixKeyHashTableControl *control) {
+    return MVM_fixkey_hash_official_size(control) + control->max_probe_distance_limit;
+}
 MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_max_items(const struct MVMFixKeyHashTableControl *control) {
     return MVM_fixkey_hash_official_size(control) * MVM_FIXKEY_HASH_LOAD_FACTOR;
 }

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -105,7 +105,7 @@ MVM_STATIC_INLINE void *MVM_fixkey_hash_fetch_nocheck(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*ls.metadata < ls.probe_distance) {
+        else if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -88,7 +88,7 @@ MVM_STATIC_INLINE void *MVM_fixkey_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + MVM_fixkey_hash_max_items(control));
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -1,5 +1,8 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_official_size(const struct MVMFixKeyHashTableControl *control) {
+    return 1 << (MVMuint32)control->official_size_log2;
+}
 MVM_STATIC_INLINE MVMuint8 *MVM_fixkey_hash_metadata(const struct MVMFixKeyHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMFixKeyHashTableControl);
 }
@@ -82,8 +85,8 @@ MVM_STATIC_INLINE void *MVM_fixkey_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + control->official_size + control->max_items);
-        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + control->official_size + 256);
+        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }
 }
 

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -61,9 +61,10 @@ MVM_fixkey_hash_create_loop_state(MVMThreadContext *tc,
     struct MVM_hash_loop_state retval;
     retval.entry_size = sizeof(MVMString ***);
     retval.metadata_increment = 1 << control->metadata_hash_bits;
+    retval.metadata_hash_mask = retval.metadata_increment - 1;
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
-    retval.probe_distance = retval.metadata_increment;
+    retval.probe_distance = retval.metadata_increment | retval.metadata_hash_mask;
     retval.entry_raw = MVM_fixkey_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_fixkey_hash_metadata(control) + bucket;
     return retval;
@@ -105,7 +106,7 @@ MVM_STATIC_INLINE void *MVM_fixkey_hash_fetch_nocheck(MVMThreadContext *tc,
         ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (ls.max_probe_distance + 1) * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 2) * ls.metadata_increment);
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + MVM_fixkey_hash_max_items(control));
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -1,5 +1,9 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+/* See comments in hash_allocate_common (and elsewhere) before changing the
+ * load factor, or FIXKEY_MIN_SIZE_BASE_2 or MVM_HASH_INITIAL_BITS_IN_METADATA,
+ * and test with assertions enabled. The current choices permit certain
+ * optimisation assumptions in parts of the code. */
 #define MVM_FIXKEY_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_official_size(const struct MVMFixKeyHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -4,8 +4,15 @@
 MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_official_size(const struct MVMFixKeyHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
 }
+/* -1 because...
+ * probe distance of 1 is the correct bucket.
+ * hence for a value whose ideal slot is the last bucket, it's *in* the official
+ * allocation.
+ * probe distance of 2 is the first extra bucket beyond the official allocation
+ * probe distance of 255 is the 254th beyond the official allocation.
+ */
 MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_allocated_items(const struct MVMFixKeyHashTableControl *control) {
-    return MVM_fixkey_hash_official_size(control) + control->max_probe_distance_limit;
+    return MVM_fixkey_hash_official_size(control) + control->max_probe_distance_limit - 1;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_max_items(const struct MVMFixKeyHashTableControl *control) {
     return MVM_fixkey_hash_official_size(control) * MVM_FIXKEY_HASH_LOAD_FACTOR;
@@ -84,7 +91,7 @@ MVM_STATIC_INLINE void *MVM_fixkey_hash_fetch_nocheck(MVMThreadContext *tc,
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
                the hash table - it would have stolen this slot, and the key we
-               find here now would have been displaced futher on. Hence, the key
+               find here now would have been displaced further on. Hence, the key
                we seek can't be in the hash table. */
             return NULL;
         }

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -1,7 +1,11 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+#define MVM_FIXKEY_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_official_size(const struct MVMFixKeyHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
+}
+MVM_STATIC_INLINE MVMuint32 MVM_fixkey_hash_max_items(const struct MVMFixKeyHashTableControl *control) {
+    return MVM_fixkey_hash_official_size(control) * MVM_FIXKEY_HASH_LOAD_FACTOR;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_fixkey_hash_metadata(const struct MVMFixKeyHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMFixKeyHashTableControl);
@@ -85,7 +89,7 @@ MVM_STATIC_INLINE void *MVM_fixkey_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + MVM_fixkey_hash_max_items(control));
         assert(ls.metadata < MVM_fixkey_hash_metadata(control) + MVM_fixkey_hash_official_size(control) + 256);
     }
 }

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -153,8 +153,7 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
 
             return;
         }
-
-        if (*ls.metadata == ls.probe_distance) {
+        else if (*ls.metadata == ls.probe_distance) {
             struct MVMIndexHashEntry *entry = (struct MVMIndexHashEntry *) ls.entry_raw;
             if (entry->index == idx) {
                 /* definately XXX - what should we do here? */

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -178,7 +178,7 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
          * insert an entry at a location beyond the maximum probe distance.
          *
          * For fetch and delete, the loop is permitted to reach (and read) one
-         * beyond the maximum probe distance (hence +1 in the seemingly
+         * beyond the maximum probe distance (hence +2 in the seemingly
          * analogous assertions) - but if so, it will always read from the
          * metadata a probe distance which is lower than the current probe
          * distance, and hence hit "not found" and terminate the loop.
@@ -187,7 +187,7 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + control->max_items);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -6,8 +6,11 @@ MVM_STATIC_INLINE void hash_demolish_internal(MVMThreadContext *tc,
                                               struct MVMIndexHashTableControl *control) {
     size_t allocated_items = MVM_index_hash_allocated_items(control);
     size_t entries_size = MVM_hash_round_size_up(sizeof(struct MVMIndexHashEntry) * allocated_items);
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
+    size_t total_size
+        = entries_size + sizeof(struct MVMIndexHashTableControl) + metadata_size;
     char *start = (char *)control - entries_size;
-    MVM_free(start);
+    MVM_fixed_size_free(tc, tc->instance->fsa, total_size, start);
 }
 
 /* Frees the entire contents of the hash, leaving you just the hashtable itself,
@@ -51,7 +54,7 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
     assert(total_size == MVM_hash_round_size_up(total_size));
 
     struct MVMIndexHashTableControl *control =
-        (struct MVMIndexHashTableControl *) ((char *)MVM_malloc(total_size) + entries_size);
+        (struct MVMIndexHashTableControl *) ((char *)MVM_fixed_size_alloc(tc, tc->instance->fsa, total_size) + entries_size);
 
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -45,7 +45,8 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->metadata_hash_bits = 0;
+    control->metadata_hash_bits = MVM_HASH_INITIAL_BITS_IN_METADATA;
+    /* ie 7: */
     MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
     control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
@@ -54,7 +55,12 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
-    /* A sentinel. This marks an occupied slot, at its ideal position. */
+    /* A sentinel. This marks an occupied slot, at its ideal position.
+     * As long as we start with (no more than) 5 metadata hash bits, certainly
+     * for the load factor we currently have (0.75) we can't actually reach this
+     * sentinel even with long-at-a-time reprocessing of the metadata, for any
+     * size shorter than the full allocation (at which point we no longer
+     * reprocess). */
     metadata[allocated_items] = 1;
 
     return control;
@@ -208,6 +214,27 @@ static struct MVMIndexHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         if (new_probe_distance > max_probe_distance_limit) {
             new_probe_distance = max_probe_distance_limit;
         }
+
+        MVMuint8 *metadata = MVM_index_hash_metadata(control);
+        assert(metadata[MVM_index_hash_allocated_items(control)] == 1);
+        MVMuint32 in_use_items = MVM_index_hash_official_size(control) + max_probe_distance;
+        /* not `in_use_items + 1` because because we don't need to shift the
+         * sentinel. */
+        size_t metadata_size = MVM_hash_round_size_up(in_use_items);
+        size_t loop_count = metadata_size / sizeof(unsigned long);
+        unsigned long *p = (unsigned long *) metadata;
+        /* right shift each byte by 1 bit, clearing the top bit. */
+        do {
+            /* 0x7F7F7F7F7F7F7F7F on 64 bit systems, 0x7F7F7F7F on 32 bit,
+             * but without using constants or shifts larger than 32 bits, or
+             * the preprocessor. (So the compiler checks all code everywhere.)
+             * Will break on a system with 128 bit longs. */
+            *p = (*p >> 1) & (0x7F7F7F7FUL | (0x7F7F7F7FUL << (4 * sizeof(long))));
+            ++p;
+        } while (--loop_count);
+        assert(metadata[MVM_index_hash_allocated_items(control)] == 1);
+        assert(control->metadata_hash_bits);
+        --control->metadata_hash_bits;
 
         control->max_probe_distance = new_probe_distance;
         /* Reset this to its proper value. */

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -27,21 +27,13 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
                                                                         MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_INDEX_HASH_LOAD_FACTOR;
-    /* -1 because...
-     * probe distance of 1 is the correct bucket.
-     * hence for a value whose ideal slot is the last bucket, it's *in* the
-     * official allocation.
-     * probe distance of 2 is the first extra bucket beyond the official
-     * allocation
-     * probe distance of 255 is the 254th beyond the official allocation.
-     */
     MVMuint8 max_probe_distance_limit;
-    if ((MVM_HASH_MAX_PROBE_DISTANCE - 1) < (max_items - 1)) {
-        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE - 1;
+    if (MVM_HASH_MAX_PROBE_DISTANCE < max_items) {
+        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE;
     } else {
-        max_probe_distance_limit = max_items - 1;
+        max_probe_distance_limit = max_items;
     }
-    size_t allocated_items = official_size + max_probe_distance_limit;
+    size_t allocated_items = official_size + max_probe_distance_limit - 1;
     size_t entries_size = sizeof(struct MVMIndexHashEntry) * allocated_items;
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
@@ -172,7 +164,22 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+
+        /* For insert, the loop must not iterate to any probe distance greater
+         * than the (current) maximum probe distance, because it must never
+         * insert an entry at a location beyond the maximum probe distance.
+         *
+         * For fetch and delete, the loop is permitted to reach (and read) one
+         * beyond the maximum probe distance (hence +1 in the seemingly
+         * analogous assertions) - but if so, it will always read from the
+         * metadata a probe distance which is lower than the current probe
+         * distance, and hence hit "not found" and terminate the loop.
+         *
+         * This is how the loop terminates when the max probe distance is
+         * reached without needing an explicit test for it, and why we need an
+         * initialised sentinel byte at the end of the metadata. */
+
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + control->max_items);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -1,6 +1,5 @@
 #include "moar.h"
 
-#define INDEX_LOAD_FACTOR 0.75
 #define INDEX_MIN_SIZE_BASE_2 3
 
 MVM_STATIC_INLINE void hash_demolish_internal(MVMThreadContext *tc,
@@ -27,7 +26,7 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
                                                                         MVMuint8 key_right_shift,
                                                                         MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
-    MVMuint32 max_items = official_size * INDEX_LOAD_FACTOR;
+    MVMuint32 max_items = official_size * MVM_INDEX_HASH_LOAD_FACTOR;
     MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
@@ -75,7 +74,7 @@ void MVM_index_hash_build(MVMThreadContext *tc,
         initial_size_base2 = INDEX_MIN_SIZE_BASE_2;
     } else {
         /* Minimum size we need to allocate, given the load factor. */
-        MVMuint32 min_needed = entries * (1.0 / INDEX_LOAD_FACTOR);
+        MVMuint32 min_needed = entries * (1.0 / MVM_INDEX_HASH_LOAD_FACTOR);
         initial_size_base2 = MVM_round_up_log_base2(min_needed);
         if (initial_size_base2 < INDEX_MIN_SIZE_BASE_2) {
             /* "Too small" - use our original defaults. */

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -45,7 +45,9 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = max_probe_distance_limit > (4 - 1) ? (4 - 1) : max_probe_distance_limit;
+    control->metadata_hash_bits = 0;
+    MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
+    control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
 
@@ -109,8 +111,8 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
                 MVMuint8 *find_me_a_gap = ls.metadata;
                 MVMuint8 old_probe_distance = *ls.metadata;
                 do {
-                    MVMuint8 new_probe_distance = 1 + old_probe_distance;
-                    if (new_probe_distance == control->max_probe_distance) {
+                    MVMuint32 new_probe_distance = ls.metadata_increment + old_probe_distance;
+                    if (new_probe_distance >> ls.probe_distance_shift == ls.max_probe_distance) {
                         /* Optimisation from Martin Ankerl's implementation:
                            setting this to zero forces a resize on any insert,
                            *before* the actual insert, so that we never end up
@@ -141,7 +143,7 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
              */
-            if (ls.probe_distance == control->max_probe_distance) {
+            if (ls.probe_distance >> ls.probe_distance_shift == control->max_probe_distance) {
                 control->max_items = 0;
             }
 
@@ -161,7 +163,7 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
                 MVM_oops(tc, "insert duplicate for %u", idx);
             }
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
 
@@ -179,7 +181,7 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
+        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + control->max_items);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }
@@ -191,6 +193,7 @@ static struct MVMIndexHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
     /* control->max_items may have been set to 0 to trigger a call into this
      * function. */
     MVMuint32 max_items = MVM_index_hash_max_items(control);
+    MVMuint32 max_probe_distance = control->max_probe_distance;
     MVMuint32 max_probe_distance_limit = control->max_probe_distance_limit;
 
     /* We can hit both the probe limit and the max items on the same insertion.
@@ -199,10 +202,9 @@ static struct MVMIndexHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
      * then we don't have more space in the metadata, so we're going to have to
      * grow anyway. */
     if (control->cur_items < max_items
-        && control->max_probe_distance < max_probe_distance_limit) {
+        && max_probe_distance < max_probe_distance_limit) {
         /* We hit the probe limit, but not the max items count. */
-        MVMuint32 new_probe_distance
-            = 2 + 2 * (MVMuint32) control->max_probe_distance;
+        MVMuint32 new_probe_distance = 1 + 2 * max_probe_distance;
         if (new_probe_distance > max_probe_distance_limit) {
             new_probe_distance = max_probe_distance_limit;
         }

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -4,8 +4,8 @@
 
 MVM_STATIC_INLINE void hash_demolish_internal(MVMThreadContext *tc,
                                               struct MVMIndexHashTableControl *control) {
-    size_t actual_items = MVM_index_hash_kompromat(control);
-    size_t entries_size = sizeof(struct MVMIndexHashEntry) * actual_items;
+    size_t allocated_items = MVM_index_hash_allocated_items(control);
+    size_t entries_size = sizeof(struct MVMIndexHashEntry) * allocated_items;
     char *start = (char *)control - entries_size;
     MVM_free(start);
 }
@@ -27,7 +27,6 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
                                                                         MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_INDEX_HASH_LOAD_FACTOR;
-    MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
      * hence for a value whose ideal slot is the last bucket, it's *in* the
@@ -36,15 +35,15 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
      * allocation
      * probe distance of 255 is the 254th beyond the official allocation.
      */
-    MVMuint8 probe_overflow_size;
-    if (MVM_HASH_MAX_PROBE_DISTANCE < overflow_size) {
-        probe_overflow_size = MVM_HASH_MAX_PROBE_DISTANCE - 1;
+    MVMuint8 max_probe_distance_limit;
+    if ((MVM_HASH_MAX_PROBE_DISTANCE - 1) < (max_items - 1)) {
+        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE - 1;
     } else {
-        probe_overflow_size = overflow_size;
+        max_probe_distance_limit = max_items - 1;
     }
-    size_t actual_items = official_size + probe_overflow_size;
-    size_t entries_size = sizeof(struct MVMIndexHashEntry) * actual_items;
-    size_t metadata_size = MVM_hash_round_size_up(actual_items + 1);
+    size_t allocated_items = official_size + max_probe_distance_limit;
+    size_t entries_size = sizeof(struct MVMIndexHashEntry) * allocated_items;
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
         = entries_size + sizeof(struct MVMIndexHashTableControl) + metadata_size;
 
@@ -54,14 +53,15 @@ MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThrea
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = probe_overflow_size;
+    control->max_probe_distance = max_probe_distance_limit;
+    control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
 
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
     /* A sentinel. This marks an occupied slot, at its ideal position. */
-    metadata[actual_items] = 1;
+    metadata[allocated_items] = 1;
 
     return control;
 }
@@ -144,7 +144,7 @@ MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
                 MVMuint8 *dest = ls.entry_raw - size_to_move;
                 memmove(dest, dest + ls.entry_size, size_to_move);
             }
-            
+
             /* The same test and optimisation as in the "make room" loop - we're
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
@@ -188,7 +188,7 @@ void MVM_index_hash_insert_nocheck(MVMThreadContext *tc,
     assert(control);
     assert(MVM_index_hash_entries(control) != NULL);
     if (MVM_UNLIKELY(control->cur_items >= control->max_items)) {
-        MVMuint32 true_size =  MVM_index_hash_kompromat(control);
+        MVMuint32 entries_in_use =  MVM_index_hash_kompromat(control);
         MVMuint8 *entry_raw_orig = MVM_index_hash_entries(control);
         MVMuint8 *metadata_orig = MVM_index_hash_metadata(control);
 
@@ -203,7 +203,7 @@ void MVM_index_hash_insert_nocheck(MVMThreadContext *tc,
         MVMuint8 *entry_raw = entry_raw_orig;
         MVMuint8 *metadata = metadata_orig;
         MVMHashNumItems bucket = 0;
-        while (bucket < true_size) {
+        while (bucket < entries_in_use) {
             if (*metadata) {
                 struct MVMIndexHashEntry *entry = (struct MVMIndexHashEntry *) entry_raw;
                 hash_insert_internal(tc, control, list, entry->index);

--- a/src/core/index_hash_table.h
+++ b/src/core/index_hash_table.h
@@ -56,6 +56,7 @@ struct MVMIndexHashTableControl {
      * We can (re)calcuate this from other values in the struct, but it's easier
      * to cache it as we have the space. */
     MVMuint8 max_probe_distance_limit;
+    MVMuint8 metadata_hash_bits;
 };
 
 struct MVMIndexHashTable {

--- a/src/core/index_hash_table.h
+++ b/src/core/index_hash_table.h
@@ -46,7 +46,7 @@ Not all the optimisations described above are in place yet. Starting with
 struct MVMIndexHashTableControl {
     MVMHashNumItems cur_items;
     MVMHashNumItems max_items; /* hit this and we grow */
-    MVMHashNumItems official_size;
+    MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
     MVMuint8 probe_overflow_size;
 };

--- a/src/core/index_hash_table.h
+++ b/src/core/index_hash_table.h
@@ -48,7 +48,14 @@ struct MVMIndexHashTableControl {
     MVMHashNumItems max_items; /* hit this and we grow */
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
+    /* This is the maximum probe distance we can use without updating the
+     * metadata. It might not *yet* be the maximum probe distance possible for
+     * the official_size. */
     MVMuint8 max_probe_distance;
+    /* This is the maximum probe distance possible for the official size.
+     * We can (re)calcuate this from other values in the struct, but it's easier
+     * to cache it as we have the space. */
+    MVMuint8 max_probe_distance_limit;
 };
 
 struct MVMIndexHashTable {

--- a/src/core/index_hash_table.h
+++ b/src/core/index_hash_table.h
@@ -48,7 +48,7 @@ struct MVMIndexHashTableControl {
     MVMHashNumItems max_items; /* hit this and we grow */
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
-    MVMuint8 probe_overflow_size;
+    MVMuint8 max_probe_distance;
 };
 
 struct MVMIndexHashTable {

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -8,7 +8,7 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_max_items(const struct MVMIndexHashTa
     return MVM_index_hash_official_size(control) * MVM_INDEX_HASH_LOAD_FACTOR;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_kompromat(const struct MVMIndexHashTableControl *control) {
-    return MVM_index_hash_official_size(control) + control->probe_overflow_size;
+    return MVM_index_hash_official_size(control) + control->max_probe_distance;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_index_hash_metadata(const struct MVMIndexHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMIndexHashTableControl);
@@ -112,7 +112,7 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + MVM_index_hash_max_items(control));
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -85,9 +85,10 @@ MVM_index_hash_create_loop_state(MVMThreadContext *tc,
     struct MVM_hash_loop_state retval;
     retval.entry_size = sizeof(struct MVMIndexHashEntry);
     retval.metadata_increment = 1 << control->metadata_hash_bits;
+    retval.metadata_hash_mask = retval.metadata_increment - 1;
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
-    retval.probe_distance = retval.metadata_increment;
+    retval.probe_distance = retval.metadata_increment | retval.metadata_hash_mask;
     retval.entry_raw = MVM_index_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_index_hash_metadata(control) + bucket;
     return retval;
@@ -129,7 +130,7 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_fetch_nocheck(MVMThreadContext *tc,
         ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (ls.max_probe_distance + 1) * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 2) * ls.metadata_increment);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + MVM_index_hash_max_items(control));
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -64,7 +64,7 @@ MVM_STATIC_INLINE void MVM_index_hash_shallow_copy(MVMThreadContext *tc,
     const char *start = (const char *)control - entries_size;
     size_t total_size
         = entries_size + sizeof(struct MVMIndexHashTableControl) + metadata_size;
-    char *target = MVM_malloc(total_size);
+    char *target =  MVM_fixed_size_alloc(tc, tc->instance->fsa, total_size);
     memcpy(target, start, total_size);
     dest->table = (struct MVMIndexHashTableControl *)(target + entries_size);
 }

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -7,6 +7,9 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_official_size(const struct MVMIndexHa
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_max_items(const struct MVMIndexHashTableControl *control) {
     return MVM_index_hash_official_size(control) * MVM_INDEX_HASH_LOAD_FACTOR;
 }
+MVM_STATIC_INLINE MVMuint32 MVM_index_hash_allocated_items(const struct MVMIndexHashTableControl *control) {
+    return MVM_index_hash_official_size(control) + control->max_probe_distance_limit;
+}
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_kompromat(const struct MVMIndexHashTableControl *control) {
     return MVM_index_hash_official_size(control) + control->max_probe_distance;
 }
@@ -44,9 +47,9 @@ MVM_STATIC_INLINE void MVM_index_hash_shallow_copy(MVMThreadContext *tc,
     const struct MVMIndexHashTableControl *control = source->table;
     if (!control)
         return;
-    size_t actual_items = MVM_index_hash_kompromat(control);
-    size_t entries_size = sizeof(struct MVMIndexHashEntry) * actual_items;
-    size_t metadata_size = MVM_hash_round_size_up(actual_items + 1);
+    size_t allocated_items = MVM_index_hash_allocated_items(control);
+    size_t entries_size = sizeof(struct MVMIndexHashEntry) * allocated_items;
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     const char *start = (const char *)control - entries_size;
     size_t total_size
         = entries_size + sizeof(struct MVMIndexHashTableControl) + metadata_size;

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -1,7 +1,11 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+#define MVM_INDEX_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_official_size(const struct MVMIndexHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
+}
+MVM_STATIC_INLINE MVMuint32 MVM_index_hash_max_items(const struct MVMIndexHashTableControl *control) {
+    return MVM_index_hash_official_size(control) * MVM_INDEX_HASH_LOAD_FACTOR;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_kompromat(const struct MVMIndexHashTableControl *control) {
     return MVM_index_hash_official_size(control) + control->probe_overflow_size;
@@ -109,7 +113,7 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + MVM_index_hash_max_items(control));
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }
 }

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -129,7 +129,7 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_fetch_nocheck(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*ls.metadata < ls.probe_distance) {
+        else if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -1,5 +1,9 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+/* See comments in hash_allocate_common (and elsewhere) before changing the
+ * load factor, or INDEX_MIN_SIZE_BASE_2 or MVM_HASH_INITIAL_BITS_IN_METADATA,
+ * and test with assertions enabled. The current choices permit certain
+ * optimisation assumptions in parts of the code. */
 #define MVM_INDEX_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_official_size(const struct MVMIndexHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -7,11 +7,18 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_official_size(const struct MVMIndexHa
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_max_items(const struct MVMIndexHashTableControl *control) {
     return MVM_index_hash_official_size(control) * MVM_INDEX_HASH_LOAD_FACTOR;
 }
+/* -1 because...
+ * probe distance of 1 is the correct bucket.
+ * hence for a value whose ideal slot is the last bucket, it's *in* the official
+ * allocation.
+ * probe distance of 2 is the first extra bucket beyond the official allocation
+ * probe distance of 255 is the 254th beyond the official allocation.
+ */
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_allocated_items(const struct MVMIndexHashTableControl *control) {
-    return MVM_index_hash_official_size(control) + control->max_probe_distance_limit;
+    return MVM_index_hash_official_size(control) + control->max_probe_distance_limit - 1;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_kompromat(const struct MVMIndexHashTableControl *control) {
-    return MVM_index_hash_official_size(control) + control->max_probe_distance;
+    return MVM_index_hash_official_size(control) + control->max_probe_distance  - 1;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_index_hash_metadata(const struct MVMIndexHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMIndexHashTableControl);
@@ -108,7 +115,7 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_fetch_nocheck(MVMThreadContext *tc,
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
                the hash table - it would have stolen this slot, and the key we
-               find here now would have been displaced futher on. Hence, the key
+               find here now would have been displaced further on. Hence, the key
                we seek can't be in the hash table. */
             return MVM_INDEX_HASH_NOT_FOUND;
         }

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -81,14 +81,25 @@ MVM_index_hash_create_loop_state(MVMThreadContext *tc,
                                  struct MVMIndexHashTableControl *control,
                                  MVMString *key) {
     MVMuint64 hash_val = MVM_string_hash_code(tc, key);
-    MVMHashNumItems bucket = hash_val >> control->key_right_shift;
     struct MVM_hash_loop_state retval;
     retval.entry_size = sizeof(struct MVMIndexHashEntry);
     retval.metadata_increment = 1 << control->metadata_hash_bits;
     retval.metadata_hash_mask = retval.metadata_increment - 1;
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
-    retval.probe_distance = retval.metadata_increment | retval.metadata_hash_mask;
+
+    MVMHashNumItems bucket;
+    unsigned int used_hash_bits
+        = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
+    if (control->metadata_hash_bits) {
+        retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
+        bucket = used_hash_bits >> control->metadata_hash_bits;
+    } else {
+        /* metadata_increment is 1, metadata_hash_mask is 0 */
+        retval.probe_distance = 1;
+        bucket = used_hash_bits;
+    }
+
     retval.entry_raw = MVM_index_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_index_hash_metadata(control) + bucket;
     return retval;

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -79,8 +79,11 @@ MVM_index_hash_create_loop_state(MVMThreadContext *tc,
     MVMuint64 hash_val = MVM_string_hash_code(tc, key);
     MVMHashNumItems bucket = hash_val >> control->key_right_shift;
     struct MVM_hash_loop_state retval;
-    retval.probe_distance = 1;
     retval.entry_size = sizeof(struct MVMIndexHashEntry);
+    retval.metadata_increment = 1 << control->metadata_hash_bits;
+    retval.probe_distance_shift = control->metadata_hash_bits;
+    retval.max_probe_distance = control->max_probe_distance;
+    retval.probe_distance = retval.metadata_increment;
     retval.entry_raw = MVM_index_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_index_hash_metadata(control) + bucket;
     return retval;
@@ -119,10 +122,10 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_fetch_nocheck(MVMThreadContext *tc,
                we seek can't be in the hash table. */
             return MVM_INDEX_HASH_NOT_FOUND;
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+        assert(ls.probe_distance <= (ls.max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + MVM_index_hash_max_items(control));
         assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -88,16 +88,14 @@ MVM_index_hash_create_loop_state(MVMThreadContext *tc,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    MVMHashNumItems bucket;
     unsigned int used_hash_bits
         = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
-    if (control->metadata_hash_bits) {
-        retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
-        bucket = used_hash_bits >> control->metadata_hash_bits;
-    } else {
-        /* metadata_increment is 1, metadata_hash_mask is 0 */
-        retval.probe_distance = 1;
-        bucket = used_hash_bits;
+    retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
+    MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
+    if (!control->metadata_hash_bits) {
+        assert(retval.probe_distance == 1);
+        assert(retval.metadata_hash_mask == 0);
+        assert(bucket == used_hash_bits);
     }
 
     retval.entry_raw = MVM_index_hash_entries(control) - bucket * retval.entry_size;

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -59,7 +59,7 @@ MVM_STATIC_INLINE void MVM_index_hash_shallow_copy(MVMThreadContext *tc,
     if (!control)
         return;
     size_t allocated_items = MVM_index_hash_allocated_items(control);
-    size_t entries_size = sizeof(struct MVMIndexHashEntry) * allocated_items;
+    size_t entries_size = MVM_hash_round_size_up(sizeof(struct MVMIndexHashEntry) * allocated_items);
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     const char *start = (const char *)control - entries_size;
     size_t total_size

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -1,7 +1,10 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+MVM_STATIC_INLINE MVMuint32 MVM_index_hash_official_size(const struct MVMIndexHashTableControl *control) {
+    return 1 << (MVMuint32)control->official_size_log2;
+}
 MVM_STATIC_INLINE MVMuint32 MVM_index_hash_kompromat(const struct MVMIndexHashTableControl *control) {
-    return control->official_size + control->probe_overflow_size;
+    return MVM_index_hash_official_size(control) + control->probe_overflow_size;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_index_hash_metadata(const struct MVMIndexHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMIndexHashTableControl);
@@ -106,8 +109,8 @@ MVM_STATIC_INLINE MVMuint32 MVM_index_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_index_hash_metadata(control) + control->official_size + control->max_items);
-        assert(ls.metadata < MVM_index_hash_metadata(control) + control->official_size + 256);
+        assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_index_hash_metadata(control) + MVM_index_hash_official_size(control) + 256);
     }
 }
 

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -31,6 +31,20 @@ MVM_STATIC_INLINE MVMuint8 *MVM_index_hash_entries(const struct MVMIndexHashTabl
     return (MVMuint8 *) control - sizeof(struct MVMIndexHashEntry);
 }
 
+MVM_STATIC_INLINE size_t MVM_index_hash_allocated_size(MVMThreadContext *tc, MVMIndexHashTable *hashtable) {
+    struct MVMIndexHashTableControl *control = hashtable->table;
+    if (!control)
+        return 0;
+    /* This special case allocation is only implemented in MVMStrHashTable: */
+    assert (!(control->cur_items == 0 && control->max_items == 0));
+
+
+    size_t allocated_items = MVM_index_hash_allocated_items(control);
+    size_t entries_size = MVM_hash_round_size_up(sizeof(struct MVMIndexHashEntry) * allocated_items);
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
+    return entries_size + sizeof(struct MVMIndexHashTableControl) + metadata_size;
+}
+
 /* Frees the entire contents of the hash, leaving you just the hashtable itself,
    which you allocated (heap, stack, inside another struct, wherever) */
 void MVM_index_hash_demolish(MVMThreadContext *tc, MVMIndexHashTable *hashtable);

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -56,14 +56,6 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
-    /* A sentinel. This marks an occupied slot, at its ideal position.
-     * As long as we start with (no more than) 5 metadata hash bits, certainly
-     * for the load factor we currently have (0.75) we can't actually reach this
-     * sentinel even with long-at-a-time reprocessing of the metadata, for any
-     * size shorter than the full allocation (at which point we no longer
-     * reprocess). */
-    metadata[allocated_items] = 1;
-
     return control;
 }
 
@@ -192,7 +184,6 @@ static struct MVMPtrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         }
 
         MVMuint8 *metadata = MVM_ptr_hash_metadata(control);
-        assert(metadata[MVM_ptr_hash_allocated_items(control)] == 1);
         MVMuint32 in_use_items = MVM_ptr_hash_official_size(control) + max_probe_distance;
         /* not `in_use_items + 1` because because we don't need to shift the
          * sentinel. */
@@ -208,7 +199,6 @@ static struct MVMPtrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
             *p = (*p >> 1) & (0x7F7F7F7FUL | (0x7F7F7F7FUL << (4 * sizeof(long))));
             ++p;
         } while (--loop_count);
-        assert(metadata[MVM_ptr_hash_allocated_items(control)] == 1);
         assert(control->metadata_hash_bits);
         --control->metadata_hash_bits;
 

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -46,7 +46,9 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = max_probe_distance_limit > (4 - 1) ? (4 - 1) : max_probe_distance_limit;
+    control->metadata_hash_bits = 0;
+    MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
+    control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
 
@@ -88,8 +90,8 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
                 MVMuint8 *find_me_a_gap = ls.metadata;
                 MVMuint8 old_probe_distance = *ls.metadata;
                 do {
-                    MVMuint8 new_probe_distance = 1 + old_probe_distance;
-                    if (new_probe_distance == control->max_probe_distance) {
+                    MVMuint32 new_probe_distance = ls.metadata_increment + old_probe_distance;
+                    if (new_probe_distance >> ls.probe_distance_shift == ls.max_probe_distance) {
                         /* Optimisation from Martin Ankerl's implementation:
                            setting this to zero forces a resize on any insert,
                            *before* the actual insert, so that we never end up
@@ -120,7 +122,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
              */
-            if (ls.probe_distance == control->max_probe_distance) {
+            if (ls.probe_distance >> ls.probe_distance_shift == control->max_probe_distance) {
                 control->max_items = 0;
             }
 
@@ -138,7 +140,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
                 return entry;
             }
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
 
@@ -156,7 +158,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
+        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }
@@ -167,6 +169,7 @@ static struct MVMPtrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
     /* control->max_items may have been set to 0 to trigger a call into this
      * function. */
     MVMuint32 max_items = MVM_ptr_hash_max_items(control);
+    MVMuint32 max_probe_distance = control->max_probe_distance;
     MVMuint32 max_probe_distance_limit = control->max_probe_distance_limit;
 
     /* We can hit both the probe limit and the max items on the same insertion.
@@ -175,10 +178,9 @@ static struct MVMPtrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
      * then we don't have more space in the metadata, so we're going to have to
      * grow anyway. */
     if (control->cur_items < max_items
-        && control->max_probe_distance < max_probe_distance_limit) {
+        && max_probe_distance < max_probe_distance_limit) {
         /* We hit the probe limit, but not the max items count. */
-        MVMuint32 new_probe_distance
-            = 2 + 2 * (MVMuint32) control->max_probe_distance;
+        MVMuint32 new_probe_distance = 1 + 2 * max_probe_distance;
         if (new_probe_distance > max_probe_distance_limit) {
             new_probe_distance = max_probe_distance_limit;
         }
@@ -304,9 +306,9 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
                 uint8_t *metadata_target = ls.metadata;
                 /* Look at the next slot */
                 uint8_t old_probe_distance = metadata_target[1];
-                while (old_probe_distance > 1) {
+                while (old_probe_distance > ls.metadata_increment) {
                     /* OK, we can move this one. */
-                    *metadata_target = old_probe_distance - 1;
+                    *metadata_target = old_probe_distance - ls.metadata_increment;
                     /* Try the next one, etc */
                     ++metadata_target;
                     old_probe_distance = metadata_target[1];
@@ -349,10 +351,10 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
             /* Strange. Not in the hash. Should this be an oops? */
             return 0;
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+        assert(ls.probe_distance <= (control->max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -131,8 +131,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
             entry->key = NULL;
             return entry;
         }
-
-        if (*ls.metadata == ls.probe_distance) {
+        else if (*ls.metadata == ls.probe_distance) {
             struct MVMPtrHashEntry *entry = (struct MVMPtrHashEntry *) ls.entry_raw;
             if (entry->key == key) {
                 return entry;
@@ -358,7 +357,7 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*ls.metadata < ls.probe_distance) {
+        else if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -1,6 +1,5 @@
 #include "moar.h"
 
-#define PTR_LOAD_FACTOR 0.75
 #define PTR_INITIAL_SIZE_LOG2 3
 #define PTR_INITIAL_KEY_RIGHT_SHIFT (8 * sizeof(uintptr_t) - 3)
 
@@ -32,7 +31,7 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
                                                                       MVMuint8 key_right_shift,
                                                                       MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
-    MVMuint32 max_items = official_size * PTR_LOAD_FACTOR;
+    MVMuint32 max_items = official_size * MVM_PTR_HASH_LOAD_FACTOR;
     MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
@@ -155,7 +154,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }
 }
@@ -303,7 +302,7 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }
 }

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -28,21 +28,13 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
                                                                       MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_PTR_HASH_LOAD_FACTOR;
-    /* -1 because...
-     * probe distance of 1 is the correct bucket.
-     * hence for a value whose ideal slot is the last bucket, it's *in* the
-     * official allocation.
-     * probe distance of 2 is the first extra bucket beyond the official
-     * allocation
-     * probe distance of 255 is the 254th beyond the official allocation.
-     */
     MVMuint8 max_probe_distance_limit;
-    if ((MVM_HASH_MAX_PROBE_DISTANCE - 1) < (max_items - 1)) {
-        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE - 1;
+    if (MVM_HASH_MAX_PROBE_DISTANCE < max_items) {
+        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE;
     } else {
-        max_probe_distance_limit = max_items - 1;
+        max_probe_distance_limit = max_items;
     }
-    size_t allocated_items = official_size + max_probe_distance_limit;
+    size_t allocated_items = official_size + max_probe_distance_limit - 1;
     size_t entries_size = sizeof(struct MVMPtrHashEntry) * allocated_items;
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
@@ -149,7 +141,22 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+
+        /* For insert, the loop must not iterate to any probe distance greater
+         * than the (current) maximum probe distance, because it must never
+         * insert an entry at a location beyond the maximum probe distance.
+         *
+         * For fetch and delete, the loop is permitted to reach (and read) one
+         * beyond the maximum probe distance (hence +1 in the seemingly
+         * analogous assertions) - but if so, it will always read from the
+         * metadata a probe distance which is lower than the current probe
+         * distance, and hence hit "not found" and terminate the loop.
+         *
+         * This is how the loop terminates when the max probe distance is
+         * reached without needing an explicit test for it, and why we need an
+         * initialised sentinel byte at the end of the metadata. */
+
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }
@@ -157,7 +164,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
 
 static struct MVMPtrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
                                                       struct MVMPtrHashTableControl *control) {
-    MVMuint32 entries_in_use = MVM_ptr_hash_official_size(control) + control->max_probe_distance;
+    MVMuint32 entries_in_use = MVM_ptr_hash_official_size(control) + control->max_probe_distance - 1;
     MVMuint8 *entry_raw_orig = MVM_ptr_hash_entries(control);
     MVMuint8 *metadata_orig = MVM_ptr_hash_metadata(control);
 
@@ -300,7 +307,7 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
                the hash table - it would have stolen this slot, and the key we
-               find here now would have been displaced futher on. Hence, the key
+               find here now would have been displaced further on. Hence, the key
                we seek can't be in the hash table. */
             /* Strange. Not in the hash. Should this be an oops? */
             return 0;

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -39,6 +39,7 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
         = entries_size + sizeof(struct MVMPtrHashTableControl) + metadata_size;
+    assert(total_size == MVM_hash_round_size_up(total_size));
 
     struct MVMPtrHashTableControl *control =
         (struct MVMPtrHashTableControl *) ((char *)MVM_malloc(total_size) + entries_size);

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -3,14 +3,10 @@
 #define PTR_INITIAL_SIZE_LOG2 3
 #define PTR_INITIAL_KEY_RIGHT_SHIFT (8 * sizeof(uintptr_t) - 3)
 
-MVM_STATIC_INLINE MVMuint32 hash_true_size(const struct MVMPtrHashTableControl *control) {
-    return MVM_ptr_hash_official_size(control) + control->max_probe_distance;
-}
-
 MVM_STATIC_INLINE void hash_demolish_internal(MVMThreadContext *tc,
                                               struct MVMPtrHashTableControl *control) {
-    size_t actual_items = hash_true_size(control);
-    size_t entries_size = sizeof(struct MVMPtrHashEntry) * actual_items;
+    size_t allocated_items = MVM_ptr_hash_allocated_items(control);
+    size_t entries_size = sizeof(struct MVMPtrHashEntry) * allocated_items;
     char *start = (char *)control - entries_size;
     MVM_free(start);
 }
@@ -32,7 +28,6 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
                                                                       MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_PTR_HASH_LOAD_FACTOR;
-    MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
      * hence for a value whose ideal slot is the last bucket, it's *in* the
@@ -41,15 +36,15 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
      * allocation
      * probe distance of 255 is the 254th beyond the official allocation.
      */
-    MVMuint8 probe_overflow_size;
-    if (MVM_HASH_MAX_PROBE_DISTANCE < overflow_size) {
-        probe_overflow_size = MVM_HASH_MAX_PROBE_DISTANCE - 1;
+    MVMuint8 max_probe_distance_limit;
+    if ((MVM_HASH_MAX_PROBE_DISTANCE - 1) < (max_items - 1)) {
+        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE - 1;
     } else {
-        probe_overflow_size = overflow_size;
+        max_probe_distance_limit = max_items - 1;
     }
-    size_t actual_items = official_size + probe_overflow_size;
-    size_t entries_size = sizeof(struct MVMPtrHashEntry) * actual_items;
-    size_t metadata_size = MVM_hash_round_size_up(actual_items + 1);
+    size_t allocated_items = official_size + max_probe_distance_limit;
+    size_t entries_size = sizeof(struct MVMPtrHashEntry) * allocated_items;
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
         = entries_size + sizeof(struct MVMPtrHashTableControl) + metadata_size;
 
@@ -59,14 +54,15 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = probe_overflow_size;
+    control->max_probe_distance = max_probe_distance_limit;
+    control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
 
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
     /* A sentinel. This marks an occupied slot, at its ideal position. */
-    metadata[actual_items] = 1;
+    metadata[allocated_items] = 1;
 
     return control;
 }
@@ -179,7 +175,7 @@ struct MVMPtrHashEntry *MVM_ptr_hash_lvalue_fetch(MVMThreadContext *tc,
             return entry;
         }
 
-        MVMuint32 true_size =  hash_true_size(control);
+        MVMuint32 entries_in_use = MVM_ptr_hash_official_size(control) + control->max_probe_distance;
         MVMuint8 *entry_raw_orig = MVM_ptr_hash_entries(control);
         MVMuint8 *metadata_orig = MVM_ptr_hash_metadata(control);
 
@@ -194,7 +190,7 @@ struct MVMPtrHashEntry *MVM_ptr_hash_lvalue_fetch(MVMThreadContext *tc,
         MVMuint8 *entry_raw = entry_raw_orig;
         MVMuint8 *metadata = metadata_orig;
         MVMHashNumItems bucket = 0;
-        while (bucket < true_size) {
+        while (bucket < entries_in_use) {
             if (*metadata) {
                 struct MVMPtrHashEntry *old_entry = (struct MVMPtrHashEntry *) entry_raw;
                 struct MVMPtrHashEntry *new_entry =

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -79,15 +79,13 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
                  key);
     }
 
-    unsigned int probe_distance = 1;
-    MVMHashNumItems bucket = MVM_ptr_hash_code(key) >> control->key_right_shift;
-    MVMuint8 *entry_raw = MVM_ptr_hash_entries(control) - bucket * sizeof(struct MVMPtrHashEntry);
-    MVMuint8 *metadata = MVM_ptr_hash_metadata(control) + bucket;
+    struct MVM_hash_loop_state ls = MVM_ptr_hash_create_loop_state(control, key);
+
     while (1) {
-        if (*metadata < probe_distance) {
+        if (*ls.metadata < ls.probe_distance) {
             /* this is our slot. occupied or not, it is our rightful place. */
 
-            if (*metadata == 0) {
+            if (*ls.metadata == 0) {
                 /* Open goal. Score! */
             } else {
                 /* make room. */
@@ -99,8 +97,8 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
                    all the following elements have probe distances in order, we
                    can maintain the invariant just as well by moving everything
                    along by one. */
-                MVMuint8 *find_me_a_gap = metadata;
-                MVMuint8 old_probe_distance = *metadata;
+                MVMuint8 *find_me_a_gap = ls.metadata;
+                MVMuint8 old_probe_distance = *ls.metadata;
                 do {
                     MVMuint8 new_probe_distance = 1 + old_probe_distance;
                     if (new_probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
@@ -116,8 +114,8 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
                     *find_me_a_gap = new_probe_distance;
                 } while (old_probe_distance);
 
-                MVMuint32 entries_to_move = find_me_a_gap - metadata;
-                size_t size_to_move = sizeof(struct MVMPtrHashEntry) * entries_to_move;
+                MVMuint32 entries_to_move = find_me_a_gap - ls.metadata;
+                size_t size_to_move = ls.entry_size * entries_to_move;
                 /* When we had entries *ascending* this was
                  * memmove(entry_raw + sizeof(struct MVMPtrHashEntry), entry_raw,
                  *         sizeof(struct MVMPtrHashEntry) * entries_to_move);
@@ -126,38 +124,38 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *hash_insert_internal(MVMThreadContext 
                  * `entry_raw` is still a pointer to where we want to make free
                  * space, but what want to do now is move everything at it and
                  * *before* it downwards. */
-                MVMuint8 *dest = entry_raw - size_to_move;
-                memmove(dest, dest + sizeof(struct MVMPtrHashEntry), size_to_move);
+                MVMuint8 *dest = ls.entry_raw - size_to_move;
+                memmove(dest, dest + ls.entry_size, size_to_move);
             }
 
             /* The same test and optimisation as in the "make room" loop - we're
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
              */
-            if (probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
+            if (ls.probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
                 control->max_items = 0;
             }
 
             ++control->cur_items;
 
-            *metadata = probe_distance;
-            struct MVMPtrHashEntry *entry = (struct MVMPtrHashEntry *) entry_raw;
+            *ls.metadata = ls.probe_distance;
+            struct MVMPtrHashEntry *entry = (struct MVMPtrHashEntry *) ls.entry_raw;
             entry->key = NULL;
             return entry;
         }
 
-        if (*metadata == probe_distance) {
-            struct MVMPtrHashEntry *entry = (struct MVMPtrHashEntry *) entry_raw;
+        if (*ls.metadata == ls.probe_distance) {
+            struct MVMPtrHashEntry *entry = (struct MVMPtrHashEntry *) ls.entry_raw;
             if (entry->key == key) {
                 return entry;
             }
         }
-        ++probe_distance;
-        ++metadata;
-        entry_raw -= sizeof(struct MVMPtrHashEntry);
-        assert(probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(metadata < MVM_ptr_hash_metadata(control) + control->official_size + control->max_items);
-        assert(metadata < MVM_ptr_hash_metadata(control) + control->official_size + 256);
+        ++ls.probe_distance;
+        ++ls.metadata;
+        ls.entry_raw -= ls.entry_size;
+        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + control->official_size + control->max_items);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + control->official_size + 256);
     }
 }
 
@@ -241,19 +239,18 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
     if (MVM_ptr_hash_is_empty(tc, hashtable)) {
         return 0;
     }
+
     struct MVMPtrHashTableControl *control = hashtable->table;
-    unsigned int probe_distance = 1;
-    MVMHashNumItems bucket = MVM_ptr_hash_code(key) >> control->key_right_shift;
-    MVMuint8 *entry_raw = MVM_ptr_hash_entries(control) - bucket * sizeof(struct MVMPtrHashEntry);
-    uint8_t *metadata = MVM_ptr_hash_metadata(control) + bucket;
+    struct MVM_hash_loop_state ls = MVM_ptr_hash_create_loop_state(control, key);
+
     while (1) {
-        if (*metadata == probe_distance) {
-            struct MVMPtrHashEntry *entry = (struct MVMPtrHashEntry *) entry_raw;
+        if (*ls.metadata == ls.probe_distance) {
+            struct MVMPtrHashEntry *entry = (struct MVMPtrHashEntry *) ls.entry_raw;
             if (entry->key == key) {
                 /* Target acquired. */
                 uintptr_t retval = entry->value;
 
-                uint8_t *metadata_target = metadata;
+                uint8_t *metadata_target = ls.metadata;
                 /* Look at the next slot */
                 uint8_t old_probe_distance = metadata_target[1];
                 while (old_probe_distance > 1) {
@@ -266,9 +263,9 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
                 /* metadata_target now points to the metadata for the last thing
                    we did move. (possibly still our target). */
 
-                uint32_t entries_to_move = metadata_target - metadata;
+                uint32_t entries_to_move = metadata_target - ls.metadata;
                 if (entries_to_move) {
-                    size_t size_to_move = sizeof(struct MVMPtrHashEntry) * entries_to_move;
+                    size_t size_to_move = ls.entry_size * entries_to_move;
                     /* When we had entries *ascending* in memory, this was
                      * memmove(entry_raw, entry_raw + sizeof(struct MVMPtrHashEntry),
                      *         sizeof(struct MVMPtrHashEntry) * entries_to_move);
@@ -278,8 +275,8 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
                      * `entry_raw` is still a pointer to the entry that we need
                      * to ovewrite, but now we need to move everything *before*
                      * it upwards to close the gap. */
-                    memmove(entry_raw - size_to_move + sizeof(struct MVMPtrHashEntry),
-                            entry_raw - size_to_move,
+                    memmove(ls.entry_raw - size_to_move + ls.entry_size,
+                            ls.entry_raw - size_to_move,
                             size_to_move);
                 }
                 /* and this slot is now emtpy. */
@@ -291,7 +288,7 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*metadata < probe_distance) {
+        if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
@@ -301,11 +298,11 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
             /* Strange. Not in the hash. Should this be an oops? */
             return 0;
         }
-        ++probe_distance;
-        ++metadata;
-        entry_raw -= sizeof(struct MVMPtrHashEntry);
-        assert(probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(metadata < MVM_ptr_hash_metadata(control) + control->official_size + control->max_items);
-        assert(metadata < MVM_ptr_hash_metadata(control) + control->official_size + 256);
+        ++ls.probe_distance;
+        ++ls.metadata;
+        ls.entry_raw -= ls.entry_size;
+        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + control->official_size + control->max_items);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + control->official_size + 256);
     }
 }

--- a/src/core/ptr_hash_table.h
+++ b/src/core/ptr_hash_table.h
@@ -46,7 +46,7 @@ Not all the optimisations described above are in place yet. Starting with
 struct MVMPtrHashTableControl {
     MVMHashNumItems cur_items;
     MVMHashNumItems max_items; /* hit this and we grow */
-    MVMHashNumItems official_size;
+    MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
     MVMuint8 probe_overflow_size;
 };

--- a/src/core/ptr_hash_table.h
+++ b/src/core/ptr_hash_table.h
@@ -48,7 +48,14 @@ struct MVMPtrHashTableControl {
     MVMHashNumItems max_items; /* hit this and we grow */
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
+    /* This is the maximum probe distance we can use without updating the
+     * metadata. It might not *yet* be the maximum probe distance possible for
+     * the official_size. */
     MVMuint8 max_probe_distance;
+    /* This is the maximum probe distance possible for the official size.
+     * We can (re)calcuate this from other values in the struct, but it's easier
+     * to cache it as we have the space. */
+    MVMuint8 max_probe_distance_limit;
 };
 
 struct MVMPtrHashTable {

--- a/src/core/ptr_hash_table.h
+++ b/src/core/ptr_hash_table.h
@@ -48,7 +48,7 @@ struct MVMPtrHashTableControl {
     MVMHashNumItems max_items; /* hit this and we grow */
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
-    MVMuint8 probe_overflow_size;
+    MVMuint8 max_probe_distance;
 };
 
 struct MVMPtrHashTable {

--- a/src/core/ptr_hash_table.h
+++ b/src/core/ptr_hash_table.h
@@ -56,6 +56,7 @@ struct MVMPtrHashTableControl {
      * We can (re)calcuate this from other values in the struct, but it's easier
      * to cache it as we have the space. */
     MVMuint8 max_probe_distance_limit;
+    MVMuint8 metadata_hash_bits;
 };
 
 struct MVMPtrHashTable {

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -108,7 +108,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *MVM_ptr_hash_fetch(MVMThreadContext *t
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -1,5 +1,9 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+/* See comments in hash_allocate_common (and elsewhere) before changing the
+ * load factor, or PTR_MIN_SIZE_BASE_2 or MVM_HASH_INITIAL_BITS_IN_METADATA,
+ * and test with assertions enabled. The current choices permit certain
+ * optimisation assumptions in parts of the code. */
 #define MVM_PTR_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_official_size(const struct MVMPtrHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -83,16 +83,14 @@ MVM_ptr_hash_create_loop_state(struct MVMPtrHashTableControl *control,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    MVMHashNumItems bucket;
     unsigned int used_hash_bits
         = MVM_ptr_hash_code(key) >> (control->key_right_shift - control->metadata_hash_bits);
-    if (control->metadata_hash_bits) {
-        retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
-        bucket = used_hash_bits >> control->metadata_hash_bits;
-    } else {
-        /* metadata_increment is 1, metadata_hash_mask is 0 */
-        retval.probe_distance = 1;
-        bucket = used_hash_bits;
+    retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
+    MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
+    if (!control->metadata_hash_bits) {
+        assert(retval.probe_distance == 1);
+        assert(retval.metadata_hash_mask == 0);
+        assert(bucket == used_hash_bits);
     }
 
     retval.entry_raw = MVM_ptr_hash_entries(control) - bucket * retval.entry_size;

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -4,8 +4,15 @@
 MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_official_size(const struct MVMPtrHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
 }
+/* -1 because...
+ * probe distance of 1 is the correct bucket.
+ * hence for a value whose ideal slot is the last bucket, it's *in* the official
+ * allocation.
+ * probe distance of 2 is the first extra bucket beyond the official allocation
+ * probe distance of 255 is the 254th beyond the official allocation.
+ */
 MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_allocated_items(const struct MVMPtrHashTableControl *control) {
-    return MVM_ptr_hash_official_size(control) + control->max_probe_distance_limit;
+    return MVM_ptr_hash_official_size(control) + control->max_probe_distance_limit - 1;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_max_items(const struct MVMPtrHashTableControl *control) {
     return MVM_ptr_hash_official_size(control) * MVM_PTR_HASH_LOAD_FACTOR;
@@ -104,7 +111,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *MVM_ptr_hash_fetch(MVMThreadContext *t
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
                the hash table - it would have stolen this slot, and the key we
-               find here now would have been displaced futher on. Hence, the key
+               find here now would have been displaced further on. Hence, the key
                we seek can't be in the hash table. */
             return NULL;
         }

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -1,7 +1,11 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+#define MVM_PTR_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_official_size(const struct MVMPtrHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
+}
+MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_max_items(const struct MVMPtrHashTableControl *control) {
+    return MVM_ptr_hash_official_size(control) * MVM_PTR_HASH_LOAD_FACTOR;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_ptr_hash_metadata(const struct MVMPtrHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMPtrHashTableControl);
@@ -105,7 +109,7 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *MVM_ptr_hash_fetch(MVMThreadContext *t
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }
 }

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -4,6 +4,9 @@
 MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_official_size(const struct MVMPtrHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
 }
+MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_allocated_items(const struct MVMPtrHashTableControl *control) {
+    return MVM_ptr_hash_official_size(control) + control->max_probe_distance_limit;
+}
 MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_max_items(const struct MVMPtrHashTableControl *control) {
     return MVM_ptr_hash_official_size(control) * MVM_PTR_HASH_LOAD_FACTOR;
 }

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -77,13 +77,24 @@ MVM_STATIC_INLINE struct MVM_hash_loop_state
 MVM_ptr_hash_create_loop_state(struct MVMPtrHashTableControl *control,
                                const void *key) {
     struct MVM_hash_loop_state retval;
-    MVMHashNumItems bucket = MVM_ptr_hash_code(key) >> control->key_right_shift;
     retval.entry_size = sizeof(struct MVMPtrHashEntry);
     retval.metadata_increment = 1 << control->metadata_hash_bits;
     retval.metadata_hash_mask = retval.metadata_increment - 1;
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
-    retval.probe_distance = retval.metadata_increment | retval.metadata_hash_mask;
+
+    MVMHashNumItems bucket;
+    unsigned int used_hash_bits
+        = MVM_ptr_hash_code(key) >> (control->key_right_shift - control->metadata_hash_bits);
+    if (control->metadata_hash_bits) {
+        retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
+        bucket = used_hash_bits >> control->metadata_hash_bits;
+    } else {
+        /* metadata_increment is 1, metadata_hash_mask is 0 */
+        retval.probe_distance = 1;
+        bucket = used_hash_bits;
+    }
+
     retval.entry_raw = MVM_ptr_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_ptr_hash_metadata(control) + bucket;
     return retval;

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -74,8 +74,11 @@ MVM_ptr_hash_create_loop_state(struct MVMPtrHashTableControl *control,
                                const void *key) {
     struct MVM_hash_loop_state retval;
     MVMHashNumItems bucket = MVM_ptr_hash_code(key) >> control->key_right_shift;
-    retval.probe_distance = 1;
     retval.entry_size = sizeof(struct MVMPtrHashEntry);
+    retval.metadata_increment = 1 << control->metadata_hash_bits;
+    retval.probe_distance_shift = control->metadata_hash_bits;
+    retval.max_probe_distance = control->max_probe_distance;
+    retval.probe_distance = retval.metadata_increment;
     retval.entry_raw = MVM_ptr_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_ptr_hash_metadata(control) + bucket;
     return retval;
@@ -115,10 +118,10 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *MVM_ptr_hash_fetch(MVMThreadContext *t
                we seek can't be in the hash table. */
             return NULL;
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+        assert(ls.probe_distance <= (ls.max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + MVM_ptr_hash_max_items(control));
         assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -1,5 +1,8 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+MVM_STATIC_INLINE MVMuint32 MVM_ptr_hash_official_size(const struct MVMPtrHashTableControl *control) {
+    return 1 << (MVMuint32)control->official_size_log2;
+}
 MVM_STATIC_INLINE MVMuint8 *MVM_ptr_hash_metadata(const struct MVMPtrHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMPtrHashTableControl);
 }
@@ -102,8 +105,8 @@ MVM_STATIC_INLINE struct MVMPtrHashEntry *MVM_ptr_hash_fetch(MVMThreadContext *t
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_ptr_hash_metadata(control) + control->official_size + control->max_items);
-        assert(ls.metadata < MVM_ptr_hash_metadata(control) + control->official_size + 256);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_ptr_hash_metadata(control) + MVM_ptr_hash_official_size(control) + 256);
     }
 }
 

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -117,6 +117,7 @@ MVM_STATIC_INLINE struct MVMStrHashTableControl *hash_allocate_common(MVMThreadC
 
     size_t total_size
         = entries_size + sizeof(struct MVMStrHashTableControl) + metadata_size;
+    assert(total_size == MVM_hash_round_size_up(total_size));
 
     struct MVMStrHashTableControl *control =
         (struct MVMStrHashTableControl *) ((char *)MVM_malloc(total_size) + entries_size);

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -153,15 +153,13 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
                  key);
     }
 
-    unsigned int probe_distance = 1;
-    MVMHashNumItems bucket = MVM_str_hash_code(tc, control->salt, key) >> control->key_right_shift;
-    MVMuint8 *entry_raw = MVM_str_hash_entries(control) - bucket * control->entry_size;
-    MVMuint8 *metadata = MVM_str_hash_metadata(control) + bucket;
+    struct MVM_hash_loop_state ls = MVM_str_hash_create_loop_state(tc, control, key);
+
     while (1) {
-        if (*metadata < probe_distance) {
+        if (*ls.metadata < ls.probe_distance) {
             /* this is our slot. occupied or not, it is our rightful place. */
 
-            if (*metadata == 0) {
+            if (*ls.metadata == 0) {
                 /* Open goal. Score! */
             } else {
                 /* make room. */
@@ -173,8 +171,8 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
                    all the following elements have probe distances in order, we
                    can maintain the invariant just as well by moving everything
                    along by one. */
-                MVMuint8 *find_me_a_gap = metadata;
-                MVMuint8 old_probe_distance = *metadata;
+                MVMuint8 *find_me_a_gap = ls.metadata;
+                MVMuint8 old_probe_distance = *ls.metadata;
                 do {
                     MVMuint8 new_probe_distance = 1 + old_probe_distance;
                     if (new_probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
@@ -190,8 +188,8 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
                     *find_me_a_gap = new_probe_distance;
                 } while (old_probe_distance);
 
-                MVMuint32 entries_to_move = find_me_a_gap - metadata;
-                size_t size_to_move = control->entry_size * entries_to_move;
+                MVMuint32 entries_to_move = find_me_a_gap - ls.metadata;
+                size_t size_to_move = ls.entry_size * entries_to_move;
                 /* When we had entries *ascending* this was
                  * memmove(entry_raw + hashtable->entry_size, entry_raw,
                  *         hashtable->entry_size * entries_to_move);
@@ -200,15 +198,15 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
                  * `entry_raw` is still a pointer to where we want to make free
                  * space, but what want to do now is move everything at it and
                  * *before* it downwards. */
-                MVMuint8 *dest = entry_raw - size_to_move;
-                memmove(dest, dest + control->entry_size, size_to_move);
+                MVMuint8 *dest = ls.entry_raw - size_to_move;
+                memmove(dest, dest + ls.entry_size, size_to_move);
              }
 
             /* The same test and optimisation as in the "make room" loop - we're
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
              */
-            if (probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
+            if (ls.probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
                 control->max_items = 0;
             }
 
@@ -218,14 +216,14 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
             control->last_delete_at = 0;
 #endif
 
-            *metadata = probe_distance;
-            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) entry_raw;
+            *ls.metadata = ls.probe_distance;
+            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) ls.entry_raw;
             entry->key = NULL;
             return entry;
         }
 
-        if (*metadata == probe_distance) {
-            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) entry_raw;
+        if (*ls.metadata == ls.probe_distance) {
+            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) ls.entry_raw;
             if (entry->key == key
                 || (MVM_string_graphs_nocheck(tc, key) == MVM_string_graphs_nocheck(tc, entry->key)
                     && MVM_string_substrings_equal_nocheck(tc, key, 0,
@@ -234,12 +232,12 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
                 return entry;
             }
         }
-        ++probe_distance;
-        ++metadata;
-        entry_raw -= control->entry_size;
-        assert(probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(metadata < MVM_str_hash_metadata(control) + control->official_size + control->max_items);
-        assert(metadata < MVM_str_hash_metadata(control) + control->official_size + 256);
+        ++ls.probe_distance;
+        ++ls.metadata;
+        ls.entry_raw -= ls.entry_size;
+        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + control->max_items);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + 256);
     }
 }
 
@@ -325,14 +323,13 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
     if (MVM_str_hash_is_empty(tc, hashtable)) {
         return;
     }
+
     struct MVMStrHashTableControl *control = hashtable->table;
-    unsigned int probe_distance = 1;
-    MVMHashNumItems bucket = MVM_str_hash_code(tc, control->salt, key) >> control->key_right_shift;
-    MVMuint8 *entry_raw = MVM_str_hash_entries(control) - bucket * control->entry_size;
-    uint8_t *metadata = MVM_str_hash_metadata(control) + bucket;
+    struct MVM_hash_loop_state ls = MVM_str_hash_create_loop_state(tc, control, key);
+
     while (1) {
-        if (*metadata == probe_distance) {
-            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) entry_raw;
+        if (*ls.metadata == ls.probe_distance) {
+            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) ls.entry_raw;
             if (entry->key == key
                 || (MVM_string_graphs_nocheck(tc, key) == MVM_string_graphs_nocheck(tc, entry->key)
                     && MVM_string_substrings_equal_nocheck(tc, key, 0,
@@ -340,7 +337,7 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                                                            entry->key, 0))) {
                 /* Target acquired. */
 
-                uint8_t *metadata_target = metadata;
+                uint8_t *metadata_target = ls.metadata;
                 /* Look at the next slot */
                 uint8_t old_probe_distance = metadata_target[1];
                 while (old_probe_distance > 1) {
@@ -353,9 +350,9 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                 /* metadata_target now points to the metadata for the last thing
                    we did move. (possibly still our target). */
 
-                uint32_t entries_to_move = metadata_target - metadata;
+                uint32_t entries_to_move = metadata_target - ls.metadata;
                 if (entries_to_move) {
-                    size_t size_to_move = control->entry_size * entries_to_move;
+                    size_t size_to_move = ls.entry_size * entries_to_move;
                     /* When we had entries *ascending* in memory, this was
                      * memmove(entry_raw, entry_raw + hashtable->entry_size,
                      *         hashtable->entry_size * entries_to_move);
@@ -365,8 +362,8 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                      * `entry_raw` is still a pointer to the entry that we need
                      * to ovewrite, but now we need to move everything *before*
                      * it upwards to close the gap. */
-                    memmove(entry_raw - size_to_move + control->entry_size,
-                            entry_raw - size_to_move,
+                    memmove(ls.entry_raw - size_to_move + ls.entry_size,
+                            ls.entry_raw - size_to_move,
                             size_to_move);
                 }
                 /* and this slot is now emtpy. */
@@ -379,7 +376,7 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                  * hash bucket we actually used.
                  * `metadata - ...metadata(...)` gives the bucket, and
                  * iterators store `$bucket + 1`, hence: */
-                control->last_delete_at = 1 + metadata - MVM_str_hash_metadata(control);
+                control->last_delete_at = 1 + ls.metadata - MVM_str_hash_metadata(control);
 #endif
 
                 /* Job's a good 'un. */
@@ -387,7 +384,7 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*metadata < probe_distance) {
+        if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
@@ -397,12 +394,12 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
             /* Strange. Not in the hash. Should this be an oops? */
             return;
         }
-        ++probe_distance;
-        ++metadata;
-        entry_raw -= control->entry_size;
-        assert(probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(metadata < MVM_str_hash_metadata(control) + control->official_size + control->max_items);
-        assert(metadata < MVM_str_hash_metadata(control) + control->official_size + 256);
+        ++ls.probe_distance;
+        ++ls.metadata;
+        ls.entry_raw -= ls.entry_size;
+        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + control->max_items);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + 256);
     }
 }
 

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -270,8 +270,7 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
             entry->key = NULL;
             return entry;
         }
-
-        if (*ls.metadata == ls.probe_distance) {
+        else if (*ls.metadata == ls.probe_distance) {
             struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) ls.entry_raw;
             if (entry->key == key
                 || (MVM_string_graphs_nocheck(tc, key) == MVM_string_graphs_nocheck(tc, entry->key)
@@ -522,7 +521,7 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*ls.metadata < ls.probe_distance) {
+        else if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -51,21 +51,13 @@ MVM_STATIC_INLINE struct MVMStrHashTableControl *hash_allocate_common(MVMThreadC
                                                                       MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_STR_HASH_LOAD_FACTOR;
-    /* -1 because...
-     * probe distance of 1 is the correct bucket.
-     * hence for a value whose ideal slot is the last bucket, it's *in* the
-     * official allocation.
-     * probe distance of 2 is the first extra bucket beyond the official
-     * allocation
-     * probe distance of 255 is the 254th beyond the official allocation.
-     */
     MVMuint8 max_probe_distance_limit;
-    if ((MVM_HASH_MAX_PROBE_DISTANCE - 1) < (max_items - 1)) {
-        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE - 1;
+    if (MVM_HASH_MAX_PROBE_DISTANCE < max_items) {
+        max_probe_distance_limit = MVM_HASH_MAX_PROBE_DISTANCE;
     } else {
-        max_probe_distance_limit = max_items - 1;
+        max_probe_distance_limit = max_items;
     }
-    size_t allocated_items = official_size + max_probe_distance_limit;
+    size_t allocated_items = official_size + max_probe_distance_limit - 1;
     size_t entries_size = entry_size * allocated_items;
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
 
@@ -238,7 +230,22 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+
+        /* For insert, the loop must not iterate to any probe distance greater
+         * than the (current) maximum probe distance, because it must never
+         * insert an entry at a location beyond the maximum probe distance.
+         *
+         * For fetch and delete, the loop is permitted to reach (and read) one
+         * beyond the maximum probe distance (hence +1 in the seemingly
+         * analogous assertions) - but if so, it will always read from the
+         * metadata a probe distance which is lower than the current probe
+         * distance, and hence hit "not found" and terminate the loop.
+         *
+         * This is how the loop terminates when the max probe distance is
+         * reached without needing an explicit test for it, and why we need an
+         * initialised sentinel byte at the end of the metadata. */
+
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
@@ -404,9 +411,8 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
                the hash table - it would have stolen this slot, and the key we
-               find here now would have been displaced futher on. Hence, the key
+               find here now would have been displaced further on. Hence, the key
                we seek can't be in the hash table. */
-            /* Strange. Not in the hash. Should this be an oops? */
             return;
         }
         ++ls.probe_distance;

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -70,7 +70,9 @@ MVM_STATIC_INLINE struct MVMStrHashTableControl *hash_allocate_common(MVMThreadC
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = max_probe_distance_limit > (4 - 1) ? (4 - 1) : max_probe_distance_limit;
+    control->metadata_hash_bits = 0;
+    MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
+    control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
     control->entry_size = entry_size;
@@ -169,8 +171,8 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
                 MVMuint8 *find_me_a_gap = ls.metadata;
                 MVMuint8 old_probe_distance = *ls.metadata;
                 do {
-                    MVMuint8 new_probe_distance = 1 + old_probe_distance;
-                    if (new_probe_distance == control->max_probe_distance) {
+                    MVMuint32 new_probe_distance = ls.metadata_increment + old_probe_distance;
+                    if (new_probe_distance >> ls.probe_distance_shift == ls.max_probe_distance) {
                         /* Optimisation from Martin Ankerl's implementation:
                            setting this to zero forces a resize on any insert,
                            *before* the actual insert, so that we never end up
@@ -201,7 +203,7 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
              */
-            if (ls.probe_distance == control->max_probe_distance) {
+            if (ls.probe_distance >> ls.probe_distance_shift == control->max_probe_distance) {
                 control->max_items = 0;
             }
 
@@ -227,7 +229,7 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
                 return entry;
             }
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
 
@@ -245,7 +247,7 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance);
+        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
@@ -256,6 +258,7 @@ static struct MVMStrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
     /* control->max_items may have been set to 0 to trigger a call into this
      * function. */
     MVMuint32 max_items = MVM_str_hash_max_items(control);
+    MVMuint32 max_probe_distance = control->max_probe_distance;
     MVMuint32 max_probe_distance_limit = control->max_probe_distance_limit;
 
     /* We can hit both the probe limit and the max items on the same insertion.
@@ -264,10 +267,9 @@ static struct MVMStrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
      * then we don't have more space in the metadata, so we're going to have to
      * grow anyway. */
     if (control->cur_items < max_items
-        && control->max_probe_distance < max_probe_distance_limit) {
+        && max_probe_distance < max_probe_distance_limit) {
         /* We hit the probe limit, but not the max items count. */
-        MVMuint32 new_probe_distance
-            = 2 + 2 * (MVMuint32) control->max_probe_distance;
+        MVMuint32 new_probe_distance = 1 + 2 * max_probe_distance;
         if (new_probe_distance > max_probe_distance_limit) {
             new_probe_distance = max_probe_distance_limit;
         }
@@ -405,9 +407,9 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                 uint8_t *metadata_target = ls.metadata;
                 /* Look at the next slot */
                 uint8_t old_probe_distance = metadata_target[1];
-                while (old_probe_distance > 1) {
+                while (old_probe_distance > ls.metadata_increment) {
                     /* OK, we can move this one. */
-                    *metadata_target = old_probe_distance - 1;
+                    *metadata_target = old_probe_distance - ls.metadata_increment;
                     /* Try the next one, etc */
                     ++metadata_target;
                     old_probe_distance = metadata_target[1];
@@ -458,10 +460,10 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                we seek can't be in the hash table. */
             return;
         }
-        ++ls.probe_distance;
+        ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
+        assert(ls.probe_distance <= (control->max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
@@ -482,6 +484,7 @@ static MVMuint64 hash_fsck_internal(MVMThreadContext *tc, struct MVMStrHashTable
     }
 
     MVMuint32 allocated_items = MVM_str_hash_allocated_items(control);
+    const MVMuint8 metadata_hash_bits = control->metadata_hash_bits;
     MVMuint8 *entry_raw = MVM_str_hash_entries(control);
     MVMuint8 *metadata = MVM_str_hash_metadata(control);
     MVMuint32 bucket = 0;
@@ -552,7 +555,8 @@ static MVMuint64 hash_fsck_internal(MVMThreadContext *tc, struct MVMStrHashTable
                 MVMuint64 hash_val = MVM_str_hash_code(tc, control->salt, key);
                 MVMuint32 ideal_bucket = hash_val >> control->key_right_shift;
                 MVMint64 offset = 1 + bucket - ideal_bucket;
-                char wrong_bucket = offset == *metadata ? ' ' : '!';
+                MVMuint32 actual_bucket = *metadata >> metadata_hash_bits;
+                char wrong_bucket = offset == actual_bucket ? ' ' : '!';
                 char wrong_order;
                 if (offset < 1) {
                     wrong_order = '<';

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -477,7 +477,11 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                 uint8_t *metadata_target = ls.metadata;
                 /* Look at the next slot */
                 uint8_t old_probe_distance = metadata_target[1];
-                while (old_probe_distance > (ls.metadata_increment | ls.metadata_hash_mask)) {
+                /* Without this, gcc seemed always to want to recalculate this
+                 * for each loop iteration. Also, expressing this only in terms
+                 * of ls.metadata_increment avoids 1 load (albeit from cache) */
+                const uint8_t can_move = 2 * ls.metadata_increment;
+                while (old_probe_distance >= can_move) {
                     /* OK, we can move this one. */
                     *metadata_target = old_probe_distance - ls.metadata_increment;
                     /* Try the next one, etc */

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -1,6 +1,5 @@
 #include "moar.h"
 
-#define STR_LOAD_FACTOR 0.75
 #define STR_MIN_SIZE_BASE_2 3
 
 /* Adapted from the log_base2 function.
@@ -51,7 +50,7 @@ MVM_STATIC_INLINE struct MVMStrHashTableControl *hash_allocate_common(MVMThreadC
                                                                       MVMuint8 key_right_shift,
                                                                       MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
-    MVMuint32 max_items = official_size * STR_LOAD_FACTOR;
+    MVMuint32 max_items = official_size * MVM_STR_HASH_LOAD_FACTOR;
     MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
@@ -112,7 +111,7 @@ void MVM_str_hash_build(MVMThreadContext *tc,
         initial_size_base2 = STR_MIN_SIZE_BASE_2;
     } else {
         /* Minimum size we need to allocate, given the load factor. */
-        MVMuint32 min_needed = entries * (1.0 / STR_LOAD_FACTOR);
+        MVMuint32 min_needed = entries * (1.0 / MVM_STR_HASH_LOAD_FACTOR);
         initial_size_base2 = MVM_round_up_log_base2(min_needed);
         if (initial_size_base2 < STR_MIN_SIZE_BASE_2) {
             /* "Too small" - use our original defaults. */
@@ -237,7 +236,7 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
 }
@@ -399,7 +398,7 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
 }

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -281,7 +281,7 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
          * insert an entry at a location beyond the maximum probe distance.
          *
          * For fetch and delete, the loop is permitted to reach (and read) one
-         * beyond the maximum probe distance (hence +1 in the seemingly
+         * beyond the maximum probe distance (hence +2 in the seemingly
          * analogous assertions) - but if so, it will always read from the
          * metadata a probe distance which is lower than the current probe
          * distance, and hence hit "not found" and terminate the loop.
@@ -290,7 +290,7 @@ MVM_STATIC_INLINE struct MVMStrHashHandle *hash_insert_internal(MVMThreadContext
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
@@ -471,7 +471,7 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
                 uint8_t *metadata_target = ls.metadata;
                 /* Look at the next slot */
                 uint8_t old_probe_distance = metadata_target[1];
-                while (old_probe_distance > ls.metadata_increment) {
+                while (old_probe_distance > (ls.metadata_increment | ls.metadata_hash_mask)) {
                     /* OK, we can move this one. */
                     *metadata_target = old_probe_distance - ls.metadata_increment;
                     /* Try the next one, etc */
@@ -527,7 +527,7 @@ void MVM_str_hash_delete_nocheck(MVMThreadContext *tc,
         ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (control->max_probe_distance + 1) * ls.metadata_increment);
+        assert(ls.probe_distance < (control->max_probe_distance + 2) * ls.metadata_increment);
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -178,6 +178,237 @@ be worth it.
  * 3) fix up the GC invariants
  */
 
+/* How does storing hash bits in the metadata work? And how come there doesn't
+ * seem to be *any* explicit code for testing it in the fetch loop?
+ *
+ * Consider the 6 keys 'R', 'a', 'k', 'u' 'd' 'o'.
+ * We'll assume that the hash value for each is their ASCII code.
+ * Assuming a hash with 16 buckets, we use the top 4 bits of the hash value
+ * to determine the ideal bucket for the key - the bucket that the key would go
+ * in, if inserted into an empty hash. So our keys look like this:
+ *
+ *           hash   bucket   extra
+ * R     01010010        5       2
+ * a     01100001        6       1
+ * k     01101011        6      11
+ * u     01110101        7       5
+ * d     01100100        6       8
+ * o     01101111        6      15
+ *      /   ||   \
+ *     bucket extra
+ *
+ * If we insert them in that order into the hash, then they would be laid out
+ * like this:
+ *
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ *     | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | ...
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * key                       R   a   k   d   o   u
+ * probe distance            1   1   2   3   4   4
+ *
+ *
+ * Insert order doesn't matter - this order would be equally valid and would be
+ * what we get by inserting the 6 keys in reverse order:
+ *
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ *     | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | ...
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * key                       R   o   d   k   a   u
+ * probe distance            1   1   2   3   4   4
+ *
+ * Consider the search for the key 'u'. Its ideal bucket is 7. We start with a
+ * probe distance of one. *Only* metadata bytes that equal the probe distance
+ * might be matches - we can immediately dismiss all other entries as "can't
+ * match" without even having to look up their full entry to get the key. So for
+ * 'u', we have:
+ *
+ *                                   ^
+ *                                  != 0x01 (so can't match)
+ *                                  >= 0x01 (so keep going)
+ *
+ *                                       ^
+ *                                      != 0x02 (so can't match)
+ *                                      >= 0x02 (so keep going)
+ *
+ *                                           ^
+ *                                          != 0x03 (so can't match)
+ *                                          >= 0x03 (so keep going)
+ *
+ *                                                   ^
+ *                                              == 0x04 (so might match match)
+ *                                              ('u' eq 'u'; found; return)
+ *
+ *
+ * Note that we don't even look at the "main" hash entries until the last case -
+ * we are in a tight loop with small data hot in the cache. Long probe distances
+ * aren't themselves aren't terrible - what hurts more is when multiple hash
+ * entries all contest the same ideal bucket. A search for 'k' would find it at
+ * probe distance 3, but would have had to look up and test the keys at probe
+ * distances 1 and 2 before then.
+ *
+ * The trick in the design from Martin Ankerl is to also store some *more* bits
+ * from the hash value in the metadata byte. Remember, the Robin Hood
+ * invariant is only about probe distance. So this order is *also* valid:
+ *
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ *     | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | ...
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * key                       R   a   d   k   o   u
+ * probe distance            1   1   2   3   4   4
+ *
+ * Consider the extra hash bits for each key:
+ *
+ *                           2   1   8  11  15   5
+ *
+ * if we store the metadata as (probe distance) << 4 | (extra hash bits) then it
+ * is (in hexadecimal) laid out like this:
+ *
+ *                          12  11  28  3b  4f  45
+ *
+ * Consider the search for the key 'k'. Its ideal bucket is 6. Its extra hash
+ * bits are 11. So we start with bucket 6, metadata byte 0x1b. Each time we
+ * advance the bucket, we add (1 << 4) to the metadata byte we need to find to
+ * match. So:
+ *
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ *     | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | ...
+ *     +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * key                       R   a   d   k   o   u
+ * metadata byte            12  11  28  3b  4f  45
+ *                               ^
+ *                              != 0x1b (so can't match)
+ *                              >= 0x10 (so keep going)
+ *
+ *                                   ^
+ *                                  != 0x2b (so can't match)
+ *                                  >= 0x20 (so keep going)
+ *
+ *                                       ^
+ *                                      == 0x3b (so might match)
+ *                                      ('k' eq 'k', so found; return)
+ *
+ * Notice that we didn't even have to do the string comparison for 'k' != 'a'
+ * and for 'k' != 'd'. They fall out naturally from the existing byte
+ * comparisons, and how the metadata is stored.
+ *
+ * For lookup We have had to do a little more CPU work to calculate the metadata
+ * byte we expect to see (figuring out the increment, rather than it just being
+ * +1 each time) but we hope that pays off by doing less work on key comparisons
+ * (and fewer cache misses)
+ *
+ *
+ * Finally, how "not found" works. In this case, the extra hash bits don't give
+ * a shortcut. Say we search for 'p'. Its ideal bucket is also 6. Its extra hash
+ * bits are 10. So again we start with bucket 6, but metadata byte 0x1a.
+ *
+ * The first 2 steps are the same. At the third, we diverge:
+ *
+ *                                       ^
+ *                                      != 0x3a (so can't match)
+ *                                      >= 0x30 (so keep going)
+ *
+ *                                           ^
+ *                                          != 0x4a (so can't match)
+ *                                          >= 0x40 (so keep going)
+ *
+ *                                                   ^
+ *                                              != 0x5a (so can't match)
+ *                                              <  0x50 (so not found; return)
+ *
+ *
+ * There is, however, a trade off. For the examples at the top, without the
+ * extra hash bits, by choosing to always insert later, we minimise the amount
+ * we move.  The hash fills up like this:
+ *
+ * key                         R
+ * probe distance              1
+ *
+ * key                         R   a
+ * probe distance              1   1
+ *
+ * key                         R   a   k
+ * probe distance              1   1   2
+ *
+ * key                         R   a   k   u
+ * probe distance              1   1   2   2
+ * [move 'u' to insert 'd']
+ * key                         R   a   k   d   u
+ * probe distance              1   1   2   3   3
+ * [move 'u' to insert 'o']
+ * key                         R   a   k   d   o   u
+ * probe distance              1   1   2   3   4   4
+ *
+ *
+ * But with hash bits in the metadata, to maintain the order, the hash fills up
+ * like this
+ *
+ * key                         R
+ * probe distance              1
+ *
+ * key                         R   a
+ * probe distance              1   1
+ *
+ * key                         R   a   k
+ * probe distance              1   1   2
+ *
+ * key                         R   a   k   u
+ * probe distance              1   1   2   2
+ * [move 'k', 'u' to insert 'd']
+ * key                         R   a   d   k   u
+ * probe distance              1   1   2   3   3
+ * [move 'u' to insert 'o']
+ * key                         R   a   d   k   o   u
+ * probe distance              1   1   2   3   4   4
+ *
+ * More entries had to be moved around. That's more CPU and more cache churn.
+ *
+ * So there is a definite trade off here. There's more work creating hashes,
+ * with the hoped-for trade off that there will be less work for hash lookups.
+ *
+ * Note also that putting probe distance in the higher bits is deliberate. It
+ * means that we can easily process the metadata bytes to increase the number of
+ * bits used to store probe distance *without* breaking either the Robin Hood
+ * invariant, or the "extra bits" invariant/assumption. So if we had (4, 4), we
+ * can go to (5, 3) with a bitshift:
+ *
+ * key                  R        a        d        k        o        u
+ * metadata was  00010010 00010001 00101000 00111011 01001111 01000101
+ *                  1   2    1   1    2   8    3   b    4   f    4   5
+ * metadata now  00001001 00001000 00010100 00011101 00100111 00100010
+ *                   1  1     1  0     2  4     3  5     4  7     4  2
+ *
+ * which we can do word-at-a-type with a suitable mask (0x7f7f7f7f7f7f7f7f)
+ * and without re-ordering *anything*.
+ *
+ *
+ * Note for tuning this
+ *
+ * 1) we don't *have* to start out by using 4 (or even 5) bits for metadata. We
+ *    could use 3. Fewer bits *increases* the chance of needing to do a key
+ *    lookup, but *decreases* the amount of memmove during hash inserts.
+ *
+ * 2) Higher load factor means longer probe distances, but also makes more
+ *    metadata fit in the CPU cache. It also means more work on insert and
+ *    delete.
+ *
+ * 3) Currently we grow the hash when we exceed the load factor *or* when we run
+ *    out of bits to store the probe distance. We could choose to limit the
+ *    probe distance, and grow the hash sooner if we get bad luck with probing.
+ *
+ * 4) We could pick both the load factors and the hash metadata split
+ *    differently at different hash sizes (or if the hash size was given at
+ *    build time).
+ *
+ * The metadata lookup loop is pretty tight. For arm32, it's 7 instructions,
+ * for each metadata "miss".
+ *
+ * The hash bits in metadata doesn't bring us as much speedup as I had hoped. I
+ * *think* that this is because (for us) the full key lookup is *relatively*
+ * cheap - it's two pointer dereferences and an equality test that will usually
+ * "fail fast". There might still be a win here, but it might be hard to be sure
+ * of, and it might only be a CPU for "last level cache miss" trade off.
+ */
+
 struct MVMStrHashTableControl {
     MVMuint64 salt;
 #if HASH_DEBUG_ITER

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -38,8 +38,10 @@ go inline. And it turns out, our keys are always pointers, and easily "hashed"
 (either because they are, because they point to something that caches its
 hash value, or because we fake it and explicitly store the hash value.)
 
-Not all the optimisations described above are in place yet. Starting with
-"minimum viable product", with a design that should support adding them.
+Some tuning is still possible (and probably a good idea), but the only
+significant code optimisation not implemented would be to change iterator
+metadata processing to be word-at-a-time when possible. And even that might not
+be worth it.
 
 */
 
@@ -142,7 +144,7 @@ Not all the optimisations described above are in place yet. Starting with
  * the last bucket), so what we actually have is this
  *
  * +----------+        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
- * | metadata | ->     | a | b | c | d | e | f | g | h | i | j | k | l | m | 1 |
+ * | metadata | ->     | a | b | c | d | e | f | g | h | i | j | k | l | m | 0 |
  * |          |        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
  * | (other)  |
  * |          |        +---+---+---+---+---+---+---+---+---+---+---+---+---+

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -277,11 +277,11 @@ be worth it.
  * metadata byte            12  11  28  3b  4f  45
  *                               ^
  *                              != 0x1b (so can't match)
- *                              >= 0x10 (so keep going)
+ *                              >= 0x1b (so keep going)
  *
  *                                   ^
  *                                  != 0x2b (so can't match)
- *                                  >= 0x20 (so keep going)
+ *                                  >= 0x2b (so keep going)
  *
  *                                       ^
  *                                      == 0x3b (so might match)
@@ -291,7 +291,7 @@ be worth it.
  * and for 'k' != 'd'. They fall out naturally from the existing byte
  * comparisons, and how the metadata is stored.
  *
- * For lookup We have had to do a little more CPU work to calculate the metadata
+ * For lookup we have had to do a little more CPU work to calculate the metadata
  * byte we expect to see (figuring out the increment, rather than it just being
  * +1 each time) but we hope that pays off by doing less work on key comparisons
  * (and fewer cache misses)
@@ -305,15 +305,15 @@ be worth it.
  *
  *                                       ^
  *                                      != 0x3a (so can't match)
- *                                      >= 0x30 (so keep going)
+ *                                      >= 0x3a (so keep going)
  *
  *                                           ^
  *                                          != 0x4a (so can't match)
- *                                          >= 0x40 (so keep going)
+ *                                          >= 0x4a (so keep going)
  *
  *                                                   ^
  *                                              != 0x5a (so can't match)
- *                                              <  0x50 (so not found; return)
+ *                                              <  0x5a (so not found; return)
  *
  *
  * There is, however, a trade off. For the examples at the top, without the
@@ -380,7 +380,6 @@ be worth it.
  * which we can do word-at-a-type with a suitable mask (0x7f7f7f7f7f7f7f7f)
  * and without re-ordering *anything*.
  *
- *
  * Note for tuning this
  *
  * 1) we don't *have* to start out by using 4 (or even 5) bits for metadata. We
@@ -399,7 +398,10 @@ be worth it.
  *    differently at different hash sizes (or if the hash size was given at
  *    build time).
  *
- * The metadata lookup loop is pretty tight. For arm32, it's 7 instructions,
+ * 5) see the comment in str_hash_table_funcs.h about (not) checking the key's
+ *    full 64 hash value
+ *
+ * The metadata lookup loop is pretty tight. For arm32, it's 8 instructions,
  * for each metadata "miss".
  *
  * The hash bits in metadata doesn't bring us as much speedup as I had hoped. I

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -188,7 +188,14 @@ struct MVMStrHashTableControl {
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
     MVMuint8 entry_size;
+    /* This is the maximum probe distance we can use without updating the
+     * metadata. It might not *yet* be the maximum probe distance possible for
+     * the official_size. */
     MVMuint8 max_probe_distance;
+    /* This is the maximum probe distance possible for the official size.
+     * We can (re)calcuate this from other values in the struct, but it's easier
+     * to cache it as we have the space. */
+    MVMuint8 max_probe_distance_limit;
 };
 
 struct MVMStrHashTable {

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -185,7 +185,7 @@ struct MVMStrHashTableControl {
 #endif
     MVMHashNumItems cur_items;
     MVMHashNumItems max_items; /* hit this and we grow */
-    MVMHashNumItems official_size;
+    MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
     MVMuint8 entry_size;
     MVMuint8 probe_overflow_size;

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -196,6 +196,7 @@ struct MVMStrHashTableControl {
      * We can (re)calcuate this from other values in the struct, but it's easier
      * to cache it as we have the space. */
     MVMuint8 max_probe_distance_limit;
+    MVMuint8 metadata_hash_bits;
 };
 
 struct MVMStrHashTable {

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -185,6 +185,13 @@ struct MVMStrHashTableControl {
     MVMuint32 serial;
     MVMuint32 last_delete_at;
 #endif
+    /* If cur_items and max_items are *both* 0 then we only allocated a control
+     * structure. All of the other entries in the struct are bogus, apart from
+     * entry_size, and calling many of the accessor methods for the hash will
+     * fail assertions.
+     * ("Doctor, Doctor, it hurts when I do this". "Well, don't do that then.")
+     * Iterators will return end immediately, fetch will fast track a not-found
+     * result, and insert will immediately allocate the default minimum size. */
     MVMHashNumItems cur_items;
     MVMHashNumItems max_items; /* hit this and we grow */
     MVMuint8 official_size_log2;

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -188,7 +188,7 @@ struct MVMStrHashTableControl {
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
     MVMuint8 entry_size;
-    MVMuint8 probe_overflow_size;
+    MVMuint8 max_probe_distance;
 };
 
 struct MVMStrHashTable {

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -153,7 +153,7 @@ be worth it.
  *
  *                     <-- official bucket positions --><--   overflow   -->
  *
- * We include a sentinel values at the end of the metadata so that the probe
+ * We include a sentinel value at the end of the metadata so that the probe
  * distance loop doesn't need a bounds check. We *had* allocated an extra byte
  * at the start too, to make the pointer arithmetic work, but that isn't needed
  * now that we use a single memory block.

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -8,7 +8,7 @@ MVM_STATIC_INLINE MVMuint32 MVM_str_hash_max_items(const struct MVMStrHashTableC
     return MVM_str_hash_official_size(control) * MVM_STR_HASH_LOAD_FACTOR;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_kompromat(const struct MVMStrHashTableControl *control) {
-    return MVM_str_hash_official_size(control) + control->probe_overflow_size;
+    return MVM_str_hash_official_size(control) + control->max_probe_distance;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_str_hash_metadata(const struct MVMStrHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMStrHashTableControl);
@@ -131,7 +131,7 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -69,20 +69,40 @@ void *MVM_str_hash_insert_nocheck(MVMThreadContext *tc,
                                   MVMStrHashTable *hashtable,
                                   MVMString *key);
 
+struct MVM_hash_loop_state {
+    MVMuint8 *entry_raw;
+    MVMuint8 *metadata;
+    unsigned int probe_distance;
+    MVMuint16 entry_size;
+};
+
+MVM_STATIC_INLINE struct MVM_hash_loop_state
+MVM_str_hash_create_loop_state(MVMThreadContext *tc,
+                               struct MVMStrHashTableControl *control,
+                               MVMString *key) {
+    MVMuint64 hash_val = MVM_str_hash_code(tc, control->salt, key);
+    MVMHashNumItems bucket = hash_val >> control->key_right_shift;
+    struct MVM_hash_loop_state retval;
+    retval.probe_distance = 1;
+    retval.entry_size = control->entry_size;
+    retval.entry_raw = MVM_str_hash_entries(control) - bucket * retval.entry_size;
+    retval.metadata = MVM_str_hash_metadata(control) + bucket;
+    return retval;
+}
+
 MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
                                                    MVMStrHashTable *hashtable,
                                                    MVMString *key) {
     if (MVM_str_hash_is_empty(tc, hashtable)) {
         return NULL;
     }
+
     struct MVMStrHashTableControl *control = hashtable->table;
-    unsigned int probe_distance = 1;
-    MVMHashNumItems bucket = MVM_str_hash_code(tc, control->salt, key) >> control->key_right_shift;
-    MVMuint8 *entry_raw = MVM_str_hash_entries(control) - bucket * control->entry_size;
-    MVMuint8 *metadata = MVM_str_hash_metadata(control) + bucket;
+    struct MVM_hash_loop_state ls = MVM_str_hash_create_loop_state(tc, control, key);
+
     while (1) {
-        if (*metadata == probe_distance) {
-            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) entry_raw;
+        if (*ls.metadata == ls.probe_distance) {
+            struct MVMStrHashHandle *entry = (struct MVMStrHashHandle *) ls.entry_raw;
             if (entry->key == key
                 || (MVM_string_graphs_nocheck(tc, key) == MVM_string_graphs_nocheck(tc, entry->key)
                     && MVM_string_substrings_equal_nocheck(tc, key, 0,
@@ -92,7 +112,7 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*metadata < probe_distance) {
+        if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
@@ -101,12 +121,12 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
                we seek can't be in the hash table. */
             return NULL;
         }
-        ++probe_distance;
-        ++metadata;
-        entry_raw -= control->entry_size;
-        assert(probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(metadata < MVM_str_hash_metadata(control) + control->official_size + control->max_items);
-        assert(metadata < MVM_str_hash_metadata(control) + control->official_size + 256);
+        ++ls.probe_distance;
+        ++ls.metadata;
+        ls.entry_raw -= ls.entry_size;
+        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + control->max_items);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + 256);
     }
 }
 

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -1,5 +1,9 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+/* See comments in hash_allocate_common (and elsewhere) before changing the
+ * load factor, or STR_MIN_SIZE_BASE_2 or MVM_HASH_INITIAL_BITS_IN_METADATA,
+ * and test with assertions enabled. The current choices permit certain
+ * optimisation assumptions in parts of the code. */
 #define MVM_STR_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_official_size(const struct MVMStrHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -71,7 +71,7 @@ MVM_STATIC_INLINE void MVM_str_hash_shallow_copy(MVMThreadContext *tc,
     if (!control)
         return;
     if (control->cur_items == 0 && control->max_items == 0) {
-        struct MVMStrHashTableControl *empty = MVM_malloc(sizeof(*empty));
+        struct MVMStrHashTableControl *empty = MVM_fixed_size_alloc(tc, tc->instance->fsa, sizeof(*empty));
         memcpy(empty, control, sizeof(*empty));
         dest->table = empty;
     } else {
@@ -81,7 +81,7 @@ MVM_STATIC_INLINE void MVM_str_hash_shallow_copy(MVMThreadContext *tc,
         const char *start = (const char *)control - entries_size;
         size_t total_size
             = entries_size + sizeof(struct MVMStrHashTableControl) + metadata_size;
-        char *target = MVM_malloc(total_size);
+        char *target = (char *) MVM_fixed_size_alloc(tc, tc->instance->fsa, total_size);
         memcpy(target, start, total_size);
         dest->table = (struct MVMStrHashTableControl *)(target + entries_size);
     }

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -94,6 +94,7 @@ struct MVM_hash_loop_state {
     MVMuint8 *entry_raw;
     MVMuint8 *metadata;
     unsigned int metadata_increment;
+    unsigned int metadata_hash_mask;
     unsigned int probe_distance_shift;
     unsigned int max_probe_distance;
     unsigned int probe_distance;
@@ -109,9 +110,10 @@ MVM_str_hash_create_loop_state(MVMThreadContext *tc,
     struct MVM_hash_loop_state retval;
     retval.entry_size = control->entry_size;
     retval.metadata_increment = 1 << control->metadata_hash_bits;
+    retval.metadata_hash_mask = retval.metadata_increment - 1;
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
-    retval.probe_distance = retval.metadata_increment;
+    retval.probe_distance = retval.metadata_increment | retval.metadata_hash_mask;
     retval.entry_raw = MVM_str_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_str_hash_metadata(control) + bucket;
     return retval;
@@ -151,7 +153,7 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
         ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (ls.max_probe_distance + 1) * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 2) * ls.metadata_increment);
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -45,6 +45,19 @@ MVM_STATIC_INLINE size_t MVM_hash_round_size_up(size_t wanted) {
     return (wanted - 1 + sizeof(long)) & ~(sizeof(long) - 1);
 }
 
+MVM_STATIC_INLINE size_t MVM_str_hash_allocated_size(MVMThreadContext *tc, MVMStrHashTable *hashtable) {
+    struct MVMStrHashTableControl *control = hashtable->table;
+    if (!control)
+        return 0;
+    if (control->cur_items == 0 && control->max_items == 0)
+        return sizeof(*control);
+
+    size_t allocated_items = MVM_str_hash_allocated_items(control);
+    size_t entries_size = control->entry_size * allocated_items;
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
+    return entries_size + sizeof(struct MVMStrHashTableControl) + metadata_size;
+}
+
 /* Frees the entire contents of the hash, leaving you just the hashtable itself,
    which you allocated (heap, stack, inside another struct, wherever) */
 void MVM_str_hash_demolish(MVMThreadContext *tc, MVMStrHashTable *hashtable);

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -152,7 +152,7 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*ls.metadata < ls.probe_distance) {
+        else if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -1,7 +1,11 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+#define MVM_STR_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_official_size(const struct MVMStrHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
+}
+MVM_STATIC_INLINE MVMuint32 MVM_str_hash_max_items(const struct MVMStrHashTableControl *control) {
+    return MVM_str_hash_official_size(control) * MVM_STR_HASH_LOAD_FACTOR;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_kompromat(const struct MVMStrHashTableControl *control) {
     return MVM_str_hash_official_size(control) + control->probe_overflow_size;
@@ -128,7 +132,7 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + MVM_str_hash_max_items(control));
         assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
 }

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -7,6 +7,9 @@ MVM_STATIC_INLINE MVMuint32 MVM_str_hash_official_size(const struct MVMStrHashTa
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_max_items(const struct MVMStrHashTableControl *control) {
     return MVM_str_hash_official_size(control) * MVM_STR_HASH_LOAD_FACTOR;
 }
+MVM_STATIC_INLINE MVMuint32 MVM_str_hash_allocated_items(const struct MVMStrHashTableControl *control) {
+    return MVM_str_hash_official_size(control) + control->max_probe_distance_limit;
+}
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_kompromat(const struct MVMStrHashTableControl *control) {
     return MVM_str_hash_official_size(control) + control->max_probe_distance;
 }
@@ -50,9 +53,9 @@ MVM_STATIC_INLINE void MVM_str_hash_shallow_copy(MVMThreadContext *tc,
     const struct MVMStrHashTableControl *control = source->table;
     if (!control)
         return;
-    size_t actual_items = MVM_str_hash_kompromat(control);
-    size_t entries_size = control->entry_size * actual_items;
-    size_t metadata_size = MVM_hash_round_size_up(actual_items + 1);
+    size_t allocated_items = MVM_str_hash_allocated_items(control);
+    size_t entries_size = control->entry_size * allocated_items;
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     const char *start = (const char *)control - entries_size;
     size_t total_size
         = entries_size + sizeof(struct MVMStrHashTableControl) + metadata_size;

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -7,11 +7,18 @@ MVM_STATIC_INLINE MVMuint32 MVM_str_hash_official_size(const struct MVMStrHashTa
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_max_items(const struct MVMStrHashTableControl *control) {
     return MVM_str_hash_official_size(control) * MVM_STR_HASH_LOAD_FACTOR;
 }
+/* -1 because...
+ * probe distance of 1 is the correct bucket.
+ * hence for a value whose ideal slot is the last bucket, it's *in* the official
+ * allocation.
+ * probe distance of 2 is the first extra bucket beyond the official allocation
+ * probe distance of 255 is the 254th beyond the official allocation.
+ */
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_allocated_items(const struct MVMStrHashTableControl *control) {
-    return MVM_str_hash_official_size(control) + control->max_probe_distance_limit;
+    return MVM_str_hash_official_size(control) + control->max_probe_distance_limit - 1;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_kompromat(const struct MVMStrHashTableControl *control) {
-    return MVM_str_hash_official_size(control) + control->max_probe_distance;
+    return MVM_str_hash_official_size(control) + control->max_probe_distance - 1;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_str_hash_metadata(const struct MVMStrHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMStrHashTableControl);
@@ -127,7 +134,7 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
                the hash table - it would have stolen this slot, and the key we
-               find here now would have been displaced futher on. Hence, the key
+               find here now would have been displaced further on. Hence, the key
                we seek can't be in the hash table. */
             return NULL;
         }

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -1,7 +1,10 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+MVM_STATIC_INLINE MVMuint32 MVM_str_hash_official_size(const struct MVMStrHashTableControl *control) {
+    return 1 << (MVMuint32)control->official_size_log2;
+}
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_kompromat(const struct MVMStrHashTableControl *control) {
-    return control->official_size + control->probe_overflow_size;
+    return MVM_str_hash_official_size(control) + control->probe_overflow_size;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_str_hash_metadata(const struct MVMStrHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMStrHashTableControl);
@@ -125,8 +128,8 @@ MVM_STATIC_INLINE void *MVM_str_hash_fetch_nocheck(MVMThreadContext *tc,
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + control->max_items);
-        assert(ls.metadata < MVM_str_hash_metadata(control) + control->official_size + 256);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_str_hash_metadata(control) + MVM_str_hash_official_size(control) + 256);
     }
 }
 

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -106,14 +106,25 @@ MVM_str_hash_create_loop_state(MVMThreadContext *tc,
                                struct MVMStrHashTableControl *control,
                                MVMString *key) {
     MVMuint64 hash_val = MVM_str_hash_code(tc, control->salt, key);
-    MVMHashNumItems bucket = hash_val >> control->key_right_shift;
     struct MVM_hash_loop_state retval;
     retval.entry_size = control->entry_size;
     retval.metadata_increment = 1 << control->metadata_hash_bits;
     retval.metadata_hash_mask = retval.metadata_increment - 1;
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
-    retval.probe_distance = retval.metadata_increment | retval.metadata_hash_mask;
+
+    unsigned int used_hash_bits
+        = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
+    MVMHashNumItems bucket;
+    if (control->metadata_hash_bits) {
+        retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
+        bucket = used_hash_bits >> control->metadata_hash_bits;
+    } else {
+        /* metadata_increment is 1, metadata_hash_mask is 0 */
+        retval.probe_distance = 1;
+        bucket = used_hash_bits;
+    }
+
     retval.entry_raw = MVM_str_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_str_hash_metadata(control) + bucket;
     return retval;

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -55,14 +55,6 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
-    /* A sentinel. This marks an occupied slot, at its ideal position.
-     * As long as we start with (no more than) 5 metadata hash bits, certainly
-     * for the load factor we currently have (0.75) we can't actually reach this
-     * sentinel even with long-at-a-time reprocessing of the metadata, for any
-     * size shorter than the full allocation (at which point we no longer
-     * reprocess). */
-    metadata[allocated_items] = 1;
-
     return control;
 }
 
@@ -218,7 +210,6 @@ static struct MVMUniHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         }
 
         MVMuint8 *metadata = MVM_uni_hash_metadata(control);
-        assert(metadata[MVM_uni_hash_allocated_items(control)] == 1);
         MVMuint32 in_use_items = MVM_uni_hash_official_size(control) + max_probe_distance;
         /* not `in_use_items + 1` because because we don't need to shift the
          * sentinel. */
@@ -234,7 +225,6 @@ static struct MVMUniHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
             *p = (*p >> 1) & (0x7F7F7F7FUL | (0x7F7F7F7FUL << (4 * sizeof(long))));
             ++p;
         } while (--loop_count);
-        assert(metadata[MVM_uni_hash_allocated_items(control)] == 1);
         assert(control->metadata_hash_bits);
         --control->metadata_hash_bits;
 

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -1,6 +1,5 @@
 #include "moar.h"
 
-#define UNI_LOAD_FACTOR 0.75
 #define UNI_MIN_SIZE_BASE_2 3
 
 MVM_STATIC_INLINE MVMuint32 hash_true_size(const struct MVMUniHashTableControl *control) {
@@ -31,7 +30,7 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
                                                                       MVMuint8 key_right_shift,
                                                                       MVMuint8 official_size_log2) {
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
-    MVMuint32 max_items = official_size * UNI_LOAD_FACTOR;
+    MVMuint32 max_items = official_size * MVM_UNI_HASH_LOAD_FACTOR;
     MVMuint32 overflow_size = max_items - 1;
     /* -1 because...
      * probe distance of 1 is the correct bucket.
@@ -79,7 +78,7 @@ void MVM_uni_hash_build(MVMThreadContext *tc,
         initial_size_base2 = UNI_MIN_SIZE_BASE_2;
     } else {
         /* Minimum size we need to allocate, given the load factor. */
-        MVMuint32 min_needed = entries * (1.0 / UNI_LOAD_FACTOR);
+        MVMuint32 min_needed = entries * (1.0 / MVM_UNI_HASH_LOAD_FACTOR);
         initial_size_base2 = MVM_round_up_log_base2(min_needed);
         if (initial_size_base2 < UNI_MIN_SIZE_BASE_2) {
             /* "Too small" - use our original defaults. */
@@ -181,7 +180,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + MVM_uni_hash_max_items(control));
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + 256);
     }
 }

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -3,7 +3,7 @@
 #define UNI_MIN_SIZE_BASE_2 3
 
 MVM_STATIC_INLINE MVMuint32 hash_true_size(const struct MVMUniHashTableControl *control) {
-    return MVM_uni_hash_official_size(control) + control->probe_overflow_size;
+    return MVM_uni_hash_official_size(control) + control->max_probe_distance;
 }
 
 MVM_STATIC_INLINE void hash_demolish_internal(MVMThreadContext *tc,
@@ -58,7 +58,7 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->probe_overflow_size = probe_overflow_size;
+    control->max_probe_distance = probe_overflow_size;
     control->key_right_shift = key_right_shift;
 
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
@@ -126,7 +126,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
                 MVMuint8 old_probe_distance = *ls.metadata;
                 do {
                     MVMuint8 new_probe_distance = 1 + old_probe_distance;
-                    if (new_probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
+                    if (new_probe_distance == control->max_probe_distance) {
                         /* Optimisation from Martin Ankerl's implementation:
                            setting this to zero forces a resize on any insert,
                            *before* the actual insert, so that we never end up
@@ -157,7 +157,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
              * about to insert something at the (current) max_probe_distance, so
              * signal to the next insertion that it needs to take action first.
              */
-            if (ls.probe_distance == MVM_HASH_MAX_PROBE_DISTANCE) {
+            if (ls.probe_distance == control->max_probe_distance) {
                 control->max_items = 0;
             }
 
@@ -179,7 +179,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + MVM_uni_hash_max_items(control));
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + 256);
     }

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -45,7 +45,8 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->max_probe_distance = max_probe_distance_limit;
+    control->max_probe_distance = max_probe_distance_limit > (4 - 1) ? (4 - 1)
+        : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
     control->key_right_shift = key_right_shift;
 
@@ -190,6 +191,32 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
 
 static struct MVMUniHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
                                                       struct MVMUniHashTableControl *control) {
+    /* control->max_items may have been set to 0 to trigger a call into this
+     * function. */
+    MVMuint32 max_items = MVM_uni_hash_max_items(control);
+    MVMuint32 max_probe_distance_limit = control->max_probe_distance_limit;
+
+    /* We can hit both the probe limit and the max items on the same insertion.
+     * In which case, upping the probe limit isn't going to save us :-)
+     * But if we hit the probe limit max (even without hitting the max items)
+     * then we don't have more space in the metadata, so we're going to have to
+     * grow anyway. */
+    if (control->cur_items < max_items
+        && control->max_probe_distance < max_probe_distance_limit) {
+        /* We hit the probe limit, but not the max items count. */
+        MVMuint32 new_probe_distance
+            = 2 + 2 * (MVMuint32) control->max_probe_distance;
+        if (new_probe_distance > max_probe_distance_limit) {
+            new_probe_distance = max_probe_distance_limit;
+        }
+
+        control->max_probe_distance = new_probe_distance;
+        /* Reset this to its proper value. */
+        control->max_items = max_items;
+        assert(control->max_items);
+        return NULL;
+    }
+
     MVMuint32 entries_in_use = MVM_uni_hash_official_size(control) + control->max_probe_distance - 1;
     MVMuint8 *entry_raw_orig = MVM_uni_hash_entries(control);
     MVMuint8 *metadata_orig = MVM_uni_hash_metadata(control);
@@ -210,6 +237,17 @@ static struct MVMUniHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
                 hash_insert_internal(tc, control, old_entry->key, old_entry->hash_val);
             assert(new_entry->key == NULL);
             *new_entry = *old_entry;
+
+            if (!control->max_items) {
+                /* Probably we hit the probe limit.
+                 * But it's just possible that one actual "grow" wasn't enough.
+                 */
+                struct MVMUniHashTableControl *new_control
+                    = maybe_grow_hash(tc, control);
+                if (new_control) {
+                    control = new_control;
+                }
+            }
         }
         ++bucket;
         ++metadata;

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -38,6 +38,7 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
     size_t total_size
         = entries_size + sizeof(struct MVMUniHashTableControl) + metadata_size;
+    assert(total_size == MVM_hash_round_size_up(total_size));
 
     struct MVMUniHashTableControl *control =
         (struct MVMUniHashTableControl *) ((char *)MVM_malloc(total_size) + entries_size);

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -181,7 +181,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
          * insert an entry at a location beyond the maximum probe distance.
          *
          * For fetch and delete, the loop is permitted to reach (and read) one
-         * beyond the maximum probe distance (hence +1 in the seemingly
+         * beyond the maximum probe distance (hence +2 in the seemingly
          * analogous assertions) - but if so, it will always read from the
          * metadata a probe distance which is lower than the current probe
          * distance, and hence hit "not found" and terminate the loop.
@@ -190,7 +190,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
          * reached without needing an explicit test for it, and why we need an
          * initialised sentinel byte at the end of the metadata. */
 
-        assert(ls.probe_distance <= ls.max_probe_distance * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 1) * ls.metadata_increment);
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + MVM_uni_hash_max_items(control));
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + 256);
     }

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -6,8 +6,11 @@ MVM_STATIC_INLINE void hash_demolish_internal(MVMThreadContext *tc,
                                               struct MVMUniHashTableControl *control) {
     size_t allocated_items = MVM_uni_hash_allocated_items(control);
     size_t entries_size = sizeof(struct MVMUniHashEntry) * allocated_items;
+    size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);
+    size_t total_size
+        = entries_size + sizeof(struct MVMUniHashTableControl) + metadata_size;
     char *start = (char *)control - entries_size;
-    MVM_free(start);
+    MVM_fixed_size_free(tc, tc->instance->fsa, total_size, start);
 }
 
 /* Frees the entire contents of the hash, leaving you just the hashtable itself,
@@ -41,7 +44,7 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
     assert(total_size == MVM_hash_round_size_up(total_size));
 
     struct MVMUniHashTableControl *control =
-        (struct MVMUniHashTableControl *) ((char *)MVM_malloc(total_size) + entries_size);
+        (struct MVMUniHashTableControl *) ((char *)MVM_fixed_size_alloc(tc, tc->instance->fsa, total_size) + entries_size);
 
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -45,7 +45,8 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
     control->official_size_log2 = official_size_log2;
     control->max_items = max_items;
     control->cur_items = 0;
-    control->metadata_hash_bits = 0;
+    control->metadata_hash_bits = MVM_HASH_INITIAL_BITS_IN_METADATA;
+    /* ie 7: */
     MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
     control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
@@ -54,7 +55,12 @@ MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadC
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
 
-    /* A sentinel. This marks an occupied slot, at its ideal position. */
+    /* A sentinel. This marks an occupied slot, at its ideal position.
+     * As long as we start with (no more than) 5 metadata hash bits, certainly
+     * for the load factor we currently have (0.75) we can't actually reach this
+     * sentinel even with long-at-a-time reprocessing of the metadata, for any
+     * size shorter than the full allocation (at which point we no longer
+     * reprocess). */
     metadata[allocated_items] = 1;
 
     return control;
@@ -210,6 +216,27 @@ static struct MVMUniHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         if (new_probe_distance > max_probe_distance_limit) {
             new_probe_distance = max_probe_distance_limit;
         }
+
+        MVMuint8 *metadata = MVM_uni_hash_metadata(control);
+        assert(metadata[MVM_uni_hash_allocated_items(control)] == 1);
+        MVMuint32 in_use_items = MVM_uni_hash_official_size(control) + max_probe_distance;
+        /* not `in_use_items + 1` because because we don't need to shift the
+         * sentinel. */
+        size_t metadata_size = MVM_hash_round_size_up(in_use_items);
+        size_t loop_count = metadata_size / sizeof(unsigned long);
+        unsigned long *p = (unsigned long *) metadata;
+        /* right shift each byte by 1 bit, clearing the top bit. */
+        do {
+            /* 0x7F7F7F7F7F7F7F7F on 64 bit systems, 0x7F7F7F7F on 32 bit,
+             * but without using constants or shifts larger than 32 bits, or
+             * the preprocessor. (So the compiler checks all code everywhere.)
+             * Will break on a system with 128 bit longs. */
+            *p = (*p >> 1) & (0x7F7F7F7FUL | (0x7F7F7F7FUL << (4 * sizeof(long))));
+            ++p;
+        } while (--loop_count);
+        assert(metadata[MVM_uni_hash_allocated_items(control)] == 1);
+        assert(control->metadata_hash_bits);
+        --control->metadata_hash_bits;
 
         control->max_probe_distance = new_probe_distance;
         /* Reset this to its proper value. */

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -157,8 +157,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *hash_insert_internal(MVMThreadContext 
             entry->hash_val = hash_val;
             return entry;
         }
-
-        if (*ls.metadata == ls.probe_distance) {
+        else if (*ls.metadata == ls.probe_distance) {
             struct MVMUniHashEntry *entry = (struct MVMUniHashEntry *) ls.entry_raw;
             if (entry->hash_val == hash_val && 0 == strcmp(entry->key, key)) {
                 return entry;

--- a/src/core/uni_hash_table.h
+++ b/src/core/uni_hash_table.h
@@ -46,7 +46,7 @@ Not all the optimisations described above are in place yet. Starting with
 struct MVMUniHashTableControl {
     MVMHashNumItems cur_items;
     MVMHashNumItems max_items; /* hit this and we grow */
-    MVMHashNumItems official_size;
+    MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
     MVMuint8 probe_overflow_size;
 };

--- a/src/core/uni_hash_table.h
+++ b/src/core/uni_hash_table.h
@@ -48,7 +48,7 @@ struct MVMUniHashTableControl {
     MVMHashNumItems max_items; /* hit this and we grow */
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
-    MVMuint8 probe_overflow_size;
+    MVMuint8 max_probe_distance;
 };
 
 struct MVMUniHashTable {

--- a/src/core/uni_hash_table.h
+++ b/src/core/uni_hash_table.h
@@ -56,6 +56,7 @@ struct MVMUniHashTableControl {
      * We can (re)calcuate this from other values in the struct, but it's easier
      * to cache it as we have the space. */
     MVMuint8 max_probe_distance_limit;
+    MVMuint8 metadata_hash_bits;
 };
 
 struct MVMUniHashTable {

--- a/src/core/uni_hash_table.h
+++ b/src/core/uni_hash_table.h
@@ -48,7 +48,14 @@ struct MVMUniHashTableControl {
     MVMHashNumItems max_items; /* hit this and we grow */
     MVMuint8 official_size_log2;
     MVMuint8 key_right_shift;
+    /* This is the maximum probe distance we can use without updating the
+     * metadata. It might not *yet* be the maximum probe distance possible for
+     * the official_size. */
     MVMuint8 max_probe_distance;
+    /* This is the maximum probe distance possible for the official size.
+     * We can (re)calcuate this from other values in the struct, but it's easier
+     * to cache it as we have the space. */
+    MVMuint8 max_probe_distance_limit;
 };
 
 struct MVMUniHashTable {

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -65,9 +65,10 @@ MVM_uni_hash_create_loop_state(struct MVMUniHashTableControl *control,
     MVMHashNumItems bucket = hash_val >> control->key_right_shift;
     retval.entry_size = sizeof(struct MVMUniHashEntry);
     retval.metadata_increment = 1 << control->metadata_hash_bits;
+    retval.metadata_hash_mask = retval.metadata_increment - 1;
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
-    retval.probe_distance = retval.metadata_increment;
+    retval.probe_distance = retval.metadata_increment | retval.metadata_hash_mask;
     retval.entry_raw = MVM_uni_hash_entries(control) - bucket * retval.entry_size;
     retval.metadata = MVM_uni_hash_metadata(control) + bucket;
     return retval;
@@ -112,7 +113,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *MVM_uni_hash_fetch(MVMThreadContext *t
         ls.probe_distance += ls.metadata_increment;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= (ls.max_probe_distance + 1) * ls.metadata_increment);
+        assert(ls.probe_distance < (ls.max_probe_distance + 2) * ls.metadata_increment);
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + MVM_uni_hash_max_items(control));
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + 256);
     }

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -1,5 +1,8 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_official_size(const struct MVMUniHashTableControl *control) {
+    return 1 << (MVMuint32)control->official_size_log2;
+}
 MVM_STATIC_INLINE MVMuint8 *MVM_uni_hash_metadata(const struct MVMUniHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMUniHashTableControl);
 }
@@ -89,7 +92,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *MVM_uni_hash_fetch(MVMThreadContext *t
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_uni_hash_metadata(control) + control->official_size + control->max_items);
-        assert(ls.metadata < MVM_uni_hash_metadata(control) + control->official_size + 256);
+        assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + 256);
     }
 }

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -68,16 +68,14 @@ MVM_uni_hash_create_loop_state(struct MVMUniHashTableControl *control,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    MVMHashNumItems bucket;
     unsigned int used_hash_bits
         = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
-    if (control->metadata_hash_bits) {
-        retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
-        bucket = used_hash_bits >> control->metadata_hash_bits;
-    } else {
-        /* metadata_increment is 1, metadata_hash_mask is 0 */
-        retval.probe_distance = 1;
-        bucket = used_hash_bits;
+    retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
+    MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
+    if (!control->metadata_hash_bits) {
+        assert(retval.probe_distance == 1);
+        assert(retval.metadata_hash_mask == 0);
+        assert(bucket == used_hash_bits);
     }
 
     retval.entry_raw = MVM_uni_hash_entries(control) - bucket * retval.entry_size;

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -4,6 +4,9 @@
 MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_official_size(const struct MVMUniHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
 }
+MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_allocated_items(const struct MVMUniHashTableControl *control) {
+    return MVM_uni_hash_official_size(control) + control->max_probe_distance_limit;
+}
 MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_max_items(const struct MVMUniHashTableControl *control) {
     return MVM_uni_hash_official_size(control) * MVM_UNI_HASH_LOAD_FACTOR;
 }

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -1,7 +1,11 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+#define MVM_UNI_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_official_size(const struct MVMUniHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
+}
+MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_max_items(const struct MVMUniHashTableControl *control) {
+    return MVM_uni_hash_official_size(control) * MVM_UNI_HASH_LOAD_FACTOR;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_uni_hash_metadata(const struct MVMUniHashTableControl *control) {
     return (MVMuint8 *) control + sizeof(struct MVMUniHashTableControl);
@@ -92,7 +96,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *MVM_uni_hash_fetch(MVMThreadContext *t
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
         assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
-        assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + control->max_items);
+        assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + MVM_uni_hash_max_items(control));
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + 256);
     }
 }

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -112,7 +112,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *MVM_uni_hash_fetch(MVMThreadContext *t
             }
         }
         /* There's a sentinel at the end. This will terminate: */
-        if (*ls.metadata < ls.probe_distance) {
+        else if (*ls.metadata < ls.probe_distance) {
             /* So, if we hit 0, the bucket is empty. "Not found".
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -1,5 +1,9 @@
 /* These are private. We need them out here for the inline functions. Use those.
  */
+/* See comments in hash_allocate_common (and elsewhere) before changing the
+ * load factor, or UNI_MIN_SIZE_BASE_2 or MVM_HASH_INITIAL_BITS_IN_METADATA,
+ * and test with assertions enabled. The current choices permit certain
+ * optimisation assumptions in parts of the code. */
 #define MVM_UNI_HASH_LOAD_FACTOR 0.75
 MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_official_size(const struct MVMUniHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -4,8 +4,15 @@
 MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_official_size(const struct MVMUniHashTableControl *control) {
     return 1 << (MVMuint32)control->official_size_log2;
 }
+/* -1 because...
+ * probe distance of 1 is the correct bucket.
+ * hence for a value whose ideal slot is the last bucket, it's *in* the official
+ * allocation.
+ * probe distance of 2 is the first extra bucket beyond the official allocation
+ * probe distance of 255 is the 254th beyond the official allocation.
+ */
 MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_allocated_items(const struct MVMUniHashTableControl *control) {
-    return MVM_uni_hash_official_size(control) + control->max_probe_distance_limit;
+    return MVM_uni_hash_official_size(control) + control->max_probe_distance_limit - 1;
 }
 MVM_STATIC_INLINE MVMuint32 MVM_uni_hash_max_items(const struct MVMUniHashTableControl *control) {
     return MVM_uni_hash_official_size(control) * MVM_UNI_HASH_LOAD_FACTOR;
@@ -91,7 +98,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *MVM_uni_hash_fetch(MVMThreadContext *t
                If we hit something with a lower probe distance then...
                consider what would have happened had this key been inserted into
                the hash table - it would have stolen this slot, and the key we
-               find here now would have been displaced futher on. Hence, the key
+               find here now would have been displaced further on. Hence, the key
                we seek can't be in the hash table. */
             return NULL;
         }

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -95,7 +95,7 @@ MVM_STATIC_INLINE struct MVMUniHashEntry *MVM_uni_hash_fetch(MVMThreadContext *t
         ++ls.probe_distance;
         ++ls.metadata;
         ls.entry_raw -= ls.entry_size;
-        assert(ls.probe_distance <= MVM_HASH_MAX_PROBE_DISTANCE);
+        assert(ls.probe_distance <= (unsigned int) control->max_probe_distance + 1);
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + MVM_uni_hash_max_items(control));
         assert(ls.metadata < MVM_uni_hash_metadata(control) + MVM_uni_hash_official_size(control) + 256);
     }

--- a/src/moar.h
+++ b/src/moar.h
@@ -99,6 +99,7 @@ typedef double   MVMnum64;
 #define HASH_DEBUG_ITER 0
 #define MVM_HASH_RANDOMIZE 1
 #define MVM_HASH_MAX_PROBE_DISTANCE 255
+#define MVM_HASH_INITIAL_BITS_IN_METADATA 5
 
 typedef MVMuint32 MVMHashNumItems;
 typedef MVMuint64 MVMHashv;


### PR DESCRIPTION
Store some hash bits in the low bits of the hashtable metadata byte, with the probe distance in the high bits, and the split between the two updated dynamically.

This works (where tested, with ASAN and with assertions)

Currently it's not much faster. I had to resort to cachegrind to see any difference - it seems to dispatch more instructions, but result in about 0.1% fewer writes misses, and 0.1% fewer last-level cache misses.

This is disappointing. I hope that the numbers can be improved with some tuning. There is a *lot* that can be tuned

1. initial choice for the split probe distance:hash bits
1. how many times to move the split (to increase the probe distance) before growing the hash
1. for each hash grow, whether to "reset" the probe distance fully, "back off" (go somewhat smaller) or just keep it the same
1. whether to pick different values if the hash is given an expected size when first built
1. load factor (this of course could also be used to tune the code on master)


and all these can be varied as a function of hash size (eg it might work best to start with a notional "8" entry hash with a high load factor, then reduce the load factor for medium sized hashes, and then raise it again for large hashes, on the assumption that they really stress the CPU cache)

**Update** - it *is* a win for last-level cache lookups. The trade is more CPU work for less data misses.
I've subsequently added a few more optimisations (again CPU work for fewer data misses) that I believe help further.

- ~~test on "awkward" platforms (eg sparc64 - I think that index hashes might currently bust alignment assumptions there)~~ - they did. Fixed in the rebase
- ~~a "total memory used" API function as requested by \@timo~~ - done. cachegrind thinks that this causes fractionally more last level cache lookup fails
- ~~test out using the FSA instead of regular malloc - at least the first two sizes allocated fit into the normal buckets~~ -- done. cachegrind likes this
- ~~allocate just a control structure to start - thanks \@lizmat~~ done. cachegrind likes this too
- ~~architecture comment explaining how the heck this works~~ done. feedback wanted

What the github UI doesn't seem to make obvious is that commit d53a4a12bc26c21cfb783e5a53ecf1a76d8f0783 on this branch is origin/hash-single-allocation and that branch *is* ready for review and merging - #1350

I think that this branch is ready for *review*, but I'd prefer not to merge it until after the next release.