### PR TITLE
Make curcode OP inlinable

### DIFF
--- a/src/core/oplist
+++ b/src/core/oplist
@@ -480,7 +480,7 @@ ctx                 w(obj) :pure :noinline
 ctxouter            w(obj) r(obj) :pure
 ctxcaller           w(obj) r(obj) :pure
 ctxlexpad           w(obj) r(obj) :pure
-curcode             w(obj) :pure :noinline
+curcode             w(obj) :pure
 callercode          w(obj) :pure :noinline
 add_I               w(obj) r(obj) r(obj) r(obj) :pure
 sub_I               w(obj) r(obj) r(obj) r(obj) :pure

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -5931,7 +5931,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         0,
         0,
-        1,
+        0,
         0,
         0,
         0,


### PR DESCRIPTION
curcode was marked :noinline as tc->cur_frame->code_ref would point at the
inliner, not at the inlinee, thus giving the wrong result. As jnthn++ noticed
though, we have the right code_ref easily available in a register, since we
need it for several ops already. So just turn the curcode into a set, reading
from the register holding the inlinee's code_ref.