### PR TITLE
MVM_box_{int,num,str,uint} and MVM_unbox_str duplicate functionality in reprconv.c

### DIFF
--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -545,7 +545,3 @@ MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj) {
 void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type, MVMRegister *dst) {
     dst->o = MVM_repr_box_str(tc, type, value);
 }
-
-void MVM_box_uint(MVMThreadContext *tc, MVMuint64 value, MVMObject *type, MVMRegister *dst) {
-    dst->o = MVM_repr_box_uint(tc, type, value);
-}

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -530,10 +530,6 @@ void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type, MVMRegis
     dst->o = MVM_repr_box_int(tc, type, value);
 };
 
-void MVM_box_num(MVMThreadContext *tc, MVMnum64 value, MVMObject *type, MVMRegister *dst) {
-    dst->o = MVM_repr_box_num(tc, type, value);
-}
-
 MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj) {
     if (!IS_CONCRETE(obj))
         MVM_exception_throw_adhoc(tc, "Cannot unbox a type object (%s) to a str.",

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -532,10 +532,12 @@ void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type,
     MVMObject *box = MVM_intcache_get(tc, type, value);
     if (box == 0) {
         box = REPR(type)->allocate(tc, STABLE(type));
-        if (REPR(box)->initialize)
-            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-        REPR(box)->box_funcs.set_int(tc, STABLE(box), box,
-                                     OBJECT_BODY(box), value);
+        MVMROOT(tc, box, {
+            if (REPR(box)->initialize)
+                REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
+            REPR(box)->box_funcs.set_int(tc, STABLE(box), box,
+                                         OBJECT_BODY(box), value);
+        });
     }
     dst->o = box;
 }
@@ -543,12 +545,13 @@ void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type,
 void MVM_box_num(MVMThreadContext *tc, MVMnum64 value, MVMObject *type,
                  MVMRegister * dst) {
     MVMObject *box = REPR(type)->allocate(tc, STABLE(type));
-    if (REPR(box)->initialize)
-        REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-    REPR(box)->box_funcs.set_num(tc, STABLE(box), box,
-                                 OBJECT_BODY(box), value);
+    MVMROOT(tc, box, {
+        if (REPR(box)->initialize)
+            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
+        REPR(box)->box_funcs.set_num(tc, STABLE(box), box,
+                                     OBJECT_BODY(box), value);
+    });
     dst->o = box;
-
 }
 
 MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj) {
@@ -564,19 +567,23 @@ void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type,
     MVMObject *box;
     MVMROOT(tc, value, {
         box = REPR(type)->allocate(tc, STABLE(type));
-        if (REPR(box)->initialize)
-            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-        REPR(box)->box_funcs.set_str(tc, STABLE(box), box,
-                                     OBJECT_BODY(box), value);
-        dst->o = box;
+        MVMROOT(tc, box, {
+            if (REPR(box)->initialize)
+                REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
+            REPR(box)->box_funcs.set_str(tc, STABLE(box), box,
+                                         OBJECT_BODY(box), value);
+            dst->o = box;
+        });
     });
 }
 
 void MVM_box_uint(MVMThreadContext *tc, MVMuint64 value, MVMObject *type,
              MVMRegister * dst) {
     MVMObject *box = REPR(type)->allocate(tc, STABLE(type));
-    if (REPR(box)->initialize)
-        REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-    REPR(box)->box_funcs.set_uint(tc, STABLE(box), box, OBJECT_BODY(box), value);
+    MVMROOT(tc, value, {
+        if (REPR(box)->initialize)
+            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
+        REPR(box)->box_funcs.set_uint(tc, STABLE(box), box, OBJECT_BODY(box), value);
+    });
     dst->o = box;
 }

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -450,9 +450,6 @@ MVMint64 MVM_coerce_simple_intify(MVMThreadContext *tc, MVMObject *obj) {
     }
 }
 
-/* concatenating with "" ensures that only literal strings are accepted as argument. */
-#define STR_WITH_LEN(str)  ("" str ""), (sizeof(str) - 1)
-
 MVMObject * MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMint64 offset, MVMint64 flag) {
     MVMObject *result;
     MVMint64 zvalue = 0;

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -526,18 +526,10 @@ MVMObject * MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMi
     return result;
 }
 
-void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type, MVMRegister *dst) {
-    dst->o = MVM_repr_box_int(tc, type, value);
-};
-
 MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj) {
     if (!IS_CONCRETE(obj))
         MVM_exception_throw_adhoc(tc, "Cannot unbox a type object (%s) to a str.",
             MVM_6model_get_debug_name(tc, obj));
     return REPR(obj)->box_funcs.get_str(tc,
         STABLE(obj), obj, OBJECT_BODY(obj));
-}
-
-void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type, MVMRegister *dst) {
-    dst->o = MVM_repr_box_str(tc, type, value);
 }

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -525,11 +525,3 @@ MVMObject * MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMi
 
     return result;
 }
-
-MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj) {
-    if (!IS_CONCRETE(obj))
-        MVM_exception_throw_adhoc(tc, "Cannot unbox a type object (%s) to a str.",
-            MVM_6model_get_debug_name(tc, obj));
-    return REPR(obj)->box_funcs.get_str(tc,
-        STABLE(obj), obj, OBJECT_BODY(obj));
-}

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -526,32 +526,12 @@ MVMObject * MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMi
     return result;
 }
 
+void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type, MVMRegister *dst) {
+    dst->o = MVM_repr_box_int(tc, type, value);
+};
 
-void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type,
-             MVMRegister * dst) {
-    MVMObject *box = MVM_intcache_get(tc, type, value);
-    if (box == 0) {
-        box = REPR(type)->allocate(tc, STABLE(type));
-        MVMROOT(tc, box, {
-            if (REPR(box)->initialize)
-                REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-            REPR(box)->box_funcs.set_int(tc, STABLE(box), box,
-                                         OBJECT_BODY(box), value);
-        });
-    }
-    dst->o = box;
-}
-
-void MVM_box_num(MVMThreadContext *tc, MVMnum64 value, MVMObject *type,
-                 MVMRegister * dst) {
-    MVMObject *box = REPR(type)->allocate(tc, STABLE(type));
-    MVMROOT(tc, box, {
-        if (REPR(box)->initialize)
-            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-        REPR(box)->box_funcs.set_num(tc, STABLE(box), box,
-                                     OBJECT_BODY(box), value);
-    });
-    dst->o = box;
+void MVM_box_num(MVMThreadContext *tc, MVMnum64 value, MVMObject *type, MVMRegister *dst) {
+    dst->o = MVM_repr_box_num(tc, type, value);
 }
 
 MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj) {
@@ -562,28 +542,10 @@ MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj) {
         STABLE(obj), obj, OBJECT_BODY(obj));
 }
 
-void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type,
-                 MVMRegister *dst) {
-    MVMObject *box;
-    MVMROOT(tc, value, {
-        box = REPR(type)->allocate(tc, STABLE(type));
-        MVMROOT(tc, box, {
-            if (REPR(box)->initialize)
-                REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-            REPR(box)->box_funcs.set_str(tc, STABLE(box), box,
-                                         OBJECT_BODY(box), value);
-            dst->o = box;
-        });
-    });
+void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type, MVMRegister *dst) {
+    dst->o = MVM_repr_box_str(tc, type, value);
 }
 
-void MVM_box_uint(MVMThreadContext *tc, MVMuint64 value, MVMObject *type,
-             MVMRegister * dst) {
-    MVMObject *box = REPR(type)->allocate(tc, STABLE(type));
-    MVMROOT(tc, value, {
-        if (REPR(box)->initialize)
-            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box));
-        REPR(box)->box_funcs.set_uint(tc, STABLE(box), box, OBJECT_BODY(box), value);
-    });
-    dst->o = box;
+void MVM_box_uint(MVMThreadContext *tc, MVMuint64 value, MVMObject *type, MVMRegister *dst) {
+    dst->o = MVM_repr_box_uint(tc, type, value);
 }

--- a/src/core/coerce.h
+++ b/src/core/coerce.h
@@ -23,5 +23,4 @@ MVMObject* MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMin
 void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type, MVMRegister *dst);
 void MVM_box_num(MVMThreadContext *tc, MVMnum64 value, MVMObject *type, MVMRegister *dst);
 void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type, MVMRegister *dst);
-void MVM_box_uint(MVMThreadContext *tc, MVMuint64 value, MVMObject *type, MVMRegister *dst);
 MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj);

--- a/src/core/coerce.h
+++ b/src/core/coerce.h
@@ -18,6 +18,3 @@ MVMObject* MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMin
 
 /* Size of the int to string coercion cache (we cache 0 ..^ this). */
 #define MVM_INT_TO_STR_CACHE_SIZE 64
-
-/* Objification */
-MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj);

--- a/src/core/coerce.h
+++ b/src/core/coerce.h
@@ -21,6 +21,5 @@ MVMObject* MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMin
 
 /* Objification */
 void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type, MVMRegister *dst);
-void MVM_box_num(MVMThreadContext *tc, MVMnum64 value, MVMObject *type, MVMRegister *dst);
 void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type, MVMRegister *dst);
 MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj);

--- a/src/core/coerce.h
+++ b/src/core/coerce.h
@@ -20,6 +20,4 @@ MVMObject* MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMin
 #define MVM_INT_TO_STR_CACHE_SIZE 64
 
 /* Objification */
-void MVM_box_int(MVMThreadContext *tc, MVMint64 value, MVMObject *type, MVMRegister *dst);
-void MVM_box_str(MVMThreadContext *tc, MVMString *value, MVMObject *type, MVMRegister *dst);
 MVMString * MVM_unbox_str(MVMThreadContext *tc, MVMObject *obj);

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -2207,7 +2207,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(unbox_s):
-                GET_REG(cur_op, 0).s = MVM_unbox_str(tc, GET_REG(cur_op, 2).o);
+                GET_REG(cur_op, 0).s = MVM_repr_get_str(tc, GET_REG(cur_op, 2).o);
                 cur_op += 4;
                 goto NEXT;
             OP(atpos_i): {

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -2174,19 +2174,17 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(box_i): {
-                MVM_box_int(tc, GET_REG(cur_op, 2).i64, GET_REG(cur_op, 4).o,
-                            &GET_REG(cur_op, 0));
+                GET_REG(cur_op, 0).o = MVM_repr_box_int(tc, GET_REG(cur_op, 4).o, GET_REG(cur_op, 2).i64);
                 cur_op += 6;
                 goto NEXT;
             }
             OP(box_n): {
-                MVM_box_num(tc, GET_REG(cur_op, 2).n64, GET_REG(cur_op, 4).o,
-                            &GET_REG(cur_op, 0));
+                GET_REG(cur_op, 0).o = MVM_repr_box_num(tc, GET_REG(cur_op, 4).o, GET_REG(cur_op, 2).n64);
                 cur_op += 6;
                 goto NEXT;
             }
             OP(box_s): {
-                 MVM_box_str(tc, GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).o, &GET_REG(cur_op, 0));
+                 GET_REG(cur_op, 0).o = MVM_repr_box_str(tc, GET_REG(cur_op, 4).o, GET_REG(cur_op, 2).s);
                  cur_op += 6;
                  goto NEXT;
             }
@@ -4966,8 +4964,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 6;
                 goto NEXT;
             OP(box_u): {
-                MVM_box_uint(tc, GET_REG(cur_op, 2).u64, GET_REG(cur_op, 4).o,
-                            &GET_REG(cur_op, 0));
+                GET_REG(cur_op, 0).o = MVM_repr_box_uint(tc, GET_REG(cur_op, 4).o, GET_REG(cur_op, 2).u64);
                 cur_op += 6;
                 goto NEXT;
             }

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -892,6 +892,13 @@
       (carg $2 ptr)
       (carg $1 int)) ptr_sz))
 
+(template: box_u
+  (call (^func &MVM_repr_box_uint)
+    (arglist
+      (carg (tc) ptr)
+      (carg $2 ptr)
+      (carg $1 int)) ptr_sz))
+
 (template: box_s
   (call (^func &MVM_repr_box_str)
     (arglist
@@ -904,6 +911,14 @@
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)) ptr_sz))
+
+(template: unbox_i
+  (call (^getf (^repr $1) MVMREPROps box_funcs.get_int)
+    (arglist
+      (carg (tc) ptr)
+      (carg (^stable $1) ptr)
+      (carg $1 ptr)
+      (carg (^body $1) ptr)) int_sz))
 
 (template: unbox_u
   (call (^getf (^repr $1) MVMREPROps box_funcs.get_uint)

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -900,7 +900,7 @@
       (carg $1 ptr)) ptr_sz))
 
 (template: unbox_s
-  (call (^func &MVM_unbox_str)
+  (call (^func &MVM_repr_get_str)
     (arglist
       (carg (tc) ptr)
       (carg $1 ptr)) ptr_sz))

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -885,21 +885,19 @@
 
 (template: eqaddr (flagval (eq $1 $2)))
 
-(template: box_i!
-  (callv (^func &MVM_box_int)
+(template: box_i
+  (call (^func &MVM_repr_box_int)
     (arglist
       (carg (tc) ptr)
-      (carg $1 int)
       (carg $2 ptr)
-      (carg \$0 ptr))))
+      (carg $1 int)) ptr_sz))
 
-(template: box_s!
-  (callv (^func &MVM_box_str)
+(template: box_s
+  (call (^func &MVM_repr_box_str)
     (arglist
       (carg (tc) ptr)
-      (carg $1 ptr)
       (carg $2 ptr)
-      (carg \$0 ptr))))
+      (carg $1 ptr)) ptr_sz))
 
 (template: unbox_s
   (call (^func &MVM_unbox_str)

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -151,9 +151,9 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_smrt_numify: return MVM_coerce_smart_numify;
     case MVM_OP_smrt_strify: return MVM_coerce_smart_stringify;
     case MVM_OP_gethow: return MVM_6model_get_how_obj;
-    case MVM_OP_box_i: return MVM_box_int;
-    case MVM_OP_box_s: return MVM_box_str;
-    case MVM_OP_box_n: return MVM_box_num;
+    case MVM_OP_box_i: return MVM_repr_box_int;
+    case MVM_OP_box_s: return MVM_repr_box_str;
+    case MVM_OP_box_n: return MVM_repr_box_num;
     case MVM_OP_unbox_i: return MVM_repr_get_int;
     case MVM_OP_unbox_u: return MVM_repr_get_uint;
     case MVM_OP_unbox_s: return MVM_repr_get_str;
@@ -2933,10 +2933,9 @@ start:
         MVMint16 val = ins->operands[1].reg.orig;
         MVMint16 type = ins->operands[2].reg.orig;
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR , { MVM_JIT_INTERP_TC } },
-                                 { MVM_JIT_REG_VAL_F, { val } },
                                  { MVM_JIT_REG_VAL, { type } },
-                                 { MVM_JIT_REG_ADDR, { dst } }};
-        jg_append_call_c(tc, jg, op_to_func(tc, op), 4, args, MVM_JIT_RV_VOID, -1);
+                                 { MVM_JIT_REG_VAL_F, { val } }};
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 3, args, MVM_JIT_RV_PTR, dst);
         break;
     }
     case MVM_OP_box_s:
@@ -2945,10 +2944,9 @@ start:
         MVMint16 val = ins->operands[1].reg.orig;
         MVMint16 type = ins->operands[2].reg.orig;
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR , { MVM_JIT_INTERP_TC } },
-                                 { MVM_JIT_REG_VAL, { val } },
                                  { MVM_JIT_REG_VAL, { type } },
-                                 { MVM_JIT_REG_ADDR, { dst } }};
-        jg_append_call_c(tc, jg, op_to_func(tc, op), 4, args, MVM_JIT_RV_VOID, -1);
+                                 { MVM_JIT_REG_VAL, { val } }};
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 3, args, MVM_JIT_RV_PTR, dst);
         break;
     }
     case MVM_OP_unbox_i: {

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -152,6 +152,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_smrt_strify: return MVM_coerce_smart_stringify;
     case MVM_OP_gethow: return MVM_6model_get_how_obj;
     case MVM_OP_box_i: return MVM_repr_box_int;
+    case MVM_OP_box_u: return MVM_repr_box_uint;
     case MVM_OP_box_s: return MVM_repr_box_str;
     case MVM_OP_box_n: return MVM_repr_box_num;
     case MVM_OP_unbox_i: return MVM_repr_get_int;
@@ -862,6 +863,7 @@ static MVMint32 consume_reprop(MVMThreadContext *tc, MVMJitGraph *jg,
             type_operand = ins->operands[1];
             break;
         case MVM_OP_box_i:
+        case MVM_OP_box_u:
         case MVM_OP_box_n:
         case MVM_OP_box_s:
             type_operand = ins->operands[2];
@@ -2939,7 +2941,8 @@ start:
         break;
     }
     case MVM_OP_box_s:
-    case MVM_OP_box_i: {
+    case MVM_OP_box_i:
+    case MVM_OP_box_u: {
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 val = ins->operands[1].reg.orig;
         MVMint16 type = ins->operands[2].reg.orig;

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -1371,9 +1371,6 @@ MVMint64 MVM_bigint_is_prime(MVMThreadContext *tc, MVMObject *a) {
     }
 }
 
-/* concatenating with "" ensures that only literal strings are accepted as argument. */
-#define STR_WITH_LEN(str)  ("" str ""), (sizeof(str) - 1)
-
 MVMObject * MVM_bigint_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMint64 offset, MVMint64 flag, MVMObject *type) {
     mp_err err;
     MVMObject *result;

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2587,9 +2587,6 @@ MVMString * MVM_string_bitxor(MVMThreadContext *tc, MVMString *a, MVMString *b) 
 #define UPV_Pf MVM_UNICODE_PVALUE_GC_PF
 #define UPV_Po MVM_UNICODE_PVALUE_GC_PO
 
-/* concatenating with "" ensures that only literal strings are accepted as argument. */
-#define STR_WITH_LEN(str)  ("" str ""), (sizeof(str) - 1)
-
 #include "strings/unicode_prop_macros.h"
 /* Checks if the specified grapheme is in the given character class. */
 MVMint64 MVM_string_grapheme_is_cclass(MVMThreadContext *tc, MVMint64 cclass, MVMGrapheme32 g) {


### PR DESCRIPTION
MVM_box_{int,num,str,uint} and MVM_unbox_str duplicate functionality in reprconv.c and can be replaced with calls to MVM_repr_box_{int,num,str,uint} and MVM_repr_get_str.