### PR TITLE
Always log the type coming out of an nqp::decont

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3058,12 +3058,12 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 4;
                 if (obj && IS_CONCRETE(obj) && STABLE(obj)->container_spec) {
                     STABLE(obj)->container_spec->fetch(tc, obj, r);
-                    if (MVM_spesh_log_is_logging(tc))
-                        MVM_spesh_log_decont(tc, prev_op, r->o);
                 }
                 else {
                     r->o = obj;
                 }
+                if (MVM_spesh_log_is_logging(tc))
+                    MVM_spesh_log_decont(tc, prev_op, r->o);
                 goto NEXT;
             }
             OP(setcontspec): {


### PR DESCRIPTION
Before, it would only log if a decont was actually perfomed. That was
usually fine because most of the time there always was or wasn't a
container. If there was a container we logged the type, and if there
wasn't we usually could throw out the decont op altogether. However, in
the cases where there *was* a mix, the stats could be misleading. Given
that we will soon have the ability to remove an optimized spesh candidate
if it gets too many deopts (and then clear the stats), we'll still end up
creating a new candidate just like the previous bad one because its new
stats will be just as misleading as the old ones. With this change we
collect good stats in any case.

The `&& r-o` in the if shouldn't be needed because there should never
be an actuall NULL in a register, but it currently can happen when
profiling (somewhere in this block
https://github.com/Raku/nqp/blob/master/src/vm/moar/HLL/Backend.nqp#L251-L257).
After `nqp::(getobjsc|scgetdesc)` are audited (and fixed), it should be
able to be removed.

Before, `my $r := "a" .. "za"; my @a = $r[^$r.elems];` used to have ~688k deops and take ~2.6s, after it's only ~660 deopts and ~2.5s.