### PR TITLE
Create a unicode.c with #include directives instead of generating it …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ moar
 *.psess
 /nmake.cmd
 UNIDATA/*
-/src/strings/unicode.c
 *.class
 tags
 install/

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -648,9 +648,7 @@ src/main@obj@: src/main.c
 	$(MSG) compiling $@
 	$(CMD)$(CC) @ccswitch@ $(CFLAGS) @mainflags@ $(CINCLUDES) @ccout@$@ $*.c
 
-src/strings/unicode.c: src/strings/unicode_db.c src/strings/unicode_uca.c src/strings/unicode_ops.c
-	$(MSG) generating $@
-	$(CMD) $(CAT) src/strings/unicode_db.c src/strings/unicode_uca.c src/strings/unicode_ops.c > $@ $(NOERR)
+src/strings/unicode@obj@: src/strings/unicode_db.c src/strings/unicode_uca.c src/strings/unicode_ops.c
 
 # Minilua requires only -lm, no libraries
 $(MINILUA): 3rdparty/dynasm/minilua.c
@@ -749,7 +747,7 @@ distclean: realclean
 	$(MSG) remove executable and libraries
 	-$(CMD)$(RM) moar@exe@ @moarlib@ @moardll@ $(NOOUT) $(NOERR)
 	$(MSG) remove configuration and generated files
-	-$(CMD)$(RM) Makefile src/gen/config.h src/gen/config.c src/strings/unicode.c \
+	-$(CMD)$(RM) Makefile src/gen/config.h src/gen/config.c \
 	    tools/check.mk 3rdparty/libatomicops/config.log 3rdparty/libatomicops/config.status $(NOOUT) $(NOERR)
 	-$(CMD)$(RM_RF) build/mk-moar-pc.pl pkgconfig/ $(NOOUT) $(NOERR)
 

--- a/src/strings/unicode.c
+++ b/src/strings/unicode.c
@@ -1,0 +1,3 @@
+#include "unicode_db.c"
+#include "unicode_uca.c"
+#include "unicode_ops.c"


### PR DESCRIPTION
…with cat.

This way we avoid generating a large temporary file, avoid needing to delete
it at cleanup, avoid needing an entry in .gitignore, and get decent line
numbers in warnings and errors from the C compiler.