### PR TITLE
Fix segfault caused by mis-spesh of unbox of Num type objects

### DIFF
--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -1948,7 +1948,7 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
                     target_facts->flags |= MVM_SPESH_FACT_KNOWN_VALUE;
                     target_facts->value.i = value;
                 }
-                else {
+                else if (facts->flags & MVM_SPESH_FACT_CONCRETE) {
                     MVMSpeshOperand *orig_operands = ins->operands;
                     MVM_spesh_graph_add_comment(tc, g, ins, "%s a %s",
                         ins->info->name, MVM_6model_get_stable_debug_name(tc, st));
@@ -1977,11 +1977,11 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
                     target_facts->flags |= MVM_SPESH_FACT_KNOWN_VALUE;
                     target_facts->value.n = result;
                 }
-                else {
+                else if (facts->flags & MVM_SPESH_FACT_CONCRETE) {
                     MVMSpeshOperand *orig_operands = ins->operands;
-                    ins->info = MVM_op_get_op(MVM_OP_sp_p6oget_n);
                     MVM_spesh_graph_add_comment(tc, g, ins, "%s a %s",
                         ins->info->name, MVM_6model_get_stable_debug_name(tc, st));
+                    ins->info = MVM_op_get_op(MVM_OP_sp_p6oget_n);
                     ins->operands = MVM_spesh_alloc(tc, g, 3 * sizeof(MVMSpeshOperand));
                     ins->operands[0] = orig_operands[0];
                     ins->operands[1] = orig_operands[1];
@@ -2006,7 +2006,7 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
                     target_facts->flags |= MVM_SPESH_FACT_KNOWN_VALUE;
                     target_facts->value.s = result;
                 }
-                else {
+                else if (facts->flags & MVM_SPESH_FACT_CONCRETE) {
                     MVMSpeshOperand *orig_operands = ins->operands;
                     MVM_spesh_graph_add_comment(tc, g, ins, "%s a %s",
                         ins->info->name, MVM_6model_get_stable_debug_name(tc, st));

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1278,6 +1278,8 @@ static void optimize_istrue_isfalse(MVMThreadContext *tc, MVMSpeshGraph *g, MVMS
             optimize_isconcrete(tc, g, ins);
             break;
         case MVM_BOOL_MODE_UNBOX_NUM: {
+            if (!guaranteed_concrete)
+                return;
             /* Unbox it into a temporary number register. */
             MVMSpeshOperand temp = MVM_spesh_manipulate_get_temp_reg(tc, g, MVM_reg_num64);
             MVMSpeshIns *unbox_ins = MVM_spesh_alloc(tc, g, sizeof(MVMSpeshIns));


### PR DESCRIPTION
We missed a check for concreteness in optimize_istrue_isfalse causing us to
"optimize" an unbox of a Num type object to MVM_OP_sp_p6oget_n which doesn't
cope with type objects for sub t($num) { $num ?? 1 !! 0 }; loop { t(Num) }

Fix by making the optimization depend on guaranteed_concrete, same as we
already do for integers. For added saftey require MVM_SPESH_FACT_CONCRETE when
speshing unbox operations of any kind on P6opaque.