### PR TITLE
D'oh! We need to set MVM_running_threads_context.

### DIFF
--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -76,12 +76,10 @@ static void start_thread(void *data) {
     /* Stash thread ID. */
     tc->thread_obj->body.native_thread_id = MVM_platform_thread_id();
 
-#ifndef MVM_THREAD_LOCAL
     /* Store this thread's thread context pointer, so that we can retrieve it
      * in places where we can't pass it in to, such as the callback function
      * used by qsort. */
-    uv_key_set(&MVM_running_threads_context_key, tc);
-#endif
+    MVM_set_running_threads_context(tc);
 
     /* Create a spesh log for this thread, unless it's just going to run C
      * code (and thus it's a VM internal worker). */

--- a/src/moar.c
+++ b/src/moar.c
@@ -229,6 +229,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     instance->threads->body.tc = instance->main_thread;
     instance->threads->body.native_thread_id = MVM_platform_thread_id();
     instance->threads->body.thread_id = instance->main_thread->thread_id;
+    MVM_set_running_threads_context(instance->main_thread);
     init_mutex(instance->mutex_threads, "threads list");
 
     /* Create compiler registry */

--- a/src/moar.h
+++ b/src/moar.h
@@ -307,6 +307,10 @@ MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
     return MVM_running_threads_context;
 }
 
+MVM_STATIC_INLINE void MVM_set_running_threads_context(MVMThreadContext *tc) {
+    MVM_running_threads_context = tc;
+}
+
 #else
 
 /* Fallback to an implememtation using UV's APIs (pretty much pthreads) */
@@ -314,6 +318,10 @@ extern uv_key_t MVM_running_threads_context_key;
 
 MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
     return uv_key_get(&MVM_running_threads_context_key);
+}
+
+MVM_STATIC_INLINE void MVM_set_running_threads_context(MVMThreadContext *tc) {
+    return uv_key_set(&MVM_running_threads_context_key, tc);
 }
 
 #endif


### PR DESCRIPTION
Add `MVM_set_running_threads_context` which sets the value to be returned
from `MVM_get_running_threads_context`. This fixes a bug that I introduced
in commits 4cfde6edf15b0bc0 and ac941c0d59286528. It was not spotted because
the only place that currently calls `MVM_get_running_threads_context` doesn't
ever actually need the value.