### PR TITLE
we need to import pthread on windows to get a type

### DIFF
--- a/src/platform/threads.h
+++ b/src/platform/threads.h
@@ -11,6 +11,9 @@
 #if defined _WIN32
 #define MVM_platform_thread_exit(status) ExitThread(0)
 #define MVM_platform_thread_id() (MVMint64)GetCurrentThreadId()
+#if defined MVM_HAS_PTHREAD_SETNAME_NP
+#include <pthread.h>
+#endif
 #else
 #define MVM_platform_thread_exit(status) pthread_exit(status)
 #define MVM_platform_thread_id() (MVMint64)uv_thread_self()


### PR DESCRIPTION
we have an `#include <pthread.h>` in the setname_np probe already, so if we want to use it, we should also include it there.

this blew up moarvm build on MinGW