### PR TITLE
Cleanup the build system probes

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -709,8 +709,20 @@ sub setup_native {
     print dots("Configuring native build environment");
     print "\n";
 
-    $os = build::probe::win32_compiler_toolchain(\%config, \%defaults)
-        if $os eq 'MSWin32';
+    if ($os eq 'MSWin32') {
+        my $has_nmake = 0 == system('nmake /? >NUL 2>&1');
+        my $has_cl    = `cl 2>&1` =~ /Microsoft Corporation/;
+        my $has_gmake = 0 == system('gmake --version >NUL 2>&1');
+        my $has_gcc   = 0 == system('gcc --version >NUL 2>&1');
+        if ($has_nmake && $has_cl) {
+            $os = 'win32';
+        }
+        elsif ($has_gmake && $has_gcc) {
+            $os = 'mingw32';
+        } else {
+            $os = "";
+        }
+    }
 
     if (!exists $::SYSTEMS{$os}) {
         softfail("unknown OS '$os'");

--- a/Configure.pl
+++ b/Configure.pl
@@ -487,21 +487,16 @@ print "OK\n\n";
 
 if ($config{crossconf}) {
     build::auto::detect_cross(\%config, \%defaults);
-    build::probe::static_inline_cross(\%config, \%defaults);
-    build::probe::thread_local_cross(\%config, \%defaults);
-    build::probe::substandard_pow_cross(\%config, \%defaults);
-    build::probe::unaligned_access_cross(\%config, \%defaults);
-    build::probe::ptr_size_cross(\%config, \%defaults);
 }
 else {
     build::auto::detect_native(\%config, \%defaults);
-    build::probe::static_inline_native(\%config, \%defaults);
-    build::probe::thread_local_native(\%config, \%defaults);
-    build::probe::substandard_pow(\%config, \%defaults);
-    build::probe::unaligned_access(\%config, \%defaults);
-    build::probe::ptr_size_native(\%config, \%defaults);
 }
 
+build::probe::static_inline(\%config, \%defaults);
+build::probe::thread_local(\%config, \%defaults);
+build::probe::substandard_pow(\%config, \%defaults);
+build::probe::unaligned_access(\%config, \%defaults);
+build::probe::ptr_size(\%config, \%defaults);
 
 my $archname = $Config{archname};
 if ($args{'jit'}) {

--- a/Configure.pl
+++ b/Configure.pl
@@ -398,7 +398,7 @@ push @cflags, $config{ccmiscflags};
 push @cflags, $config{ccoptiflags}  if $args{optimize};
 push @cflags, $config{ccdebugflags} if $args{debug};
 push @cflags, $config{ccinstflags}  if $args{instrument};
-push @cflags, $config{ld_covflags}  if $args{coverage};
+push @cflags, $config{cc_covflags}  if $args{coverage};
 push @cflags, $config{ccwarnflags};
 push @cflags, $config{ccdefflags};
 push @cflags, $config{ccshared}     unless $args{static};

--- a/Configure.pl
+++ b/Configure.pl
@@ -41,7 +41,7 @@ my @args = @ARGV;
 
 GetOptions(\%args, qw(
     help|?
-    debug:s optimize:s instrument! coverage
+    debug:s optimize:s coverage
     os=s shell=s toolchain=s compiler=s
     ar=s cc=s ld=s make=s has-sha has-libuv
     static has-libtommath has-libatomic_ops
@@ -92,7 +92,7 @@ if ( $args{relocatable} && ($^O eq 'aix' || $^O eq 'openbsd') ) {
     ".\n    Leave off the --relocatable flag to do a non-relocatable build.");
 }
 
-for (qw(coverage instrument static big-endian has-libtommath has-sha has-libuv
+for (qw(coverage static big-endian has-libtommath has-sha has-libuv
         has-libatomic_ops asan ubsan tsan valgrind dtrace show-vec)) {
     $args{$_} = 0 unless defined $args{$_};
 }
@@ -397,7 +397,6 @@ my @cflags;
 push @cflags, $config{ccmiscflags};
 push @cflags, $config{ccoptiflags}  if $args{optimize};
 push @cflags, $config{ccdebugflags} if $args{debug};
-push @cflags, $config{ccinstflags}  if $args{instrument};
 push @cflags, $config{cc_covflags}  if $args{coverage};
 push @cflags, $config{ccwarnflags};
 push @cflags, $config{ccdefflags};
@@ -438,7 +437,6 @@ $config{cflags} = join ' ', uniq(@cflags);
 my @ldflags = ($config{ldmiscflags});
 push @ldflags, $config{ldoptiflags}  if $args{optimize};
 push @ldflags, $config{lddebugflags} if $args{debug};
-push @ldflags, $config{ldinstflags}  if $args{instrument};
 push @ldflags, $config{ld_covflags}  if $args{coverage};
 if (not $args{static} and $config{prefix} ne '/usr') {
     push @ldflags, $config{ldrpath_relocatable} if  $args{relocatable};
@@ -990,7 +988,7 @@ __END__
     ./Configure.pl [--os <os>] [--shell <shell>]
                    [--toolchain <toolchain>] [--compiler <compiler>]
                    [--ar <ar>] [--cc <cc>] [--ld <ld>] [--make <make>]
-                   [--debug] [--optimize] [--instrument]
+                   [--debug] [--optimize]
                    [--static] [--prefix <path>] [--relocatable]
                    [--has-libtommath] [--has-sha] [--has-libuv]
                    [--has-libatomic_ops]
@@ -999,7 +997,7 @@ __END__
 
     ./Configure.pl --build <build-triple> --host <host-triple>
                    [--ar <ar>] [--cc <cc>] [--ld <ld>] [--make <make>]
-                   [--debug] [--optimize] [--instrument]
+                   [--debug] [--optimize]
                    [--static] [--prefix <path>] [--relocatable]
                    [--big-endian] [--make-install]
 
@@ -1032,13 +1030,6 @@ default.
 
 Toggle optimization and debug flags during compile and link. If nothing
 is specified the default is to optimize.
-
-=item --instrument
-
-=item --no-instrument
-
-Toggle extra instrumentation flags during compile and link; for example,
-turns on Address Sanitizer when compiling with C<clang>.  Defaults to off.
 
 =item --os <os>
 

--- a/build/probe.pm
+++ b/build/probe.pm
@@ -789,24 +789,6 @@ EOT
     $config->{arch_bits} = $num_bits;
 }
 
-sub win32_compiler_toolchain {
-    my ($config) = @_;
-    my $has_nmake = 0 == system('nmake /? >NUL 2>&1');
-    my $has_cl    = `cl 2>&1` =~ /Microsoft Corporation/;
-    my $has_gmake = 0 == system('gmake --version >NUL 2>&1');
-    my $has_gcc   = 0 == system('gcc --version >NUL 2>&1');
-    if ($has_nmake && $has_cl) {
-        $config->{win32_compiler_toolchain} = 'win32';
-    }
-    elsif ($has_gmake && $has_gcc) {
-        $config->{win32_compiler_toolchain} = 'mingw32';
-    }
-    else {
-        $config->{win32_compiler_toolchain} = ''
-    }
-    $config->{win32_compiler_toolchain}
-}
-
 sub rdtscp {
     my ($config) = @_;
     my $restore = _to_probe_dir();

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -250,6 +250,10 @@ TERM
 
     staticlib => '',
 
+    dllimport => '__declspec(dllimport)',
+    dllexport => '__declspec(dllexport)',
+    dlllocal  => '',
+
     -auxfiles => [ qw( @name@.ilk @name@.pdb @moardll@.lib @moardll@.exp vc100.pdb ) ],
 
     -thirdparty => {
@@ -282,6 +286,10 @@ my %TC_MINGW32 = (
     ldrpath_relocatable      => '',
     sharedlib                => 'lib@moardll@.a',
 
+    dllimport => '__declspec(dllimport)',
+    dllexport => '__declspec(dllexport)',
+    dlllocal  => '',
+
     -thirdparty => {
         dc => {
             %TP_DC,
@@ -291,12 +299,21 @@ my %TC_MINGW32 = (
     },
 );
 
+my %TC_CYGWIN = (
+    %TC_GNU,
+
+    dllimport => '__declspec(dllimport)',
+    dllexport => '__declspec(dllexport)',
+    dlllocal  => '',
+);
+
 our %TOOLCHAINS = (
     posix => { %TC_POSIX },
     gnu   => { %TC_GNU },
     bsd   => { %TC_BSD },
     msvc  => { %TC_MSVC },
     mingw32 => { %TC_MINGW32 },
+    cygwin => { %TC_CYGWIN },
 );
 
 # compiler configuration
@@ -449,10 +466,6 @@ my %OS_WIN32 = (
     defs     => [ qw( WIN32 AO_ASSUME_WINDOWS98 ) ],
     syslibs  => [ qw( shell32 ws2_32 mswsock rpcrt4 advapi32 psapi iphlpapi userenv user32 ) ],
     platform => '$(PLATFORM_WIN32)',
-
-    dllimport => '__declspec(dllimport)',
-    dllexport => '__declspec(dllexport)',
-    dlllocal  => '',
 
     translate_newline_output => 1,
 
@@ -608,7 +621,7 @@ our %SYSTEMS = (
     gnukfreebsd => [ qw( posix gnu   gcc ),   { %OS_GNUKFREEBSD } ],
     solaris     => [ qw( posix posix gcc ),   { %OS_SOLARIS } ],
     win32       => [ qw( win32 msvc  cl ),    { %OS_WIN32 } ],
-    cygwin      => [ qw( posix gnu   gcc ),   { %OS_WIN32 } ],
+    cygwin      => [ qw( posix cygwin gcc ),  { %OS_WIN32 } ],
     mingw32     => [ qw( win32 mingw32 gcc ), { %OS_MINGW32 } ],
 );
 

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -200,7 +200,6 @@ my %TC_DARWIN = (
 
     dll => 'lib%s.dylib',
 
-    sharedlib                => 'libmoar.dylib',
     ccshared                 => '',
     ldshared                 => '-dynamiclib',
     moarshared_norelocatable => '-install_name "@prefix@/lib/libmoar.dylib"',

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -287,13 +287,11 @@ our %COMPILERS = (
         ccwarnflags  => '',
         ccoptiflags  => '-O%s -DNDEBUG',
         ccdebugflags => '-g%s',
-        ccinstflags  => '-pg',
         ccjitflags   => '',
 
         ldmiscflags  => '',
         ldoptiflags  => undef,
         lddebugflags => undef,
-        ldinstflags  => undef,
 
         noreturnspecifier => '',
         noreturnattribute => '__attribute__((noreturn))',
@@ -318,13 +316,11 @@ our %COMPILERS = (
         ccwarnflags  => '',
         ccoptiflags  => '-O%s -DNDEBUG',
         ccdebugflags => '-g%s',
-        ccinstflags  => '-pg',
         ccjitflags   => '',
 
         ldmiscflags  => '',
         ldoptiflags  => undef,
         lddebugflags => undef,
-        ldinstflags  => undef,
 
         noreturnspecifier => '',
         noreturnattribute => '__attribute__((noreturn))',
@@ -346,14 +342,12 @@ our %COMPILERS = (
         ccwarnflags  => '-Wno-logical-op-parentheses',
         ccoptiflags  => '-O%s -DNDEBUG',
         ccdebugflags => '-g%s',
-        ccinstflags  => '-fsanitize=address',
         cc_covflags => '-fprofile-instr-generate -fcoverage-mapping',
         ccjitflags   => '',
 
         ldmiscflags  => '',
         ldoptiflags  => undef,
         lddebugflags => undef,
-        ldinstflags  => undef,
         ld_covflags => '-fprofile-instr-generate -fcoverage-mapping',
 
         noreturnspecifier => '',
@@ -377,13 +371,11 @@ our %COMPILERS = (
         ccwarnflags  => '',
         ccoptiflags  => '/Ox /GL /DNDEBUG',
         ccdebugflags => '/Zi',
-        ccinstflags  => '',
         ccjitflags   => '',
 
         ldmiscflags  => '/nologo',
         ldoptiflags  => '/LTCG',
         lddebugflags => '/debug /pdb:$@.pdb',
-        ldinstflags  => '/Profile',
 
         noreturnspecifier => '__declspec(noreturn)',
         noreturnattribute => '',
@@ -406,13 +398,11 @@ our %COMPILERS = (
         ccwarnflags  => '',
         ccoptiflags  => '-O -DNDEBUG',
         ccdebugflags => '-g',
-        ccinstflags  => '',
         ccjitflags   => '',
 
         ldmiscflags  => '',
         ldoptiflags  => undef,
         lddebugflags => undef,
-        ldinstflags  => undef,
 
         noreturnspecifier => '',
         noreturnattribute => '',

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -7,65 +7,65 @@ my $devnull = devnull();
 
 # 3rdparty library configuration
 
-our %TP_LAO = (
+my %TP_LAO = (
     name  => 'atomic_ops',
     path  => '3rdparty/libatomicops/src',
     rule  => 'cd 3rdparty/libatomicops && CC=\'$(CC)\' CFLAGS=\'$(CFLAGS)\' MAKE=\'$(MAKE)\' ./configure @crossconf@ && cd src && $(MAKE) && cd ..',
     clean => 'cd 3rdparty/libatomicops/src && $(MAKE) distclean',
 );
 
-our %TP_SHA = (
+my %TP_SHA = (
     name => 'sha1',
     path => '3rdparty/sha1',
     src  => [ '3rdparty/sha1' ],
 );
 
-our %TP_TOM = (
+my %TP_TOM = (
     name => 'tommath',
     path => '3rdparty/libtommath',
     src  => [ '3rdparty/libtommath' ],
 );
 
-our %TP_MT = (
+my %TP_MT = (
     name => 'tinymt',
     path => '3rdparty/tinymt',
     src  => [ '3rdparty/tinymt' ],
 );
 
-our %TP_DC = (
+my %TP_DC = (
     name  => 'dyncall_s',
     path  => '3rdparty/dyncall/dyncall',
     rule  => 'cd 3rdparty/dyncall &&  ./configure && CC=\'$(CC)\' CFLAGS=\'-fPIC\' $(MAKE) -f Makefile ',
     clean => 'cd 3rdparty/dyncall && $(MAKE) -f Makefile clean',
 );
 
-our %TP_DCB = (
+my %TP_DCB = (
     name  => 'dyncallback_s',
     path  => '3rdparty/dyncall/dyncallback',
     dummy => 1, # created as part of dyncall build
 );
 
-our %TP_DL = (
+my %TP_DL = (
     name  => 'dynload_s',
     path  => '3rdparty/dyncall/dynload',
     dummy => 1, # created as part of dyncall build
 );
 
-our %TP_CMP = (
+my %TP_CMP = (
     name => 'cmp',
     path => '3rdparty/cmp',
     src  => [ '3rdparty/cmp' ],
     clean => 'cd 3rdparty/cmp && $(RM) libcmp.a && $(RM) cmp.lib && $(RM) cmp.obj && $(MAKE) clean'
 );
 
-our %TP_UVDUMMY = (
+my %TP_UVDUMMY = (
     name => 'uv',
     path => '3rdparty/libuv',
     # no default rule
     # building libuv is always OS-specific
 );
 
-our %TP_UV = (
+my %TP_UV = (
     %TP_UVDUMMY,
     rule  => '$(AR) $(ARFLAGS) @arout@$@ $(UV_OBJECTS)',
     clean => '$(RM) @uvlib@ $(UV_OBJECTS)',
@@ -107,7 +107,7 @@ our %SHELLS = (
 # toolchain configuration
 # selected by C<--toolchain>
 
-our %TC_POSIX = (
+my %TC_POSIX = (
     -compiler => 'cc',
 
     make => 'make',
@@ -161,7 +161,7 @@ our %TC_POSIX = (
     -auxfiles => [],
 );
 
-our %TC_GNU = (
+my %TC_GNU = (
     %TC_POSIX,
 
     -compiler => 'gcc',
@@ -180,7 +180,7 @@ TERM
     dlllocal  => '__attribute__ ((visibility ("hidden")))',
 );
 
-our %TC_BSD = (
+my %TC_BSD = (
     %TC_POSIX,
 
     mknoisy => <<'TERM',
@@ -193,7 +193,7 @@ NOERR = 2> @nul@
 TERM
 );
 
-our %TC_MSVC = (
+my %TC_MSVC = (
     -compiler => 'cl',
 
     make => 'nmake',
@@ -417,7 +417,7 @@ our %COMPILERS = (
 # OS configuration
 # selected by C<--os> or taken from C<$^O>
 
-our %OS_WIN32 = (
+my %OS_WIN32 = (
     exe      => '.exe',
     defs     => [ qw( WIN32 AO_ASSUME_WINDOWS98 ) ],
     syslibs  => [ qw( shell32 ws2_32 mswsock rpcrt4 advapi32 psapi iphlpapi userenv user32 ) ],
@@ -440,7 +440,7 @@ our %OS_WIN32 = (
     },
 );
 
-our %OS_MINGW32 = (
+my %OS_MINGW32 = (
     %OS_WIN32,
 
     make => 'gmake',
@@ -471,13 +471,13 @@ our %OS_MINGW32 = (
     },
 );
 
-our %OS_POSIX = (
+my %OS_POSIX = (
     defs     => [ qw( _REENTRANT _FILE_OFFSET_BITS=64 ) ],
     syslibs  => [ qw( m pthread ) ],
     platform => '$(PLATFORM_POSIX)',
 );
 
-our %OS_AIX = (
+my %OS_AIX = (
     %OS_POSIX,
 
     defs                => [ qw( _ALL_SOURCE _XOPEN_SOURCE=500 _LINUX_SOURCE_COMPAT ) ],
@@ -491,7 +491,7 @@ our %OS_AIX = (
     },
 );
 
-our %OS_LINUX = (
+my %OS_LINUX = (
     %OS_POSIX,
 
     syslibs => [ @{$OS_POSIX{syslibs}}, qw( rt dl ) ],
@@ -501,7 +501,7 @@ our %OS_LINUX = (
     },
 );
 
-our %OS_OPENBSD = (
+my %OS_OPENBSD = (
     %OS_POSIX,
 
     syslibs     => [ @{$OS_POSIX{syslibs}}, qw( kvm ) ],
@@ -511,7 +511,7 @@ our %OS_OPENBSD = (
     },
 );
 
-our %OS_NETBSD = (
+my %OS_NETBSD = (
     %OS_POSIX,
 
     syslibs => [ @{$OS_POSIX{syslibs}}, qw( kvm ) ],
@@ -521,7 +521,7 @@ our %OS_NETBSD = (
     },
 );
 
-our %OS_FREEBSD = (
+my %OS_FREEBSD = (
     %OS_POSIX,
 
     cc => (qx!cc -v 2>&1 >$devnull! !~ 'clang') ? 'gcc' : 'clang',
@@ -533,7 +533,7 @@ our %OS_FREEBSD = (
     },
 );
 
-our %OS_DRAGONFLY = (
+my %OS_DRAGONFLY = (
     %OS_POSIX,
 
     syslibs => [ @{$OS_POSIX{syslibs}}, qw( kvm ) ],
@@ -543,13 +543,13 @@ our %OS_DRAGONFLY = (
     },
 );
 
-our %OS_GNUKFREEBSD = (
+my %OS_GNUKFREEBSD = (
     %OS_FREEBSD,
 
     syslibs => [ @{$OS_FREEBSD{syslibs}}, qw( rt dl ) ],
 );
 
-our %OS_SOLARIS = (
+my %OS_SOLARIS = (
     %OS_POSIX,
 
     defs     => [ qw( _XOPEN_SOURCE=500 _XOPEN_SOURCE_EXTENDED=1  __EXTENSIONS__=1 _POSIX_PTHREAD_SEMANTICS _REENTRANT ) ],
@@ -565,7 +565,7 @@ our %OS_SOLARIS = (
     },
 );
 
-our %OS_DARWIN = (
+my %OS_DARWIN = (
     %OS_POSIX,
 
     defs     => [ qw( _DARWIN_USE_64_BIT_INODE=1 ) ],

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -312,12 +312,14 @@ our %COMPILERS = (
 
         cc => 'icc',
         ld => undef,
+        as => 'as',
 
         ccmiscflags  => '-Werror=declaration-after-statement -Werror=pointer-arith -wd858 -fp-model precise -fp-model source',
         ccwarnflags  => '',
         ccoptiflags  => '-O%s -DNDEBUG',
         ccdebugflags => '-g%s',
         ccinstflags  => '-pg',
+        ccjitflags   => '',
 
         ldmiscflags  => '',
         ldoptiflags  => undef,

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -193,6 +193,21 @@ NOERR = 2> @nul@
 TERM
 );
 
+my %TC_DARWIN = (
+    %TC_GNU,
+
+    -compiler => 'clang',
+
+    dll => 'lib%s.dylib',
+
+    sharedlib                => 'libmoar.dylib',
+    ccshared                 => '',
+    ldshared                 => '-dynamiclib',
+    moarshared_norelocatable => '-install_name "@prefix@/lib/libmoar.dylib"',
+    moarshared_relocatable   => '-install_name @rpath/libmoar.dylib',
+    ldrpath_relocatable      => '-Wl,-rpath,@executable_path/../lib',
+);
+
 my %TC_MSVC = (
     -compiler => 'cl',
 
@@ -311,6 +326,7 @@ our %TOOLCHAINS = (
     posix => { %TC_POSIX },
     gnu   => { %TC_GNU },
     bsd   => { %TC_BSD },
+    darwin => { %TC_DARWIN },
     msvc  => { %TC_MSVC },
     mingw32 => { %TC_MINGW32 },
     cygwin => { %TC_CYGWIN },
@@ -595,15 +611,6 @@ my %OS_DARWIN = (
     syslibs  => [],
     usrlibs  => [ qw( pthread ) ],
 
-    dll => 'lib%s.dylib',
-
-    sharedlib                => 'libmoar.dylib',
-    ccshared                 => '',
-    ldshared                 => '-dynamiclib',
-    moarshared_norelocatable => '-install_name "@prefix@/lib/libmoar.dylib"',
-    moarshared_relocatable   => '-install_name @rpath/libmoar.dylib',
-    ldrpath_relocatable      => '-Wl,-rpath,@executable_path/../lib',
-
     -thirdparty => {
         uv => { %TP_UVDUMMY, objects => '$(UV_DARWIN)' },
     },
@@ -613,7 +620,7 @@ our %SYSTEMS = (
     posix       => [ qw( posix posix cc ),    { %OS_POSIX } ],
     linux       => [ qw( posix gnu   gcc ),   { %OS_LINUX } ],
     aix         => [ qw( posix gnu   gcc ),   { %OS_AIX } ],
-    darwin      => [ qw( posix gnu   clang ), { %OS_DARWIN } ],
+    darwin      => [ qw( posix darwin clang ), { %OS_DARWIN } ],
     openbsd     => [ qw( posix bsd   clang ),   { %OS_OPENBSD} ],
     netbsd      => [ qw( posix bsd   gcc ),   { %OS_NETBSD } ],
     dragonfly   => [ qw( posix bsd   gcc ),   { %OS_DRAGONFLY } ],


### PR DESCRIPTION
Currently MoarVM doesn't build on AIX, and doesn't build well on Solaris. Fixing this requires changing some of the structure of how the build system does probes. Hence...

As a first step, these changes attempt to tidy up how we split the overrides between *OS*, *toolchain* and *compiler* such that any override is consistently used at exactly one level. By locally editing the code to disable some sanity checks I can "run" `Configure.pl` for any OS and confirm whether the generated files have any (unintended) changes. I believe on this branch

1. `./Configure` without parameters will generate the same Makefile *etc* as on master
2. `./Configure` with sensible `--toolchain` or `--compiler` options will still work (ie as we permit all combinations, nonsense like "MSVC on AIX" still won't work, but will likely break with a different error message)

CI will check (default) macOS and WIn32. I can check most *nix. Nothing seems to check Mingw32, but I don't think that that is at risk of being broken by these changes.

I see that @manchicken fixed the rakubrew build recently. I don't want to break this. Am I right in thinking that the configurations that need to work for it are

1. `./Configure.pl`
2. `./Configure.pl --toolchain=gnu`

(with --os=darwin set automatically)? I can't find this documented anywhere, but I might have missed something.