### PR TITLE
Fix two *printf size warnings reported on ILP32 platforms.

### DIFF
--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1308,7 +1308,7 @@ static MVMuint64 request_find_method(MVMThreadContext *dtc, cmp_ctx_t *ctx, requ
 
     if (!target) {
         if (dtc->instance->debugserver->debugspam_protocol)
-            fprintf(stderr, "could not retrieve object of handle %ld", argument->handle_id);
+            fprintf(stderr, "could not retrieve object of handle %"PRId64, argument->handle_id);
         return 1;
     }
 
@@ -1340,7 +1340,7 @@ static MVMuint64 request_object_decontainerize(MVMThreadContext *dtc, cmp_ctx_t 
 
     if (!target) {
         if (dtc->instance->debugserver->debugspam_protocol)
-            fprintf(stderr, "could not retrieve object of handle %ld", argument->handle_id);
+            fprintf(stderr, "could not retrieve object of handle %"PRId64, argument->handle_id);
         return 1;
     }
 


### PR DESCRIPTION
In debugserver.c, handle_id is 64 bit, so use PRId64.

In the profiler, we print out the difference between two pointers. This has
the type ptrdiff_t. It seems that on most platforms that ptrdiff_t is a
typedef for long. However, on (at least) arm32 and sparc32 it is a typedef
for int (despite int and long being the same size on these platforms).
Hence *printf format checking warns about a mismatch between types.
Oh so helpful.

C11 provides a size modifier `t` for ptrdiff_t, but we're still stuck in
the century of the fruitbat, so we can't use that. So just cast to long.