### PR TITLE
Add a function to fix up the STD IO handles

### DIFF
--- a/src/io/io.h
+++ b/src/io/io.h
@@ -112,3 +112,7 @@ MVMint64 MVM_io_getport(MVMThreadContext *tc, MVMObject *oshandle);
 void MVM_io_set_buffer_size(MVMThreadContext *tc, MVMObject *oshandle, MVMint64 size);
 MVMObject * MVM_io_get_async_task_handle(MVMThreadContext *tc, MVMObject *oshandle);
 void MVM_io_flush_standard_handles(MVMThreadContext *tc);
+
+#ifdef _WIN32
+int MVM_set_std_handle_to_nul(FILE* file, int fd, BOOL read, int std_handle_type);
+#endif

--- a/src/moar.c
+++ b/src/moar.c
@@ -852,3 +852,12 @@ void MVM_vm_set_lib_path(MVMInstance *instance, int count, const char **lib_path
 int MVM_exepath(char* buffer, size_t* size) {
     return uv_exepath(buffer, size);
 }
+
+#ifdef _WIN32
+int MVM_set_std_handles_to_nul() {
+    if (!MVM_set_std_handle_to_nul(stdin,  0, 1, STD_INPUT_HANDLE))  return 0;
+    if (!MVM_set_std_handle_to_nul(stdout, 1, 0, STD_OUTPUT_HANDLE)) return 0;
+    if (!MVM_set_std_handle_to_nul(stderr, 2, 0, STD_ERROR_HANDLE))  return 0;
+    return 1;
+}
+#endif

--- a/src/moar.h
+++ b/src/moar.h
@@ -259,6 +259,11 @@ MVM_PUBLIC void MVM_vm_event_subscription_configure(MVMThreadContext *tc, MVMObj
 /* Returns absolute executable path. */
 MVM_PUBLIC int MVM_exepath(char* buffer, size_t* size);
 
+#ifdef _WIN32
+/* Reopens STDIN, STDOUT, STDERR to the 'NUL' device. */
+MVM_PUBLIC int MVM_set_std_handles_to_nul();
+#endif
+
 /* Seems that both 32 and 64 bit sparc need this crutch */
 #if defined(__s390__) || defined(__sparc__)
 AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t new_val);


### PR DESCRIPTION
This is in preparation for a Rakudo fix that will make sure Rakudo won't silently die if the STD handles are used on Windows in "windows"-subsystem executables. (`rakudow.exe`, `rakuw.exe` and `perl6w.exe`)