### PR TITLE
Avoid segfaults caused by repossessed native call sites

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -1196,5 +1196,7 @@ void MVM_nativecall_invoke_jit(MVMThreadContext *tc, MVMObject *site) {
     }
 
     MVMJitCode * const jitcode = body->jitcode;
+    assert(jitcode);
+    assert(jitcode->func_ptr);
     jitcode->func_ptr(tc, *tc->interp_cu, jitcode->labels[0]);
 }

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -529,6 +529,11 @@ static MVMint32 consume_invoke(MVMThreadContext *tc, MVMJitGraph *jg,
 
             body = MVM_nativecall_get_nc_body(tc, object_facts->value.o);
             nc_jg = MVM_nativecall_jit_graph_for_caller_code(tc, iter->graph, body, restype, dst, arg_ins);
+            /* Check the entry_point after we've used it to generate the code to avoid a race
+             * condition where the check turned out fine, but entry_point got overwritten before we
+             * got to use it for generating the code. */
+            if (!body->entry_point)
+                return 0;
             if (nc_jg == NULL)
                 return 0;
 


### PR DESCRIPTION
We deserialize a native call site. Then we call the function which triggers the
actual setup, i.e. resolving the library name, loading the library, generating
caller code. We run the function often enough that spesh decides its worth its
time. While spesh is working however, we deserialize the module again and as
part of the repossession process clear the native call site's body. I.e.
body->entry_point becomes NULL. This causes us to compile a jump to 0.

The real fix for this is to avoid repossession of the native call site in the
first place. In case the HLL layer neglects to to the appropriate steps, do
what we can to detect the situation and downgrade the segfault to just a missed
optimization opportunity.