### PR TITLE
Fix confused profiler output in multi-threaded app

### DIFF
--- a/src/profiler/instrument.c
+++ b/src/profiler/instrument.c
@@ -683,7 +683,7 @@ static MVMObject * dump_thread_data(MVMThreadContext *tc, ProfDumpStrs *pds,
 
     ProfTcPdsStruct tcpds;
 
-    tcpds.tc = tc;
+    tcpds.tc = othertc;
     tcpds.pds = pds;
     tcpds.types_array = types_data;
 


### PR DESCRIPTION
At some point we started to assign indexes to static frames and then
look them up, so as to cheapen GC of the profiler data. Unfortunately,
this introduced a bug when we recorded profiles in multi-threaded
programs: the wrong thread context was used to resolve those indices
when dumping the profile results, which in turn led to the indices
resolving to the wrong static frame. Thus the output of profiles
involving multiple threads would often end up garbled.