### PR TITLE
Use MVM_{malloc,realloc,calloc,free} consistency.

### DIFF
--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -909,7 +909,7 @@ static void send_thread_info(MVMThreadContext *dtc, cmp_ctx_t *ctx, request_data
     while (cur_thread) {
         char *threadname = NULL;
 #if MVM_HAS_PTHREAD_SETNAME_NP
-        threadname = malloc(16);
+        threadname = MVM_malloc(16);
         if (pthread_getname_np((pthread_t)cur_thread->body.native_thread_id, threadname, 16) != 0) {
             MVM_free_null(threadname);
         }

--- a/src/strings/nfg.c
+++ b/src/strings/nfg.c
@@ -462,7 +462,7 @@ static void cache_crlf(MVMThreadContext *tc) {
 }
 void MVM_nfg_init(MVMThreadContext *tc) {
     int init_stat;
-    tc->instance->nfg = calloc(1, sizeof(MVMNFGState));
+    tc->instance->nfg = MVM_calloc(1, sizeof(MVMNFGState));
     if ((init_stat = uv_mutex_init(&(tc->instance->nfg->update_mutex))) < 0) {
         fprintf(stderr, "MoarVM: Initialization of NFG update mutex failed\n    %s\n",
             uv_strerror(init_stat));

--- a/src/strings/normalize.c
+++ b/src/strings/normalize.c
@@ -240,7 +240,7 @@ void MVM_unicode_normalizer_translate_newlines(MVMThreadContext *tc, MVMNormaliz
 
 /* Cleanup an MVMNormalization once we're done normalizing. */
 void MVM_unicode_normalizer_cleanup(MVMThreadContext *tc, MVMNormalizer *n) {
-    free(n->buffer);
+    MVM_free(n->buffer);
 }
 
 /* Adds a codepoint into the buffer, making sure there's space. */

--- a/src/strings/windows1252.c
+++ b/src/strings/windows1252.c
@@ -505,7 +505,7 @@ MVMString * MVM_string_windows125X_decode(MVMThreadContext *tc,
                      * grapheme in the replacement string */
                     if (1 < repl_length) {
                         additional_bytes += repl_length - 1;
-                        buffer = realloc(buffer, sizeof(MVMGrapheme32) * (additional_bytes + bytes));
+                        buffer = MVM_realloc(buffer, sizeof(MVMGrapheme32) * (additional_bytes + bytes));
                         for (; i < repl_length - 1; i++) {
                             MVMGrapheme32 graph = MVM_string_get_grapheme_at(tc, replacement, i);
                             buffer[result_graphs++] = graph;


### PR DESCRIPTION
All these calls changed to the MVM_* wrappers are on memory blocks where the
other calls are MVM_* wrappers.

There are still a few "bare" `malloc`s/`free`s, but these seem to be
self-contained, or related to memory allocated by `strdup`/`strndup`, which
is using the platform `malloc` internally.