### PR TITLE
Fix a potential bug when all elements are individually deleted from a hash

### DIFF
--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -360,6 +360,15 @@ uintptr_t MVM_ptr_hash_fetch_and_delete(MVMThreadContext *tc,
                 *metadata_target = 0;
                 --control->cur_items;
 
+                if (control->max_items == 0
+                    && control->cur_items < control->max_probe_distance) {
+                    /* Unlike MVMStrHashTable, resetting this here is merely an
+                     * optimisation (to avoid a doubling), as we don't have a
+                     * "control structure only" special case allocation. */
+                    MVMuint32 official_size = 1 << (MVMuint32)control->official_size_log2;
+                    control->max_items = official_size * MVM_PTR_HASH_LOAD_FACTOR;
+                }
+
                 /* Job's a good 'un. */
                 return retval;
             }


### PR DESCRIPTION
Two optimisations were coming together in an unforeseen way, which could
cause an assertion failure on a debugging build.

There's a space optimisation for empty hashes which only allocates the
control structure, and flags this with both `cur_items` and `max_items`
set to 0.

To avoid repeated checks in the insert code for probe distance overflows,
if an insert detects that it has caused any probe distance to hit the limit,
it signals that the next insert will need to reallocate by setting
`max_items` to 0.

What I'd not realised was that if a hash has a series of inserts that chance
to end with that state of "next insert needs to reallocate", but there are
no more inserts, then `max_items` remains set to 0 to flag this, and is
never "cleared". This usually doesn't matter, but in the specific unusual
case that the code then systematically deletes all entries in the hash
(without ever making any more inserts) that the count `cur_items` will
return to 0, and hence the special case "empty hash" optimisation flag
state is set, but with a regular allocation.

This doesn't happen reliably (it depends on hash randomisation), but could
sometimes be hit by t/spec/integration/advent2012-day14.t

To trip the assertion, both assertions and HASH_DEBUG_ITER need to be
enabled. If these aren't hit (and abort the process), I think that the
upshot of hitting this bug would be that part of a larger section of memory
would be returned to the FSA pool for a smaller bin size. Given that the
larger section of memory was still deemed allocated from its bin, and the
FSA never returns blocks of bins to free() (until global shutdown), I don't
think that this could cause any memory corruption.