### PR TITLE
CStruct bind_attribute can write beyond malloc'd buffer.

### DIFF
--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -605,9 +605,11 @@ static void bind_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                         if (REPR(value)->ID != MVM_REPR_ID_MVMCArray)
                             MVM_exception_throw_adhoc(tc,
                                 "Can only store CArray attribute in CArray slot in CStruct");
-                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED)
-                            cobj = ((MVMCArray *)value)->body.storage
-                                 = (char *)body->cstruct + repr_data->struct_offsets[slot];
+                        if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED) {
+                            ((MVMCArray *)value)->body.storage
+                                = (char *)body->cstruct + repr_data->struct_offsets[slot];
+                            break;
+                        }
                         else
                             cobj = ((MVMCArray *)value)->body.storage;
                     }


### PR DESCRIPTION
**Please review this commit with the assumption that my proposed _fix_ is incorrect.**

`bind_attribute` had been calling `set_ptr_at_offset` for all `CArray`s, whether inlined or not. That writes a pointer at the slot offset.

For the corner case of the inlined array being both the last member in the structure and smaller than the size of a pointer
(eg `HAS int32 @.b[1] is CArray;` on a 64 bit system), this causes a pointer write beyond the end of the allocated storage.
More generally, on a system which faults unaligned pointer writes, this write faults in the more realistic case where the previous structure member(s) don't add up to pointer-sized alignment.

This is clearly a bug.

Minimum test case I can find is

```
use v6;

use NativeCall;

class InlinedArrayInStruct is repr('CStruct') {
    has int32 $.a is rw;
    HAS int32 @.b[1] is CArray;
}

my $iais = InlinedArrayInStruct.new();
```

with this result:

```
==31060== Invalid write of size 8
==31060==    at 0x51126B6: set_ptr_at_offset (CStruct.c:362)
==31060==    by 0x5113814: bind_attribute (CStruct.c:651)
==31060==    by 0x503B798: MVM_interp_run (interp.c:2018)
==31060==    by 0x51D646D: MVM_vm_run_file (moar.c:486)
==31060==    by 0x109784: main (main.c:305)
==31060==  Address 0xe1ef4b4 is 4 bytes inside a block of size 8 alloc'd
==31060==    at 0x4C2DBC5: calloc (vg_replace_malloc.c:711)
==31060==    by 0x51105AA: MVM_calloc (alloc.h:11)
==31060==    by 0x51129CA: initialize (CStruct.c:413)
==31060==    by 0x503A4AA: MVM_interp_run (interp.c:1880)
==31060==    by 0x51D646D: MVM_vm_run_file (moar.c:486)
==31060==    by 0x109784: main (main.c:305)
```

ASAN doesn't seem to spot this.

Run this on sparc64 and it will `SIGBUS`, because that write is not properly aligned. This is how I found the problem.

It seems that the write to the slot is not needed in this case. The next case statement down was changed by commit e4ff6949548e4f18 to `break`ing out of the switch statement for the inlined case.

I am *assuming* that this is the correct fix here. Please could someone who actually understands this code double check this.

Looking further through the code, it seems to me that the logic of commit e4ff6949548e4f18 for the `type == MVM_CSTRUCT_ATTR_CSTRUCT` case really ought to be duplicated further down for the `MVM_CSTRUCT_ATTR_CPPSTRUCT` and `MVM_CSTRUCT_ATTR_CUNION` cases. If I take the test case from rakudo/rakudo#3687 and change `repr('CStruct')` to `repr('CPPStruct')` then it no longer works. And *then* the layout of `CPPstruct.c` suggests that it too needs all of this...

There seems to be a lot of repetition here. It's unclear to me how much is unavoidable.