### PR TITLE
Implement MVM_nativecall_find_thread_context using MVM_get_running_threads_context

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -2,7 +2,6 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
-#include <platform/threads.h>
 #include <platform/time.h>
 
 /* Grabs a NativeCall body. */

--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -1148,42 +1148,6 @@ void MVM_nativecall_refresh(MVMThreadContext *tc, MVMObject *cthingy) {
     }
 }
 
-/* Locate the thread that a callback should be run on. */
-MVMThreadContext * MVM_nativecall_find_thread_context(MVMInstance *instance) {
-    MVMint64 wanted_thread_id = MVM_platform_thread_id();
-    MVMThreadContext *tc = NULL;
-    while (1) {
-        uv_mutex_lock(&(instance->mutex_threads));
-        if (instance->in_gc) {
-            /* VM is in GC; free lock since the GC will acquire it again to
-             * clear the in_gc flag, and sleep a bit until it's safe to read
-             * the threads list. */
-            uv_mutex_unlock(&(instance->mutex_threads));
-            MVM_platform_sleep(0.0001);
-        }
-        else {
-            /* Not in GC. If a GC starts while we are reading this, then we
-             * are holding mutex_threads, and the GC will block on it before
-             * it gets to a stage where it can move things. */
-            MVMThread *thread = instance->threads;
-            while (thread) {
-                if (thread->body.native_thread_id == wanted_thread_id) {
-                    tc = thread->body.tc;
-                    if (tc)
-                        break;
-                }
-                thread = thread->body.next;
-            }
-            if (!tc)
-                MVM_panic(1, "native callback ran on thread (%"PRId64") unknown to MoarVM",
-                    wanted_thread_id);
-            uv_mutex_unlock(&(instance->mutex_threads));
-            break;
-        }
-    }
-    return tc;
-}
-
 typedef struct ResolverData {
     MVMObject *site;
     MVMRegister args[1];

--- a/src/core/nativecall.h
+++ b/src/core/nativecall.h
@@ -135,7 +135,19 @@ void * MVM_nativecall_unmarshal_cpointer(MVMThreadContext *tc, MVMObject *value,
 void * MVM_nativecall_unmarshal_carray(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
 void * MVM_nativecall_unmarshal_vmarray(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
 void * MVM_nativecall_unmarshal_cunion(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
-MVMThreadContext * MVM_nativecall_find_thread_context(MVMInstance *instance);
+
+/* Locate the thread that a callback should be run on. */
+MVM_STATIC_INLINE MVMThreadContext * MVM_nativecall_find_thread_context(MVMInstance *instance) {
+    MVMThreadContext *tc = MVM_get_running_threads_context();
+
+    if (!tc)
+        MVM_panic(1, "native callback ran on thread (%"PRId64") unknown to MoarVM",
+                  MVM_platform_thread_id());
+
+    return tc;
+}
+
+
 MVMJitGraph *MVM_nativecall_jit_graph_for_caller_code(
     MVMThreadContext   *tc,
     MVMSpeshGraph      *sg,

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -1,5 +1,4 @@
 #include "moar.h"
-#include <platform/threads.h>
 
 //~ ffi_type * MVM_nativecall_get_ffi_type(MVMThreadContext *tc, MVMuint64 type_id, void **values, MVMuint64 offset) {
 ffi_type * MVM_nativecall_get_ffi_type(MVMThreadContext *tc, MVMuint64 type_id) {

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -76,12 +76,10 @@ static void start_thread(void *data) {
     /* Stash thread ID. */
     tc->thread_obj->body.native_thread_id = MVM_platform_thread_id();
 
-#ifndef MVM_THREAD_LOCAL
     /* Store this thread's thread context pointer, so that we can retrieve it
      * in places where we can't pass it in to, such as the callback function
      * used by qsort. */
-    uv_key_set(&MVM_running_threads_context_key, tc);
-#endif
+    MVM_set_running_threads_context(tc);
 
     /* Create a spesh log for this thread, unless it's just going to run C
      * code (and thus it's a VM internal worker). */

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -1,5 +1,4 @@
 #include "moar.h"
-#include <platform/threads.h>
 
 /* Temporary structure for passing data to thread start. */
 typedef struct {

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1,5 +1,4 @@
 #include "moar.h"
-#include "platform/threads.h"
 
 #define DEBUGSERVER_MAJOR_PROTOCOL_VERSION 1
 #define DEBUGSERVER_MINOR_PROTOCOL_VERSION 2

--- a/src/gc/orchestrate.c
+++ b/src/gc/orchestrate.c
@@ -1,5 +1,4 @@
 #include "moar.h"
-#include <platform/threads.h>
 #include "platform/malloc_trim.h"
 
 /* If we have the job of doing GC for a thread, we add it to our work

--- a/src/moar.c
+++ b/src/moar.c
@@ -229,6 +229,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     instance->threads->body.tc = instance->main_thread;
     instance->threads->body.native_thread_id = MVM_platform_thread_id();
     instance->threads->body.thread_id = instance->main_thread->thread_id;
+    MVM_set_running_threads_context(instance->main_thread);
     init_mutex(instance->mutex_threads, "threads list");
 
     /* Create compiler registry */

--- a/src/moar.c
+++ b/src/moar.c
@@ -1,7 +1,6 @@
 #include "platform/memmem.h"
 #include "moar.h"
 #include "platform/io.h"
-#include <platform/threads.h>
 #include "platform/random.h"
 #include "platform/time.h"
 #include "platform/mmap.h"

--- a/src/moar.h
+++ b/src/moar.h
@@ -39,6 +39,9 @@
 #include <dyncall_callback.h>
 #endif
 
+/* needed in threadcontext.h */
+#include <platform/threads.h>
+
 /* forward declarations */
 #include "types.h"
 
@@ -292,36 +295,3 @@ AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t
  * which the other atomic operation macros are used... */
 #define MVM_store(addr, new) AO_store_full((volatile AO_t *)(addr), (AO_t)(new))
 #define MVM_load(addr) AO_load_full((volatile AO_t *)(addr))
-
-/* UV always defines this for Win32 but not Unix. Which is fine, as we can probe
- * for it on Unix more easily than on Win32. */
-#if !defined(MVM_THREAD_LOCAL) && defined(UV_THREAD_LOCAL)
-#define MVM_THREAD_LOCAL UV_THREAD_LOCAL
-#endif
-
-#ifdef MVM_THREAD_LOCAL
-
-extern MVM_THREAD_LOCAL MVMThreadContext *MVM_running_threads_context;
-
-MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
-    return MVM_running_threads_context;
-}
-
-MVM_STATIC_INLINE void MVM_set_running_threads_context(MVMThreadContext *tc) {
-    MVM_running_threads_context = tc;
-}
-
-#else
-
-/* Fallback to an implememtation using UV's APIs (pretty much pthreads) */
-extern uv_key_t MVM_running_threads_context_key;
-
-MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
-    return uv_key_get(&MVM_running_threads_context_key);
-}
-
-MVM_STATIC_INLINE void MVM_set_running_threads_context(MVMThreadContext *tc) {
-    return uv_key_set(&MVM_running_threads_context_key, tc);
-}
-
-#endif

--- a/src/moar.h
+++ b/src/moar.h
@@ -307,6 +307,10 @@ MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
     return MVM_running_threads_context;
 }
 
+MVM_STATIC_INLINE void MVM_set_running_threads_context(MVMThreadContext *tc) {
+    MVM_running_threads_context = tc;
+}
+
 #else
 
 /* Fallback to an implememtation using UV's APIs (pretty much pthreads) */
@@ -314,6 +318,10 @@ extern uv_key_t MVM_running_threads_context_key;
 
 MVM_STATIC_INLINE MVMThreadContext *MVM_get_running_threads_context(void) {
     return uv_key_get(&MVM_running_threads_context_key);
+}
+
+MVM_STATIC_INLINE void MVM_set_running_threads_context(MVMThreadContext *tc) {
+    return uv_key_set(&MVM_running_threads_context_key, tc);
 }
 
 #endif


### PR DESCRIPTION
O(1) is better than O(n) :\-)

And no need for a mutex is infinitely more efficient.
