### PR TITLE
Eliminate static race condition

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -490,12 +490,14 @@ print "OK\n\n";
 if ($config{crossconf}) {
     build::auto::detect_cross(\%config, \%defaults);
     build::probe::static_inline_cross(\%config, \%defaults);
+    build::probe::thread_local_cross(\%config, \%defaults);
     build::probe::unaligned_access_cross(\%config, \%defaults);
     build::probe::ptr_size_cross(\%config, \%defaults);
 }
 else {
     build::auto::detect_native(\%config, \%defaults);
     build::probe::static_inline_native(\%config, \%defaults);
+    build::probe::thread_local_native(\%config, \%defaults);
     build::probe::unaligned_access(\%config, \%defaults);
     build::probe::ptr_size_native(\%config, \%defaults);
 }

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -46,6 +46,11 @@
 /* How this compiler does static inline functions. */
 #define MVM_STATIC_INLINE @static_inline@
 
+#if @has_thread_local@
+/* How this compiler declares thread local storage. */
+#define MVM_THREAD_LOCAL @thread_local@
+#endif
+
 #if @can_unaligned_int32@
 #define MVM_CAN_UNALIGNED_INT32
 #endif

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -508,9 +508,9 @@ static void write_array_str(MVMThreadContext *tc, MVMSerializationWriter *writer
 }
 
 /* Writes a hash where each key is a MVMString and each value a variant reference. */
-static MVMThreadContext *cmp_tc;
 static int cmp_strings(const void *s1, const void *s2) {
-    return MVM_string_compare(cmp_tc, *(MVMString **)s1, *(MVMString **)s2);
+    MVMThreadContext *tc = MVM_get_running_threads_context();
+    return MVM_string_compare(tc, *(MVMString **)s1, *(MVMString **)s2);
 }
 static void write_hash_str_var(MVMThreadContext *tc, MVMSerializationWriter *writer, MVMObject *hash) {
     MVMuint32 elems = (MVMuint32)MVM_repr_elems(tc, hash);
@@ -526,7 +526,6 @@ static void write_hash_str_var(MVMThreadContext *tc, MVMSerializationWriter *wri
         MVM_repr_shift_o(tc, iter);
         keys[i++] = MVM_iterkey_s(tc, (MVMIter *)iter);
     }
-    cmp_tc = tc;
     qsort(keys, elems, sizeof(MVMString*), cmp_strings);
     for (i = 0; i < elems; i++) {
         MVM_serialization_write_str(tc, writer, keys[i]);

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -76,6 +76,13 @@ static void start_thread(void *data) {
     /* Stash thread ID. */
     tc->thread_obj->body.native_thread_id = MVM_platform_thread_id();
 
+#ifndef MVM_THREAD_LOCAL
+    /* Store this thread's thread context pointer, so that we can retrieve it
+     * in places where we can't pass it in to, such as the callback function
+     * used by qsort. */
+    uv_key_set(&MVM_running_threads_context_key, tc);
+#endif
+
     /* Create a spesh log for this thread, unless it's just going to run C
      * code (and thus it's a VM internal worker). */
     if (REPR(tc->thread_obj->body.invokee)->ID != MVM_REPR_ID_MVMCFunction)

--- a/src/moar.c
+++ b/src/moar.c
@@ -87,7 +87,9 @@ MVM_STATIC_INLINE MVMuint64 ptr_hash_64_to_64(MVMuint64 u) {
     return (MVMuint64)u;
 }
 
-#ifndef MVM_THREAD_LOCAL
+#ifdef MVM_THREAD_LOCAL
+MVM_THREAD_LOCAL MVMThreadContext *MVM_running_threads_context;
+#else
 uv_key_t MVM_running_threads_context_key;
 
 static void

--- a/src/moar.c
+++ b/src/moar.c
@@ -87,6 +87,17 @@ MVM_STATIC_INLINE MVMuint64 ptr_hash_64_to_64(MVMuint64 u) {
     return (MVMuint64)u;
 }
 
+#ifndef MVM_THREAD_LOCAL
+uv_key_t MVM_running_threads_context_key;
+
+static void
+make_uv_key() {
+    int result = uv_key_create(&MVM_running_threads_context_key);
+    if (result)
+        MVM_panic(1, "uv_key_create failed with code %u", result);
+}
+#endif
+
 /* Create a new instance of the VM. */
 MVMInstance * MVM_vm_create_instance(void) {
     MVMInstance *instance;
@@ -97,6 +108,11 @@ MVMInstance * MVM_vm_create_instance(void) {
     char *jit_expr_disable, *jit_disable, *jit_last_frame, *jit_last_bb;
     char *dynvar_log;
     int init_stat;
+
+#ifndef MVM_THREAD_LOCAL
+    static uv_once_t key_once = UV_ONCE_INIT;
+    uv_once(&key_once, make_uv_key);
+#endif
 
     /* Set up instance data structure. */
     instance = MVM_calloc(1, sizeof(MVMInstance));

--- a/src/moar.h
+++ b/src/moar.h
@@ -293,7 +293,21 @@ AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t
 #define MVM_store(addr, new) AO_store_full((volatile AO_t *)(addr), (AO_t)(new))
 #define MVM_load(addr) AO_load_full((volatile AO_t *)(addr))
 
-#ifndef MVM_THREAD_LOCAL
+/* UV always defines this for Win32 but not Unix. Which is fine, as we can probe
+ * for it on Unix more easily than on Win32. */
+#if !defined(MVM_THREAD_LOCAL) && defined(UV_THREAD_LOCAL)
+#define MVM_THREAD_LOCAL UV_THREAD_LOCAL
+#endif
+
+#ifdef MVM_THREAD_LOCAL
+
+extern MVM_THREAD_LOCAL MVMThreadContext *MVM_running_threads_context;
+
+MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
+    return MVM_running_threads_context;
+}
+
+#else
 
 /* Fallback to an implememtation using UV's APIs (pretty much pthreads) */
 extern uv_key_t MVM_running_threads_context_key;

--- a/src/moar.h
+++ b/src/moar.h
@@ -292,3 +292,14 @@ AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t
  * which the other atomic operation macros are used... */
 #define MVM_store(addr, new) AO_store_full((volatile AO_t *)(addr), (AO_t)(new))
 #define MVM_load(addr) AO_load_full((volatile AO_t *)(addr))
+
+#ifndef MVM_THREAD_LOCAL
+
+/* Fallback to an implememtation using UV's APIs (pretty much pthreads) */
+extern uv_key_t MVM_running_threads_context_key;
+
+MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
+    return uv_key_get(&MVM_running_threads_context_key);
+}
+
+#endif


### PR DESCRIPTION
The code in master:src/6model/serialization.c uses a C `static` variable to pass the running thread's `MVMThreadContext` pointer into the C callback function passed to `qsort`. This is a subtle race condition - if two threads are serialising (ie compiling) at the same time, they might see the wrong value.

We should instead use some form of thread local storage to pass this value into the callback. C11 and later provide a `_Thread_local` attribute which makes all of this (almost) transparent. Before this gcc (and its impersonators) provided `__thread` which works in the same way. It seems also that all Win32 compilers that UV supports provide an attribute which we can use. If there is nothing better (likely vendor compilers on OSes we don't yet reach) we fall back to UV's API, which seems to be a thin wrapper around pthreads.

I had hoped that the `_Thread_local` approach would be significantly faster than the classic pthreads approach, and about as fast as the static global, but it seems that this is only true when compiling regular unshared code. MoarVM is set up to build a shared library by default, and the implication of this is that there still needs to be a call through the shared library redirection tables to get the correct thread locals for this thread for this process (to something like `__tls_get_addr(PLT)`). It looks like TLS is *slightly* faster - for ARM, with it the callback compiles to 11 instructions, with UV (wrapping pthreads) its 12. The called function *might* also be simpler (I haven't checked), and there is no need to call `uv_key_create` to create a key each runtime - the setup is now done at C compilation time.

(And it ought to be 10 instructions, because the compiler seems to miss the opportunity to exploit the tailcall. We left it an open goal and still it missed :\-()