### PR TITLE
Fix zeroing of reallocated memory in MVM_recalloc

### DIFF
--- a/src/core/alloc.h
+++ b/src/core/alloc.h
@@ -28,10 +28,13 @@ MVM_STATIC_INLINE void * MVM_realloc(void *p, size_t size) {
 MVM_STATIC_INLINE void * MVM_recalloc(void *p, size_t old_size, size_t size) {
     void *ptr = realloc(p, size);
 
-    if (!ptr && size > 0)
-        MVM_panic_allocation_failed(size);
+    if (size > 0) {
+        if (!ptr)
+            MVM_panic_allocation_failed(size);
 
-    memset((char *)ptr + old_size, 0, size - old_size);
+        if (size > old_size)
+            memset((char *)ptr + old_size, 0, size - old_size);
+    }
 
     return ptr;
 }


### PR DESCRIPTION
This function assumes that the new size of memory to be reallocated is
greater than or equal to its old size. Should it be lesser instead, this
will attempt to zero memory that is out of bounds, leading to a
segfault.  Only attempt to zero reallocated memory if its size has
grown.