### PR TITLE
Fix a bunch of memory leaks

### DIFF
--- a/src/6model/6model.c
+++ b/src/6model/6model.c
@@ -332,6 +332,10 @@ static void mark_sr_data(MVMThreadContext *tc, MVMFrame *frame, MVMGCWorklist *w
     MVM_gc_worklist_add(tc, worklist, &atd->type);
 }
 
+static void free_sr_data(MVMThreadContext *tc, void *sr_data) {
+    MVM_free(sr_data);
+}
+
 void MVM_6model_istype(MVMThreadContext *tc, MVMObject *obj, MVMObject *type, MVMRegister *res) {
     MVMObject **cache;
     MVMSTable  *st;
@@ -390,7 +394,7 @@ void MVM_6model_istype(MVMThreadContext *tc, MVMObject *obj, MVMObject *type, MV
                 atd->obj = obj;
                 atd->type = type;
                 atd->res = res;
-                MVM_frame_special_return(tc, tc->cur_frame, accepts_type_sr, NULL,
+                MVM_frame_special_return(tc, tc->cur_frame, accepts_type_sr, free_sr_data,
                     atd, mark_sr_data);
             }
             STABLE(code)->invoke(tc, code, typecheck_callsite, tc->cur_frame->args);

--- a/src/6model/6model.c
+++ b/src/6model/6model.c
@@ -61,6 +61,9 @@ static void die_over_missing_method(MVMThreadContext *tc, MVMObject *obj, MVMStr
             c_name, MVM_6model_get_debug_name(tc, obj));
     }
 }
+static void find_method_unwind(MVMThreadContext *tc, void *sr_data) {
+    MVM_free(sr_data);
+}
 static void late_bound_find_method_return(MVMThreadContext *tc, void *sr_data) {
     FindMethodSRData *fm = (FindMethodSRData *)sr_data;
     if (MVM_is_null(tc, fm->res->o) || !IS_CONCRETE(fm->res->o)) {
@@ -157,7 +160,7 @@ void MVM_6model_find_method(MVMThreadContext *tc, MVMObject *obj, MVMString *nam
         fm->res  = res;
         fm->throw_if_not_found = throw_if_not_found;
         MVM_frame_special_return(tc, tc->cur_frame, late_bound_find_method_return,
-            NULL, fm, mark_find_method_sr_data);
+            find_method_unwind, fm, mark_find_method_sr_data);
     }
     tc->cur_frame->args[0].o = HOW;
     tc->cur_frame->args[1].o = obj;

--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -384,6 +384,8 @@ static const MVMContainerSpec value_desc_cont_spec = {
 };
 
 static void value_desc_cont_set_container_spec(MVMThreadContext *tc, MVMSTable *st) {
+    if (st->container_data)
+        value_desc_cont_gc_free_data(tc, st);
     MVMValueDescContainer *data = MVM_calloc(1, sizeof(MVMValueDescContainer));
     st->container_data = data;
     st->container_spec = &value_desc_cont_spec;

--- a/src/6model/parametric.c
+++ b/src/6model/parametric.c
@@ -84,6 +84,9 @@ static void mark_parameterize_sr_data(MVMThreadContext *tc, MVMFrame *frame, MVM
     MVM_gc_worklist_add(tc, worklist, &(prd->parametric_type));
     MVM_gc_worklist_add(tc, worklist, &(prd->parameters));
 }
+static void free_parameterize_sr_data(MVMThreadContext *tc, void *sr_data) {
+    MVM_free(sr_data);
+}
 void MVM_6model_parametric_parameterize(MVMThreadContext *tc, MVMObject *type, MVMObject *params,
                                         MVMRegister *result) {
     ParameterizeReturnData *prd;
@@ -107,7 +110,7 @@ void MVM_6model_parametric_parameterize(MVMThreadContext *tc, MVMObject *type, M
     prd->parametric_type                    = type;
     prd->parameters                         = params;
     prd->result                             = result;
-    MVM_frame_special_return(tc, tc->cur_frame, finish_parameterizing, NULL,
+    MVM_frame_special_return(tc, tc->cur_frame, finish_parameterizing, free_parameterize_sr_data,
         prd, mark_parameterize_sr_data);
     MVM_args_setup_thunk(tc, result, MVM_RETURN_OBJ, MVM_callsite_get_common(tc, MVM_CALLSITE_ID_TWO_OBJ));
     tc->cur_frame->args[0].o = st->WHAT;

--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -189,6 +189,7 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVM_free(body->local_types);
     MVM_free(body->lexical_types);
     MVM_free(body->lexical_names_list);
+    MVM_free(body->instrumentation);
     MVM_index_hash_demolish(tc, &body->lexical_names);
 }
 

--- a/src/6model/sc.c
+++ b/src/6model/sc.c
@@ -91,6 +91,15 @@ void MVM_sc_add_all_scs_entry(MVMThreadContext *tc, MVMSerializationContextBody 
     tc->instance->all_scs_next_idx++;
 }
 
+void MVM_sc_all_scs_destroy(MVMThreadContext *tc) {
+    MVM_fixed_size_free(
+        tc,
+        tc->instance->fsa,
+        tc->instance->all_scs_alloc * sizeof(MVMSerializationContextBody *),
+        tc->instance->all_scs
+    );
+}
+
 /* Given an SC, returns its unique handle. */
 MVMString * MVM_sc_get_handle(MVMThreadContext *tc, MVMSerializationContext *sc) {
     return sc->body->handle;

--- a/src/6model/sc.h
+++ b/src/6model/sc.h
@@ -1,6 +1,7 @@
 /* SC manipulation functions. */
 MVMObject * MVM_sc_create(MVMThreadContext *tc, MVMString *handle);
 void MVM_sc_add_all_scs_entry(MVMThreadContext *tc, MVMSerializationContextBody *scb);
+void MVM_sc_all_scs_destroy(MVMThreadContext *tc);
 MVMString * MVM_sc_get_handle(MVMThreadContext *tc, MVMSerializationContext *sc);
 MVMString * MVM_sc_get_description(MVMThreadContext *tc, MVMSerializationContext *sc);
 void MVM_sc_set_description(MVMThreadContext *tc, MVMSerializationContext *sc, MVMString *desc);

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -26,6 +26,9 @@ MVMint64 MVM_coerce_istrue_s(MVMThreadContext *tc, MVMString *str) {
  * next instruction before this is called. */
 static void boolify_return(MVMThreadContext *tc, void *sr_data);
 static void flip_return(MVMThreadContext *tc, void *sr_data);
+static void free_boolify_return_data(MVMThreadContext *tc, void *sr_data) {
+    MVM_free(sr_data);
+}
 void MVM_coerce_istrue(MVMThreadContext *tc, MVMObject *obj, MVMRegister *res_reg,
         MVMuint8 *true_addr, MVMuint8 *false_addr, MVMuint8 flip) {
     MVMint64 result = 0;
@@ -53,7 +56,7 @@ void MVM_coerce_istrue(MVMThreadContext *tc, MVMObject *obj, MVMRegister *res_re
                     data->true_addr  = true_addr;
                     data->false_addr = false_addr;
                     data->flip       = flip;
-                    MVM_frame_special_return(tc, tc->cur_frame, boolify_return, NULL, data, NULL);
+                    MVM_frame_special_return(tc, tc->cur_frame, boolify_return, free_boolify_return_data, data, NULL);
                     MVM_args_setup_thunk(tc, &data->res_reg, MVM_RETURN_INT, inv_arg_callsite);
                     tc->cur_frame->args[0].o = obj;
                     STABLE(code)->invoke(tc, code, inv_arg_callsite, tc->cur_frame->args);

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1076,6 +1076,9 @@ static void continue_unwind(MVMThreadContext *tc, void *sr_data) {
     MVM_free(sr_data);
     MVM_frame_unwind_to(tc, frame, abs_addr, rel_addr, NULL, jit_return_label);
 }
+static void free_unwind_data(MVMThreadContext *tc, void *sr_data) {
+    MVM_free(sr_data);
+}
 void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_addr,
                          MVMuint32 rel_addr, MVMObject *return_value, void *jit_return_label) {
     while (tc->cur_frame != frame) {
@@ -1117,7 +1120,7 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
                 ud->abs_addr = abs_addr;
                 ud->rel_addr = rel_addr;
                 ud->jit_return_label = jit_return_label;
-                MVM_frame_special_return(tc, cur_frame, continue_unwind, NULL, ud,
+                MVM_frame_special_return(tc, cur_frame, continue_unwind, free_unwind_data, ud,
                     mark_unwind_data);
             }
             cur_frame->flags |= MVM_FRAME_FLAG_EXIT_HAND_RUN;

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -82,6 +82,14 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
 void MVM_tc_destroy(MVMThreadContext *tc) {
     MVMint32 i;
 
+    /* If an exception handler calls nqp::exit, we don't unwind the stack and
+     * exception handlers aren't cleaned up yet */
+    while (tc->active_handlers) {
+        MVMActiveHandler *ah = tc->active_handlers;
+        tc->active_handlers = ah->next_handler;
+        MVM_free(ah);
+    }
+
     /* Free the native callback cache. Needs the fixed size allocator. */
     /* (currently not. but might if MVMStrHash moves internally to the FSA.) */
     MVM_str_hash_demolish(tc, &tc->native_callback_cache);

--- a/src/core/vector.h
+++ b/src/core/vector.h
@@ -36,9 +36,9 @@
 
 #define MVM_VECTOR_GROW(x, size) do {\
         size_t _s = (size); \
-        x = MVM_realloc(x, _s*sizeof(*x));   \
-        memset(x + (x ## _alloc), 0, (_s - (x ## _alloc)) * sizeof(*x)); \
-        x ## _alloc = _s; \
+        (x) = MVM_realloc(x, _s*sizeof(*x));   \
+        memset((x) + (x ## _alloc), 0, (_s - (x ## _alloc)) * sizeof(*(x))); \
+        (x ## _alloc) = _s; \
     } while (0)
 
 
@@ -56,7 +56,7 @@
 
 #define MVM_VECTOR_PUSH(x, value) do { \
         MVM_VECTOR_ENSURE_SPACE(x, 1); \
-        x[x ## _num++] = (value); \
+        (x)[(x ## _num)++] = (value); \
     } while(0)
 
 #define MVM_VECTOR_POP(x) \
@@ -66,20 +66,20 @@
 #define MVM_VECTOR_APPEND(x, ar, len) do { \
         size_t _l = (len); \
         MVM_VECTOR_ENSURE_SPACE(x, _l); \
-        memcpy(MVM_VECTOR_TOP(x), ar, _l * sizeof(x[0])); \
-        x ## _num += _l; \
+        memcpy(MVM_VECTOR_TOP(x), ar, _l * sizeof((x)[0])); \
+        (x ## _num) += _l; \
     } while(0)
 
 #define MVM_VECTOR_SPLICE(x, ofs, len, out) do { \
         size_t _l = (len), _o = (ofs); \
         void * buf = (out); \
-        if (buf != NULL) { memcpy(buf, (x) + _o, _l * sizeof(x[0])); } \
-        memmove((x) + _o, (x) + _o + _l, ((x ## _num) - _l - _o) * sizeof(x[0])); \
-        x ## _num -= _l; \
+        if (buf != NULL) { memcpy(buf, (x) + _o, _l * sizeof((x)[0])); } \
+        memmove((x) + _o, (x) + _o + _l, ((x ## _num) - _l - _o) * sizeof((x)[0])); \
+        (x ## _num) -= _l; \
     } while (0)
 
 #define MVM_VECTOR_ASSIGN(a, b) do { \
-        a = b; \
-        a ## _alloc = b ## _alloc; \
-        a ## _num = b ## _num; \
+        (a) = (b); \
+        (a ## _alloc) = (b ## _alloc); \
+        (a ## _num) = (b ## _num); \
     } while (0)

--- a/src/instrument/crossthreadwrite.c
+++ b/src/instrument/crossthreadwrite.c
@@ -129,6 +129,8 @@ void MVM_cross_thread_write_instrument(MVMThreadContext *tc, MVMStaticFrame *sf)
         if (!sf->body.instrumentation)
             add_instrumentation(tc, sf);
         sf->body.bytecode      = sf->body.instrumentation->instrumented_bytecode;
+        if (sf->body.handlers)
+            MVM_free(sf->body.handlers);
         sf->body.handlers      = sf->body.instrumentation->instrumented_handlers;
         sf->body.bytecode_size = sf->body.instrumentation->instrumented_bytecode_size;
 

--- a/src/instrument/line_coverage.c
+++ b/src/instrument/line_coverage.c
@@ -284,6 +284,8 @@ static void line_numbers_instrument(MVMThreadContext *tc, MVMStaticFrame *sf, MV
         if (!sf->body.instrumentation || !sf->body.instrumentation->instrumented_bytecode)
             add_instrumentation(tc, sf, want_coverage);
         sf->body.bytecode      = sf->body.instrumentation->instrumented_bytecode;
+        if (sf->body.handlers)
+            MVM_free(sf->body.handlers);
         sf->body.handlers      = sf->body.instrumentation->instrumented_handlers;
         sf->body.bytecode_size = sf->body.instrumentation->instrumented_bytecode_size;
 

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -359,6 +359,11 @@ static void proc_async_gc_mark(MVMThreadContext *tc, void *data, MVMGCWorklist *
         MVM_gc_worklist_add(tc, worklist, &(apd->async_task));
 }
 
+static void proc_async_gc_free(MVMThreadContext *tc, MVMObject *root, void *data) {
+    if (data)
+        MVM_free(data);
+}
+
 /* Does an asynchronous close (since it must run on the event loop). */
 static void close_cb(uv_handle_t *handle) {
     MVM_free(handle);
@@ -457,7 +462,7 @@ static const MVMIOOps proc_op_table = {
     NULL,
     NULL,
     proc_async_gc_mark,
-    NULL
+    proc_async_gc_free
 };
 
 static void spawn_async_close(uv_handle_t *handle) {

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -944,6 +944,9 @@ static void spawn_gc_mark(MVMThreadContext *tc, void *data, MVMGCWorklist *workl
 static void spawn_gc_free(MVMThreadContext *tc, MVMObject *t, void *data) {
     if (data) {
         SpawnInfo *si = (SpawnInfo *)data;
+        if (si->prog) {
+            MVM_free_null(si->prog);
+        }
         if (si->cwd) {
             MVM_free_null(si->cwd);
         }

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -967,6 +967,12 @@ static void spawn_gc_free(MVMThreadContext *tc, MVMObject *t, void *data) {
                 MVM_free(si->args[i++]);
             MVM_free_null(si->args);
         }
+        if (si->pipe_stdout) {
+            MVM_free_null(si->pipe_stdout);
+        }
+        if (si->pipe_stderr) {
+            MVM_free_null(si->pipe_stderr);
+        }
         MVM_free(si);
     }
 }

--- a/src/moar.c
+++ b/src/moar.c
@@ -649,6 +649,7 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     MVM_gc_global_destruction(instance->main_thread);
 
     MVM_ptr_hash_demolish(instance->main_thread, &instance->object_ids);
+    MVM_sc_all_scs_destroy(instance->main_thread);
 
     /* Cleanup REPR registry */
     uv_mutex_destroy(&instance->mutex_repr_registry);

--- a/src/moar.c
+++ b/src/moar.c
@@ -648,6 +648,8 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
      * no 6model object pointers should be accessed. */
     MVM_gc_global_destruction(instance->main_thread);
 
+    MVM_ptr_hash_demolish(instance->main_thread, &instance->object_ids);
+
     /* Cleanup REPR registry */
     uv_mutex_destroy(&instance->mutex_repr_registry);
     MVM_index_hash_demolish(instance->main_thread, &instance->repr_hash);

--- a/src/moar.c
+++ b/src/moar.c
@@ -644,6 +644,8 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     /* Run the normal GC one more time to actually collect the spesh thread */
     MVM_gc_enter_from_allocator(instance->main_thread);
 
+    MVM_profile_instrumented_free_data(instance->main_thread);
+
     /* Run the GC global destruction phase. After this,
      * no 6model object pointers should be accessed. */
     MVM_gc_global_destruction(instance->main_thread);

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -890,8 +890,23 @@ void serialize_attribute_stream(MVMThreadContext *tc, MVMHeapSnapshotCollection 
     }
 
     {
-        char namebuf[8] = {0};
-        memcpy(namebuf, name, 8);
+        char namebuf[8];
+        /* Yes, this is a lot of boiler plate to silence a bogus warning :(
+         * Unfortunately, this is a real edge case. Using memcpy would lead to
+         * a buffer overflow if name is shorter than 8 bytes. The compiler
+         * warning aside, strncpy seems like exactly the right tool for the job
+         * as we want at most 8 bytes and don't care for any trailing \0, but
+         * are OK with zero padding at the end. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+        strncpy(namebuf, name, 8);
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
         fwrite(namebuf, 8, 1, fh);
     }
 

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -798,9 +798,20 @@ static void record_snapshot(MVMThreadContext *tc, MVMHeapSnapshotCollection *col
 static void destroy_current_heap_snapshot(MVMThreadContext *tc) {
     MVMHeapSnapshotCollection *col = tc->instance->heap_snapshots;
 
+    MVM_free(col->snapshot->stats->type_counts);
+    MVM_free(col->snapshot->stats->type_size_sum);
+    MVM_free(col->snapshot->stats->sf_counts);
+    MVM_free(col->snapshot->stats->sf_size_sum);
+    MVM_free(col->snapshot->stats);
     MVM_free(col->snapshot->collectables);
     MVM_free(col->snapshot->references);
     MVM_free_null(col->snapshot);
+}
+
+static void destroy_toc(MVMHeapDumpTableOfContents *toc) {
+    MVM_free(toc->toc_words);
+    MVM_free(toc->toc_positions);
+    MVM_free(toc);
 }
 
 /* Frees all memory associated with the heap snapshot. */
@@ -818,9 +829,9 @@ static void destroy_heap_snapshot_collection(MVMThreadContext *tc) {
     MVM_free(col->static_frames);
 
 #if MVM_HEAPSNAPSHOT_FORMAT == 3
-    MVM_free(col->toplevel_toc);
+    destroy_toc(col->toplevel_toc);
     if (col->second_level_toc)
-        MVM_free(col->second_level_toc);
+        destroy_toc(col->second_level_toc);
 #elif MVM_HEAPSNAPSHOT_FORMAT == 2
     MVM_free(col->index->snapshot_sizes);
     MVM_free(col->index);

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -370,8 +370,13 @@ static void set_static_frame_index(MVMThreadContext *tc, MVMHeapSnapshotState *s
        heap by MVM_cu_string, it will have been allocated in gen2 directly, but not
        marked as live for this gc run. Do it here to prevent it from getting freed
        after taking this heap snapshot, while it's actually still referenced from the
-       comp unit's strings list */
-    if (file_name && file_name->common.header.flags2 & MVM_CF_SECOND_GEN)
+       comp unit's strings list. But only do so if we're actually collecting gen2
+       in this run. Otherwise the flag may still be set during global destruction. */
+    if (
+        tc->instance->gc_full_collect
+        && file_name
+        && file_name->common.header.flags2 & MVM_CF_SECOND_GEN
+    )
         file_name->common.header.flags2 |= MVM_CF_GEN2_LIVE;
 
     MVMuint64 file_idx = get_vm_string_index(tc, ss, file_name);

--- a/src/profiler/instrument.c
+++ b/src/profiler/instrument.c
@@ -342,6 +342,8 @@ void MVM_profile_instrument(MVMThreadContext *tc, MVMStaticFrame *sf) {
         if (!sf->body.instrumentation)
             add_instrumentation(tc, sf);
         sf->body.bytecode      = sf->body.instrumentation->instrumented_bytecode;
+        if (sf->body.handlers)
+            MVM_free(sf->body.handlers);
         sf->body.handlers      = sf->body.instrumentation->instrumented_handlers;
         sf->body.bytecode_size = sf->body.instrumentation->instrumented_bytecode_size;
 

--- a/src/profiler/instrument.c
+++ b/src/profiler/instrument.c
@@ -939,6 +939,55 @@ void MVM_profile_instrumented_mark_data(MVMThreadContext *tc, MVMGCWorklist *wor
     }
 }
 
+static void MVM_profile_free_nodes(MVMThreadContext *tc, MVMProfileCallNode *node, MVMProfileCallNode ***seen, size_t *seen_num, size_t *seen_alloc) {
+    for (MVMuint32 i = 0; i < node->num_succ; i++) {
+        int found = 0;
+        for (size_t j = 0; j < *seen_num; j++)
+            if (node->succ[i] == (*seen)[j]) {
+                found = 1;
+                break;
+            }
+        if (!found) {
+            MVM_VECTOR_PUSH(*seen, node->succ[i]);
+            MVM_profile_free_nodes(tc, node->succ[i], seen, seen_num, seen_alloc);
+        }
+    }
+    MVM_free(node->succ);
+    MVM_free(node);
+}
+
+void MVM_profile_free_node(MVMThreadContext *tc, MVMProfileCallNode *node) {
+    MVM_VECTOR_DECL(MVMProfileCallNode*, nodes);
+    MVM_VECTOR_INIT(nodes, 0);
+
+    MVM_profile_free_nodes(tc, node, &nodes, &nodes_num, &nodes_alloc);
+
+    MVM_VECTOR_DESTROY(nodes);
+}
+
+void MVM_profile_instrumented_free_data(MVMThreadContext *tc) {
+    if (tc->prof_data) {
+        MVMProfileThreadData *ptd = tc->prof_data;
+        MVMProfileCallNode *node = ptd->call_graph;
+
+        if (node)
+            MVM_profile_free_node(tc, node);
+
+        MVM_VECTOR_DESTROY(ptd->staticframe_array);
+        MVM_VECTOR_DESTROY(ptd->type_array);
+        for (MVMuint32 i = 0; i < ptd->num_gcs; i++)
+            MVM_fixed_size_free(
+                tc,
+                tc->instance->fsa,
+                ptd->gcs[i].alloc_dealloc * sizeof(MVMProfileDeallocationCount),
+                ptd->gcs[i].deallocs
+            );
+        MVM_free(ptd->gcs);
+        MVM_free(ptd);
+        tc->prof_data = NULL;
+    }
+}
+
 static void dump_callgraph_node(MVMThreadContext *tc, MVMProfileCallNode *n, MVMuint16 depth) {
     MVMuint16 dc = depth;
     MVMuint32 idx;

--- a/src/profiler/instrument.h
+++ b/src/profiler/instrument.h
@@ -3,4 +3,6 @@ void MVM_profile_instrument(MVMThreadContext *tc, MVMStaticFrame *sf);
 void MVM_profile_ensure_uninstrumented(MVMThreadContext *tc, MVMStaticFrame *sf);
 void MVM_profile_instrumented_start(MVMThreadContext *tc, MVMObject *config);
 MVMObject * MVM_profile_instrumented_end(MVMThreadContext *tc);
+void MVM_profile_free_node(MVMThreadContext *tc, MVMProfileCallNode *node);
+void MVM_profile_instrumented_free_data(MVMThreadContext *tc);
 void MVM_profile_instrumented_mark_data(MVMThreadContext *tc, MVMGCWorklist *worklist);

--- a/src/profiler/profile.c
+++ b/src/profiler/profile.c
@@ -15,10 +15,15 @@ void MVM_profile_start(MVMThreadContext *tc, MVMObject *config) {
 
             /* Call the profiling functions a bunch of times and record how long they took. */
             s = uv_hrtime();
-            for (i = 0; i < 1000; i++) {
+            /* Need an intitial frame for the call_graph as the profiler assumes sensibly that
+             * there's only 1 top level frame. Otherwise we'd leak all frames but the very
+             * first */
+            MVM_profile_log_enter(tc, tc->cur_frame->static_info, MVM_PROFILE_ENTER_NORMAL);
+            for (i = 1; i < 1000; i++) {
                 MVM_profile_log_enter(tc, tc->cur_frame->static_info, MVM_PROFILE_ENTER_NORMAL);
                 MVM_profile_log_exit(tc);
             }
+            MVM_profile_log_exit(tc);
             e = uv_hrtime();
             tc->instance->profiling_overhead = (MVMuint64) ((e - s) / 1000) * 0.9;
 
@@ -28,11 +33,14 @@ void MVM_profile_start(MVMThreadContext *tc, MVMObject *config) {
                 uv_cond_wait(&(tc->instance->cond_spesh_sync), &(tc->instance->mutex_spesh_sync));
             tc->instance->profiling = 0;
             MVM_free_null(tc->prof_data->collected_data);
-            MVM_free_null(tc->prof_data);
+
+            MVM_profile_instrumented_free_data(tc);
+
             uv_mutex_unlock(&(tc->instance->mutex_spesh_sync));
 
             /* Now start profiling for real. */
             MVM_profile_instrumented_start(tc, config);
+            MVM_profile_log_enter(tc, tc->cur_frame->static_info, MVM_PROFILE_ENTER_NORMAL);
         }
         else if (MVM_string_equal(tc, kind, tc->instance->str_consts.heap))
             MVM_profile_heap_start(tc, config);
@@ -48,8 +56,10 @@ void MVM_profile_start(MVMThreadContext *tc, MVMObject *config) {
 
 /* Ends profiling and returns the result data structure. */
 MVMObject * MVM_profile_end(MVMThreadContext *tc) {
-    if (tc->instance->profiling)
+    if (tc->instance->profiling) {
+        MVM_profile_log_exit(tc);
         return MVM_profile_instrumented_end(tc);
+    }
     else if (MVM_profile_heap_profiling(tc))
         return MVM_profile_heap_end(tc);
     else

--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -1488,6 +1488,8 @@ void MVM_spesh_graph_destroy(MVMThreadContext *tc, MVMSpeshGraph *g) {
         MVM_free(g->local_types);
     if (g->lexical_types &&  (!g->cand || g->cand->lexical_types != g->lexical_types))
         MVM_free(g->lexical_types);
+    if (!g->cand)
+        MVM_spesh_pea_destroy_deopt_info(tc, &(g->deopt_pea));
 
     /* Handlers can come directly from static frame, from spesh candidate, and
      * from malloc/realloc. We only free it in the last case */

--- a/src/spesh/stats.c
+++ b/src/spesh/stats.c
@@ -488,6 +488,10 @@ static void save_or_free_sim_stack(MVMThreadContext *tc, MVMSpeshSimStack *sims,
     if (first_survivor >= 0) {
         /* Move survivors to the start. */
         if (first_survivor > 0) {
+            for (i = 0; i < (MVMuint32)first_survivor; i++) {
+                MVM_free(sims->frames[i].offset_logs);
+                MVM_free(sims->frames[i].call_type_info);
+            }
             sims->used -= first_survivor;
             memmove(sims->frames, sims->frames + first_survivor,
                 sims->used * sizeof(MVMSpeshSimStackFrame));

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -912,6 +912,7 @@ MVMint64 MVM_unicode_name_to_property_code(MVMThreadContext *tc, MVMString *name
         generate_property_codes_by_names_aliases(tc);
     }
     struct MVMUniHashEntry *result = MVM_uni_hash_fetch(tc, &property_codes_by_names_aliases, cname);
+    MVM_free(cname);
     return result ? result->value : 0;
 }
 


### PR DESCRIPTION
This PR contains fixes to assortment of memory leaks uncovered by ASAN. This covers all individual leaks that occur during a make test or make spectest but not those that need architectural changes like the whole NativeCall memory management situation, cleanup of background threads or cleanup when exceptions occur deep in the call stack.

The commits starting with "Fix ..." fix leaks that occur during a normal run of programs, i.e. these leaks make programs grow over time. The additional commits improve cleanup for runs with --full-cleanup, i.e. reduce "false" positives reported by ASAN. Proper cleanup may also help for embedding situations, so those are not purely theoretical either.

Note that this branch by itself is not enough to be able to simply run make test or make spectest and find new memory leaks. For that one needs additional patches to the build system to enable --full-cleanup everywhere and patches for proper thread cleanup. The latter are not ready yet for review and may need complete re-thinking before committing to them. If desired, I can make available these local patches. After all they have been good enough to facilitate developing these 19 memory leak fixes.