### PR TITLE
MVM_nativeref_{read,write}_lex_i should handle uint8, uint16, uint32

### DIFF
--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -441,6 +441,14 @@ MVMint64 MVM_nativeref_read_lex_i(MVMThreadContext *tc, MVMObject *ref_obj) {
     MVMNativeRef *ref = (MVMNativeRef *)ref_obj;
     MVMRegister *var = &(ref->body.u.lex.frame->env[ref->body.u.lex.env_idx]);
     switch (ref->body.u.lex.type) {
+        case MVM_reg_uint8:
+            return var->u8;
+        case MVM_reg_uint16:
+            return var->u16;
+        case MVM_reg_uint32:
+            return var->u32;
+        case MVM_reg_uint64:
+            return var->u64;
         case MVM_reg_int8:
             return var->i8;
         case MVM_reg_int16:
@@ -510,6 +518,18 @@ void MVM_nativeref_write_lex_i(MVMThreadContext *tc, MVMObject *ref_obj, MVMint6
     MVMNativeRef *ref = (MVMNativeRef *)ref_obj;
     MVMRegister *var = &(ref->body.u.lex.frame->env[ref->body.u.lex.env_idx]);
     switch (ref->body.u.lex.type) {
+        case MVM_reg_uint8:
+            var->u8 = (MVMuint8)value;
+            break;
+        case MVM_reg_uint16:
+            var->u16 = (MVMuint16)value;
+            break;
+        case MVM_reg_uint32:
+            var->u32 = (MVMuint32)value;
+            break;
+        case MVM_reg_uint64:
+            var->u64 = (MVMuint64)value;
+            break;
         case MVM_reg_int8:
             var->i8 = (MVMint8)value;
             break;


### PR DESCRIPTION
Previously these three (and uint64) all took the `default:` path through
the case statement, which meant that they were read/written as 64 bits, eg:

        default:
            return var->i64;

This works fine on little endian systems, where the least significant byte
of the 64 bit value is at the the same memory address as the 8 bit value,
but on big endian systems it all goes wrong.

The two routines already had cases for the various sized signed types.
We need case statements to cover the 3 smaller unsigned types.

For clarity, I think it better to cover all 4 unsigned types explicitly,
and use the corresponding members in the union. Likely the compiler will
fold the signed and unsigned cases together in the final code, but I'd
prefer it to be doing that, rather than us making assumptions about
equivalence.

With this change (and the fix to `swap_bytes` in utf16.c) I am down to 3 failing tests on sparc64:

```
Test Summary Report
-------------------
t/spec/S32-io/utf16.t                                           (Wstat: 768 Tests: 39 Failed: 3)
  Failed tests:  13-15
  Non-zero exit status: 3
Files=1336, Tests=113360, 1721 wallclock secs (64.14 usr 13.46 sys + 12939.13 cusr 474.14 csys = 13490.87 CPU)
```

(cause known for those 3. Correct solution not yet obvious)