### PR TITLE
Improve performance of repeated `unshift`ing

### DIFF
--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -629,7 +629,7 @@ static void unshift(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *
     MVMArrayREPRData *repr_data = (MVMArrayREPRData *)st->REPR_data;
     MVMArrayBody     *body      = (MVMArrayBody *)data;
 
-    /* If we don't have room at the beginning of the slots, make some room
+    /* If we don't have room at the beginning of the slots, make some
      * room for unshifting. We make room for a minimum of 8 elements, but
      * for cases where we're just continuously unshifting factor in the
      * body size too - however also apply an upper limit on that as in the

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -18,6 +18,9 @@ static void exit_single_user(MVMThreadContext *tc, MVMArrayBody *arr) {
 #endif
 }
 
+#define MVM_MAX(a,b) ((a)>(b)?(a):(b))
+#define MVM_MIN(a,b) ((a)<(b)?(a):(b))
+
 /* Creates a new type object of this representation, and associates it with
  * the given HOW. */
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
@@ -626,12 +629,15 @@ static void unshift(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *
     MVMArrayREPRData *repr_data = (MVMArrayREPRData *)st->REPR_data;
     MVMArrayBody     *body      = (MVMArrayBody *)data;
 
-    /* If we don't have room at the beginning of the slots,
-     * make some room (8 slots) for unshifting */
+    /* If we don't have room at the beginning of the slots, make some room
+     * room for unshifting. We make room for a minimum of 8 elements, but
+     * for cases where we're just continuously unshifting factor in the
+     * body size too - however also apply an upper limit on that as in the
+     * push-based growth. */
     enter_single_user(tc, body);
     if (body->start < 1) {
-        MVMuint64 n = 8;
         MVMuint64 elems = body->elems;
+        MVMuint64 n = MVM_MIN(MVM_MAX(elems, 8), 8192);
 
         /* grow the array */
         set_size_internal(tc, body, elems + n, repr_data);


### PR DESCRIPTION
Prior to this, we always created a fixed amount of extra space (8
elements) at the start of the array, regardless of array size. With
this change we start accounting for the number of elements in the
array. This will make no difference for steady state unshift/pop,
but for situations where we repeatedly unshift will bring the
performance in line with that of push. Fixes #1382.