### PR TITLE
Fix some simple things the clang static analyzer found

### DIFF
--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -843,9 +843,10 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
                                         MVM_free_null(name_map->names);
                                         MVM_free_null(name_map->slots);
                                     }
+                                    MVMint16 unbox_int_slot = repr_data->unbox_int_slot;
                                     free_repr_data(repr_data);
                                     MVM_exception_throw_adhoc(tc,
-                                        "While composing %s: Duplicate box_target for native int: attributes %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), repr_data->unbox_int_slot, i);
+                                        "While composing %s: Duplicate box_target for native int: attributes %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), unbox_int_slot, i);
                                 }
                                 repr_data->unbox_int_slot = cur_slot;
                                 break;
@@ -855,9 +856,10 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
                                         MVM_free_null(name_map->names);
                                         MVM_free_null(name_map->slots);
                                     }
+                                    MVMint16 unbox_num_slot = repr_data->unbox_num_slot;
                                     free_repr_data(repr_data);
                                     MVM_exception_throw_adhoc(tc,
-                                        "While composing %s: Duplicate box_target for native num: attributes %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), repr_data->unbox_num_slot, i);
+                                        "While composing %s: Duplicate box_target for native num: attributes %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), unbox_num_slot, i);
                                 }
                                 repr_data->unbox_num_slot = cur_slot;
                                 break;
@@ -867,9 +869,10 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
                                         MVM_free_null(name_map->names);
                                         MVM_free_null(name_map->slots);
                                     }
+                                    MVMint16 unbox_str_slot = repr_data->unbox_str_slot;
                                     free_repr_data(repr_data);
                                     MVM_exception_throw_adhoc(tc,
-                                        "While composing %s: Duplicate box_target for native str: attributes %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), repr_data->unbox_str_slot, i);
+                                        "While composing %s: Duplicate box_target for native str: attributes %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), unbox_str_slot, i);
                                 }
                                 repr_data->unbox_str_slot = cur_slot;
                                 break;
@@ -910,9 +913,10 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
                         MVM_free_null(name_map->names);
                         MVM_free_null(name_map->slots);
                     }
+                    MVMint16 pos_del_slot = repr_data->pos_del_slot;
                     free_repr_data(repr_data);
                     MVM_exception_throw_adhoc(tc,
-                        "While composing %s: Duplicate positional delegate attributes: %d and %"PRId64"", MVM_6model_get_stable_debug_name(tc, st), repr_data->pos_del_slot, cur_slot);
+                        "While composing %s: Duplicate positional delegate attributes: %d and %"PRId64"", MVM_6model_get_stable_debug_name(tc, st), pos_del_slot, cur_slot);
                 }
                 if (unboxed_type == MVM_STORAGE_SPEC_BP_NONE)
                     repr_data->pos_del_slot = cur_slot;
@@ -932,9 +936,10 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info_hash) {
                         MVM_free_null(name_map->names);
                         MVM_free_null(name_map->slots);
                     }
+                    MVMint16 pos_del_slot = repr_data->pos_del_slot;
                     free_repr_data(repr_data);
                     MVM_exception_throw_adhoc(tc,
-                        "While composing %s: Duplicate associative delegate attributes: %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), repr_data->pos_del_slot, cur_slot);
+                        "While composing %s: Duplicate associative delegate attributes: %d and %"PRId64, MVM_6model_get_stable_debug_name(tc, st), pos_del_slot, cur_slot);
                 }
                 if (unboxed_type == MVM_STORAGE_SPEC_BP_NONE)
                     repr_data->ass_del_slot = cur_slot;
@@ -1127,14 +1132,15 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
             MVMuint16 repr_id = MVM_serialization_read_int(tc, reader);
             MVMuint16 slot = MVM_serialization_read_int(tc, reader);
             if (slot > repr_data->num_attributes) {
+                MVMuint16 num_attributes = repr_data->num_attributes;
                 free_repr_data(repr_data);
-                MVM_exception_throw_adhoc(tc, "Serialization error: P6opaque's unbox slot out of range (slot %d > %d attributes).", slot, repr_data->num_attributes);
+                MVM_exception_throw_adhoc(tc, "Serialization error: P6opaque's unbox slot out of range (slot %d > %d attributes).", slot, num_attributes);
             }
             if (repr_id < MVM_REPR_MAX_COUNT)
                 repr_data->unbox_slots[repr_id] = slot;
             else {
                 free_repr_data(repr_data);
-                MVM_exception_throw_adhoc(tc, "Serialization error: P6opaque's unbox slot repr id out of range.");
+                MVM_exception_throw_adhoc(tc, "Serialization error: P6opaque's unbox slot repr id out of range (repr id %d >= %d).", repr_id, MVM_REPR_MAX_COUNT);
             }
         }
     } else {

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2208,7 +2208,6 @@ static void resolve_dependencies(MVMThreadContext *tc, MVMSerializationReader *r
             else {
                 cdesc = "<unknown>";
             }
-            if (!desc) desc = handle;
             fail_deserialize(tc, waste, reader,
                 "Missing or wrong version of dependency '%s' (from '%s')",
                 cname,

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -52,7 +52,7 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
             }
             MVM_free(tc->temp_bigints[i]);
             MVM_tc_destroy(tc);
-            MVM_exception_throw_adhoc(tc, "Error creating a temporary big integer: %s", mp_error_to_string(err));
+            MVM_exception_throw_adhoc(parent, "Error creating a temporary big integer: %s", mp_error_to_string(err));
         }
     }
 

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -934,8 +934,8 @@ static void send_thread_info(MVMThreadContext *dtc, cmp_ctx_t *ctx, request_data
         if (threadname != NULL && strlen(threadname)) {
             cmp_write_str(ctx, "name", 4);
             cmp_write_str(ctx, threadname, strlen(threadname));
-            MVM_free(threadname);
         }
+        MVM_free(threadname);
 
         cur_thread = cur_thread->body.next;
     }

--- a/src/instrument/line_coverage.c
+++ b/src/instrument/line_coverage.c
@@ -26,7 +26,6 @@ static void instrument_graph_with_breakpoints(MVMThreadContext *tc, MVMSpeshGrap
             filename_string_index = bbba->filename_string_heap_index;
             MVM_free(bbba);
         } else {
-            line_number = -1;
             bb = bb->linear_next;
             continue;
         }
@@ -147,7 +146,6 @@ static void instrument_graph(MVMThreadContext *tc, MVMSpeshGraph *g) {
             filename_string_index = bbba->filename_string_heap_index;
             MVM_free(bbba);
         } else {
-            line_number = -1;
             bb = bb->linear_next;
             continue;
         }
@@ -308,12 +306,11 @@ void MVM_line_coverage_report(MVMThreadContext *tc, MVMString *filename, MVMuint
     if (tc->instance->coverage_control == 2 || (!tc->instance->coverage_control && cache[cache_slot] == 0)) {
         char *encoded_filename;
         char composed_line[256];
-        size_t length;
 
         cache[cache_slot] = 1;
 
         encoded_filename = MVM_string_utf8_encode_C_string(tc, filename);
-        if ((length = snprintf(composed_line, 255, "HIT  %s  %d\n", encoded_filename, line_number)) > 0) {
+        if (snprintf(composed_line, 255, "HIT  %s  %d\n", encoded_filename, line_number) > 0) {
             fputs(composed_line, tc->instance->coverage_log_fh);
         }
         MVM_free(encoded_filename);

--- a/src/platform/random.c
+++ b/src/platform/random.c
@@ -71,8 +71,7 @@
     #include <unistd.h>
     MVMint32 MVM_getrandom_urandom (MVMThreadContext *tc, void *out, size_t size) {
         int fd = MVM_platform_open("/dev/urandom", O_RDONLY);
-        ssize_t num_read = 0;
-        if (fd < 0 || (num_read = read(fd, out, size) <= 0)) {
+        if (fd < 0 || read(fd, out, size) <= 0) {
             if (fd) close(fd);
             /* If using /dev/urandom fails (maybe we're in a chroot), on BSD's
              * use arc4random, which is likely seeded from the system's random

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1149,8 +1149,6 @@ static void optimize_string_equality(MVMThreadContext *tc, MVMSpeshGraph *g, MVM
     MVMSpeshFacts *b_facts = MVM_spesh_get_facts(tc, g, ins->operands[2]);
     MVMuint8 was_eq = 0;
 
-    return;
-
     if (ins->info->opcode == MVM_OP_eq_s)
         was_eq = 1;
 

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2329,9 +2329,6 @@ MVMString * MVM_string_flip(MVMThreadContext *tc, MVMString *s) {
         while (spos_l < s->body.num_graphs)
             rbuffer[--rpos_l] = s->body.storage.blob_8[spos_l++];
 
-        spos += sgraphs - spos;
-        rpos -= sgraphs - spos;
-
         MVMROOT(tc, s, {
             res = (MVMString *)MVM_repr_alloc_init(tc, tc->instance->VMString);
         });
@@ -2348,9 +2345,6 @@ MVMString * MVM_string_flip(MVMThreadContext *tc, MVMString *s) {
             MVM_VECTORIZE_LOOP
             while (spos_l < s->body.num_graphs)
                 rbuffer[--rpos_l] = s->body.storage.blob_32[spos_l++];
-
-            spos += sgraphs - spos;
-            rpos -= sgraphs - spos;
         }
         else
             for (; spos < sgraphs; spos++)

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -426,7 +426,6 @@ MVMuint32 MVM_string_utf8_c8_decodestream(MVMThreadContext *tc, MVMDecodeStream 
     /* If there's no buffers, we're done. */
     if (!ds->bytes_head)
         return 0;
-    last_accept_pos = ds->bytes_head_pos;
 
     /* If we're asked for zero chars, also done. */
     if (stopper_chars && *stopper_chars == 0)


### PR DESCRIPTION
It was easy to run `make clean; scan-build make install` and it produces an html report. There are 112 more things it found, but verifying them is a bit trickier.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.