### PR TITLE
`char` can be unsigned. Rewrite the "is it ASCII?" test to handle thi…

### DIFF
--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -13,7 +13,9 @@ MVMString * MVM_string_ascii_decode(MVMThreadContext *tc, const MVMObject *resul
             buffer[result_graphs++] = MVM_nfg_crlf_grapheme(tc);
             i++;
         }
-        else if (ascii[i] >= 0) {
+        /* `ascii[i] < 0` is always false on platforms where char is unsigned.
+         * This expression works whatever plain char is. */
+        else if ((ascii[i] & 0x80) == 0) {
             buffer[result_graphs++] = ascii[i];
         }
         else {


### PR DESCRIPTION
…s too.

Without this gcc correctly warns that the "comparison is always false" on
platforms where plain char is unsigned, and the code (as was) was buggy.

On x86_64 (where plain char is signed) this commit makes no difference to
the generated code.