### PR TITLE
Use `foo(void)` instead of just `foo()` for functions that take no arguments

### DIFF
--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -662,7 +662,7 @@ static void mk_storage_spec(MVMThreadContext *tc, MVMP6opaqueREPRData * repr_dat
 }
 
 /* Compose the representation. */
-static MVMuint16 * allocate_unbox_slots() {
+static MVMuint16 * allocate_unbox_slots(void) {
     MVMuint16 *slots = MVM_malloc(MVM_REPR_MAX_COUNT * sizeof(MVMuint16));
     MVMuint16 i;
     for (i = 0; i < MVM_REPR_MAX_COUNT; i++)

--- a/src/core/callstack.c
+++ b/src/core/callstack.c
@@ -2,7 +2,7 @@
 
 /* Allocates a new call stack region, not incorporated into the regions double
  * linked list yet. */
-static MVMCallStackRegion * create_region() {
+static MVMCallStackRegion * create_region(void) {
     MVMCallStackRegion *region = MVM_malloc(MVM_CALLSTACK_REGION_SIZE);
     region->prev = region->next = NULL;
     region->alloc = (char *)region + sizeof(MVMCallStackRegion);

--- a/src/core/interp.h
+++ b/src/core/interp.h
@@ -110,7 +110,7 @@ struct MVMRunloopState {
 /* Functions. */
 void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContext *, void *), void *invoke_data, MVMRunloopState *outer_runloop);
 void MVM_interp_run_nested(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContext *, void *), void *invoke_data, MVMRegister *res);
-MVM_PUBLIC void MVM_interp_enable_tracing();
+MVM_PUBLIC void MVM_interp_enable_tracing(void);
 
 MVM_STATIC_INLINE MVMint64 MVM_BC_get_I64(const MVMuint8 *cur_op, int offset) {
     const MVMuint8 *const where = cur_op + offset;

--- a/src/moar.h
+++ b/src/moar.h
@@ -261,7 +261,7 @@ MVM_PUBLIC int MVM_exepath(char* buffer, size_t* size);
 
 #ifdef _WIN32
 /* Reopens STDIN, STDOUT, STDERR to the 'NUL' device. */
-MVM_PUBLIC int MVM_set_std_handles_to_nul();
+MVM_PUBLIC int MVM_set_std_handles_to_nul(void);
 #endif
 
 /* Seems that both 32 and 64 bit sparc need this crutch */

--- a/src/profiler/telemeh.h
+++ b/src/profiler/telemeh.h
@@ -8,4 +8,4 @@ MVM_PUBLIC void MVM_telemetry_interval_annotate(uintptr_t subject, int intervalI
 MVM_PUBLIC void MVM_telemetry_interval_annotate_dynamic(uintptr_t subject, int intervalID, char *description);
 
 MVM_PUBLIC void MVM_telemetry_init(FILE *outfile);
-MVM_PUBLIC void MVM_telemetry_finish();
+MVM_PUBLIC void MVM_telemetry_finish(void);


### PR DESCRIPTION
Whilst the two are equivalent in C++, in C the latter is just a declaration
not a prototype - it specifies the return type but not the parameters,
meaning that the compiler can't actually check the parameters passed and
report errors. An explicit `void` makes it a prototype, declaring that the
function takes no arguments.

(More wonderfully, it seems that even on some fairly recent versions of gcc,
is seems a function *definition* `static int foo() { ... }` doesn't act as a
prototype, meaning that even incorrect calls made to it later in the same
source file aren't faulted. clang does not stay silent on these.)

Found with a combination of `-Werror=strict-prototypes` and `git grep`.
We can't actually build with that compiler flag, because some of our
dependencies have header files that contain the problematic constructions,
and trying to work around these to turn the flag on by default probably
only creates fragile "solutions" and likely is more cost than benefit.