### PR TITLE
Early exit gc_mark for VMArray+MVMHash if able

### DIFF
--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -51,7 +51,13 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
 static void MVMHash_gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorklist *worklist) {
     MVMHashBody     *body = (MVMHashBody *)data;
     MVMStrHashTable *hashtable = &(body->hashtable);
-    MVM_gc_worklist_presize_for(tc, worklist, 2 * MVM_str_hash_count(tc, hashtable));
+    MVMuint64            elems = MVM_str_hash_count(tc, hashtable);
+
+    /* Aren't holding anything, nothing to do. */
+    if (elems == 0)
+        return;
+
+    MVM_gc_worklist_presize_for(tc, worklist, 2 * elems);
     if (worklist->include_gen2) {
         MVMStrHashIterator iterator = MVM_str_hash_first(tc, hashtable);
         while (!MVM_str_hash_at_end(tc, hashtable, iterator)) {

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -68,6 +68,11 @@ static void VMArray_gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVM
     MVMuint64         elems     = body->elems;
     MVMuint64         start     = body->start;
     MVMuint64         i         = 0;
+
+    /* Aren't holding anything, nothing to do. */
+    if (elems == 0)
+        return;
+
     switch (repr_data->slot_type) {
         case MVM_ARRAY_OBJ: {
             MVMObject **slots = body->slots.o;


### PR DESCRIPTION
Don't need to go through the setup work to try and mark the held
elements if there aren't in fact any elements.

I wasn't sure how to best benchmark any actual time saved, but the
early exit triggered ~4m times for VMArray and ~500k times for MVMHash
when compiling just Rakudo's CORE.c setting.