### PR TITLE
`fastcreate` Int and BigInt objects from IntConstCache metadata

### DIFF
--- a/src/6model/reprs/P6int.c
+++ b/src/6model/reprs/P6int.c
@@ -215,16 +215,21 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
                 MVM_spesh_graph_add_comment(tc, g, ins, "box_i into a %s",
                         MVM_6model_get_stable_debug_name(tc, st));
 
-                ins->info = MVM_op_get_op(int_cache_type_idx < 0
-                        ? MVM_OP_sp_fastbox_i
-                        : MVM_OP_sp_fastbox_i_ic);
-                ins->operands = MVM_spesh_alloc(tc, g, 6 * sizeof(MVMSpeshOperand));
-                ins->operands[0] = orig_operands[0];
-                ins->operands[1].lit_i16 = st->size;
-                ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot(tc, g, (MVMCollectable *)st);
-                ins->operands[3].lit_i16 = offsetof(MVMP6int, body.value);
-                ins->operands[4] = orig_operands[1];
-                ins->operands[5].lit_i16 = (MVMint16)int_cache_type_idx;
+                if (int_cache_type_idx == MVM_INTCACHE_P6INT_INDEX) {
+                    ins->info = MVM_op_get_op(MVM_OP_sp_fastbox_i_ic);
+                    ins->operands = MVM_spesh_alloc(tc, g, 2 * sizeof(MVMSpeshOperand));
+                    ins->operands[0] = orig_operands[0];
+                    ins->operands[1] = orig_operands[1];
+                }
+                else {
+                    ins->info = MVM_op_get_op(MVM_OP_sp_fastbox_i);
+                    ins->operands = MVM_spesh_alloc(tc, g, 5 * sizeof(MVMSpeshOperand));
+                    ins->operands[0] = orig_operands[0];
+                    ins->operands[1].lit_i16 = st->size;
+                    ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot(tc, g, (MVMCollectable *)st);
+                    ins->operands[3].lit_i16 = offsetof(MVMP6int, body.value);
+                    ins->operands[4] = orig_operands[1];
+                }
                 MVM_spesh_usages_delete_by_reg(tc, g, orig_operands[2], ins);
                 tgt_facts->flags |= MVM_SPESH_FACT_KNOWN_TYPE | MVM_SPESH_FACT_CONCRETE;
                 tgt_facts->type = st->WHAT;

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -1804,17 +1804,22 @@ static void spesh(MVMThreadContext *tc, MVMSTable *st, MVMSpeshGraph *g, MVMSpes
                 MVMint32 int_cache_type_idx = MVM_intcache_type_index(tc, st->WHAT);
                 MVMSpeshFacts *tgt_facts = MVM_spesh_get_facts(tc, g, ins->operands[0]);
                 MVMSpeshOperand *orig_operands = ins->operands;
-                ins->info = MVM_op_get_op(int_cache_type_idx < 0
-                        ? MVM_OP_sp_fastbox_bi
-                        : MVM_OP_sp_fastbox_bi_ic);
-                ins->operands = MVM_spesh_alloc(tc, g, 6 * sizeof(MVMSpeshOperand));
-                ins->operands[0] = orig_operands[0];
-                ins->operands[1].lit_i16 = st->size;
-                ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot(tc, g, (MVMCollectable *)st);
-                ins->operands[3].lit_i16 = sizeof(MVMObject) +
-                    repr_data->attribute_offsets[repr_data->unbox_int_slot];
-                ins->operands[4] = orig_operands[1];
-                ins->operands[5].lit_i16 = (MVMint16)int_cache_type_idx;
+                if (int_cache_type_idx = MVM_INTCACHE_P6BIGINT_INDEX) {
+                    ins->info = MVM_op_get_op(MVM_OP_sp_fastbox_bi_ic);
+                    ins->operands = MVM_spesh_alloc(tc, g, 2 * sizeof(MVMSpeshOperand));
+                    ins->operands[0] = orig_operands[0];
+                    ins->operands[1] = orig_operands[1];
+                }
+                else {
+                    ins->info = MVM_op_get_op(MVM_OP_sp_fastbox_bi);
+                    ins->operands = MVM_spesh_alloc(tc, g, 5 * sizeof(MVMSpeshOperand));
+                    ins->operands[0] = orig_operands[0];
+                    ins->operands[1].lit_i16 = st->size;
+                    ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot(tc, g, (MVMCollectable *)st);
+                    ins->operands[3].lit_i16 = sizeof(MVMObject) +
+                        repr_data->attribute_offsets[repr_data->unbox_int_slot];
+                    ins->operands[4] = orig_operands[1];
+                }
                 MVM_spesh_usages_delete_by_reg(tc, g, orig_operands[2], ins);
                 tgt_facts->flags |= MVM_SPESH_FACT_KNOWN_TYPE | MVM_SPESH_FACT_CONCRETE | MVM_SPESH_FACT_KNOWN_BOX_SRC;
                 tgt_facts->type = st->WHAT;

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -1980,17 +1980,8 @@ MVMObject * MVM_serialization_read_ref(MVMThreadContext *tc, MVMSerializationRea
             return read_obj_ref(tc, reader);
         case REFVAR_VM_NULL:
             return tc->instance->VMNull;
-        case REFVAR_VM_INT: {
-            MVMint64 value;
-            value = MVM_serialization_read_int(tc, reader);
-            if (MVM_INTCACHE_RANGE_CHECK(value))
-                result = MVM_intcache_get(tc, tc->instance->boot_types.BOOTInt, value);
-            if (result == 0) {
-                result = MVM_gc_allocate_object(tc, STABLE(tc->instance->boot_types.BOOTInt));
-                MVMP6int_set_int(tc, STABLE(result), result, OBJECT_BODY(result), value);
-            }
-            return result;
-        }
+        case REFVAR_VM_INT:
+            return MVM_repr_box_int(tc, tc->instance->boot_types.BOOTInt, MVM_serialization_read_int(tc, reader));
         case REFVAR_VM_NUM:
             result = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTNum);
             MVM_repr_set_num(tc, result, MVM_serialization_read_num(tc, reader));

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -248,23 +248,7 @@ static MVMObject * decont_arg(MVMThreadContext *tc, MVMObject *arg) {
 } while (0)
 
 #define autobox_int(tc, target, result, dest) do { \
-    MVMObject *box, *box_type; \
-    MVMint64 result_int = result; \
-    MVMObject *autobox_temp; \
-    box_type = target->static_info->body.cu->body.hll_config->int_box_type; \
-    autobox_temp = MVM_intcache_get(tc, box_type, result_int); \
-    if (autobox_temp == NULL) { \
-        box = REPR(box_type)->allocate(tc, STABLE(box_type)); \
-        MVM_gc_root_temp_push(tc, (MVMCollectable **)&box); \
-        if (REPR(box)->initialize) \
-            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box)); \
-        REPR(box)->box_funcs.set_int(tc, STABLE(box), box, OBJECT_BODY(box), result_int); \
-        MVM_gc_root_temp_pop(tc); \
-        dest = box; \
-    } \
-    else { \
-        dest = autobox_temp; \
-    } \
+    dest = MVM_repr_box_int(tc, target->static_info->body.cu->body.hll_config->int_box_type, result); \
 } while (0)
 
 #define autobox_switch(tc, result) do { \
@@ -652,14 +636,7 @@ void MVM_args_assert_void_return_ok(MVMThreadContext *tc, MVMint32 frameless) {
     if (!type || IS_CONCRETE(type)) { \
         MVM_exception_throw_adhoc(tc, "Missing hll " name " box type"); \
     } \
-    box = MVM_intcache_get(tc, type, value); \
-    if (!box) { \
-        box = REPR(type)->allocate(tc, STABLE(type)); \
-        if (REPR(box)->initialize) \
-            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box)); \
-        REPR(box)->box_funcs.set_func(tc, STABLE(box), box, \
-            OBJECT_BODY(box), value); \
-    } \
+    box = MVM_repr_box_int(tc, type, value); \
     reg.o = box; \
     REPR(result)->pos_funcs.push(tc, STABLE(result), result, \
         OBJECT_BODY(result), reg, MVM_reg_obj); \
@@ -742,14 +719,7 @@ MVMObject * MVM_args_slurpy_positional(MVMThreadContext *tc, MVMArgProcContext *
     if (!type || IS_CONCRETE(type)) { \
         MVM_exception_throw_adhoc(tc, "Missing hll int box type"); \
     } \
-    box = MVM_intcache_get(tc, type, value); \
-    if (box == NULL) { \
-        box = REPR(type)->allocate(tc, STABLE(type)); \
-        if (REPR(box)->initialize) \
-            REPR(box)->initialize(tc, STABLE(box), box, OBJECT_BODY(box)); \
-        REPR(box)->box_funcs.set_int(tc, STABLE(box), box, \
-            OBJECT_BODY(box), value); \
-    } \
+    box = MVM_repr_box_int(tc, type, value); \
     reg.o = box; \
     REPR(result)->ass_funcs.bind_key(tc, STABLE(result), result, \
         OBJECT_BODY(result), (MVMObject *)key, reg, MVM_reg_obj); \

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -122,6 +122,9 @@ enum {
 struct MVMIntConstCache {
     MVMObject *types[MVM_INTCACHE_MAX];
     MVMObject *cache[MVM_INTCACHE_MAX][16];
+    MVMSTable *stables[MVM_INTCACHE_MAX];
+    MVMuint16  sizes[MVM_INTCACHE_MAX];
+    MVMuint16  offsets[MVM_INTCACHE_MAX];
 };
 
 /* Represents a MoarVM instance. */

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -109,6 +109,20 @@ struct MVMSerializationContextWeakHashEntry {
     struct MVMStrHashHandle hash_handle;
     MVMSerializationContextBody *scb;
 };
+/* Seems that we only ever have (at most) two types that we want to cache, and
+ * always the same two types. At which point, it becomes easier if we always use
+ * the same index for each, as that then permits other space optimisations. */
+
+enum {
+    MVM_INTCACHE_P6INT_INDEX = 0,
+    MVM_INTCACHE_P6BIGINT_INDEX,
+    MVM_INTCACHE_MAX
+};
+
+struct MVMIntConstCache {
+    MVMObject *types[MVM_INTCACHE_MAX];
+    MVMObject *cache[MVM_INTCACHE_MAX][16];
+};
 
 /* Represents a MoarVM instance. */
 struct MVMInstance {
@@ -385,8 +399,8 @@ struct MVMInstance {
 
     /* By far the most common integers are between 0 and 8, but we cache up to 15
      * so that it lines up properly. */
-    MVMIntConstCache    *int_const_cache;
     uv_mutex_t mutex_int_const_cache;
+    MVMIntConstCache    int_const_cache;
 
     /* Multi-dispatch cache addition mutex (additions are relatively
      * rare, so little motivation to have it more fine-grained). */

--- a/src/core/intcache.c
+++ b/src/core/intcache.c
@@ -1,68 +1,74 @@
 #include "moar.h"
 
 void MVM_intcache_for(MVMThreadContext *tc, MVMObject *type) {
-    int type_index;
-    int right_slot = -1;
+    int type_index = MVM_intcache_possible_type_index(type);
+    if (type_index < 0) {
+        return;
+    }
+
     uv_mutex_lock(&tc->instance->mutex_int_const_cache);
-    for (type_index = 0; type_index < 4; type_index++) {
-        if (tc->instance->int_const_cache->types[type_index] == NULL) {
-            right_slot = type_index;
-            break;
-        }
-        else if (tc->instance->int_const_cache->types[type_index] == type) {
-            uv_mutex_unlock(&tc->instance->mutex_int_const_cache);
-            return;
-        }
+
+    MVMObject *was = tc->instance->int_const_cache.types[type_index];
+    if (was == type) {
+        uv_mutex_unlock(&tc->instance->mutex_int_const_cache);
+        return;
     }
-    if (right_slot != -1) {
-        MVMROOT(tc, type, {
-            int val;
-            for (val = -1; val < 15; val++) {
-                MVMObject *obj;
-                obj = MVM_repr_alloc_init(tc, type);
-                MVM_repr_set_int(tc, obj, val);
-                tc->instance->int_const_cache->cache[type_index][val + 1] = obj;
-                MVM_gc_root_add_permanent_desc(tc,
-                    (MVMCollectable **)&tc->instance->int_const_cache->cache[type_index][val + 1],
-                    "Boxed integer cache entry");
-            }
-        });
-        tc->instance->int_const_cache->types[type_index] = type;
-        MVM_gc_root_add_permanent_desc(tc,
-            (MVMCollectable **)&tc->instance->int_const_cache->types[type_index],
-            "Boxed integer cache type");
+
+    if (was) {
+        uv_mutex_unlock(&tc->instance->mutex_int_const_cache);
+        MVM_oops(tc, "Duplicate intcache initialisation for %d - %p vs %p",
+                 type_index, was, type);
+        return;
     }
+
+    MVMROOT(tc, type, {
+        int val;
+        for (val = -1; val < 15; val++) {
+            MVMObject *obj;
+            obj = MVM_repr_alloc_init(tc, type);
+            MVM_repr_set_int(tc, obj, val);
+            tc->instance->int_const_cache.cache[type_index][val + 1] = obj;
+            MVM_gc_root_add_permanent_desc(tc,
+                (MVMCollectable **)&tc->instance->int_const_cache.cache[type_index][val + 1],
+                "Boxed integer cache entry");
+        }
+    });
+
+    tc->instance->int_const_cache.types[type_index] = type;
+    MVM_gc_root_add_permanent_desc(tc,
+        (MVMCollectable **)&tc->instance->int_const_cache.types[type_index],
+        "Boxed integer cache type");
+
     uv_mutex_unlock(&tc->instance->mutex_int_const_cache);
 }
 
 MVMObject *MVM_intcache_get(MVMThreadContext *tc, MVMObject *type, MVMint64 value) {
-    int type_index;
-    int right_slot = -1;
-
-    if (value < -1 || value >= 15)
+    if (!(MVM_INTCACHE_RANGE_CHECK(value))) {
         return NULL;
+    }
 
-    for (type_index = 0; type_index < 4; type_index++) {
-        if (tc->instance->int_const_cache->types[type_index] == type) {
-            right_slot = type_index;
-            break;
-        }
+    int type_index = MVM_intcache_possible_type_index(type);
+    if (type_index < 0) {
+        return NULL;
     }
-    if (right_slot != -1) {
-        return tc->instance->int_const_cache->cache[right_slot][value + 1];
+
+    if (tc->instance->int_const_cache.types[type_index] != type) {
+        return NULL;
     }
-    return NULL;
+
+    return tc->instance->int_const_cache.cache[type_index][value + MVM_INTCACHE_ZERO_OFFSET];
 }
 
-MVMint32 MVM_intcache_type_index(MVMThreadContext *tc, MVMObject *type) {
-    int type_index;
+int MVM_intcache_type_index(MVMThreadContext *tc, MVMObject *type) {
+    int type_index = MVM_intcache_possible_type_index(type);
+    if (type_index < 0) {
+        return type_index;
+    }
+
     int found = -1;
     uv_mutex_lock(&tc->instance->mutex_int_const_cache);
-    for (type_index = 0; type_index < 4; type_index++) {
-        if (tc->instance->int_const_cache->types[type_index] == type) {
-            found = type_index;
-            break;
-        }
+    if (tc->instance->int_const_cache.types[type_index] == type) {
+        found = type_index;
     }
     uv_mutex_unlock(&tc->instance->mutex_int_const_cache);
     return found;

--- a/src/core/intcache.h
+++ b/src/core/intcache.h
@@ -1,10 +1,16 @@
-struct MVMIntConstCache {
-    MVMObject *types[4];
-    MVMObject *cache[4][16];
-};
+/* We play both kinds of music, Country *and* Western... */
+MVM_STATIC_INLINE int MVM_intcache_possible_type_index(MVMObject *type) {
+    MVMuint32 id = REPR(type)->ID;
+    if (id == MVM_REPR_ID_P6int)
+        return MVM_INTCACHE_P6INT_INDEX;
+    if (id == MVM_REPR_ID_P6opaque)
+        return MVM_INTCACHE_P6BIGINT_INDEX;
+    return -1;
+}
 
 #define MVM_INTCACHE_RANGE_CHECK(value) ((value) >= -1 && (value) < 15)
+#define MVM_INTCACHE_ZERO_OFFSET 1
 
 void MVM_intcache_for(MVMThreadContext *tc, MVMObject *type);
 MVMObject *MVM_intcache_get(MVMThreadContext *tc, MVMObject *type, MVMint64 value);
-MVMint32 MVM_intcache_type_index(MVMThreadContext *tc, MVMObject *type);
+int MVM_intcache_type_index(MVMThreadContext *tc, MVMObject *type);

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -6273,9 +6273,9 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             }
             OP(sp_fastbox_i_ic): {
                 MVMint64 value = GET_REG(cur_op, 8).i64;
-                if (value >= -1 && value < 15) {
+                if (MVM_INTCACHE_RANGE_CHECK(value)) {
                     MVMint16 slot = GET_UI16(cur_op, 10);
-                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache->cache[slot][value + 1];
+                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache.cache[slot][value + MVM_INTCACHE_ZERO_OFFSET];
                 }
                 else {
                     MVMObject *obj = fastcreate(tc, cur_op);
@@ -6287,9 +6287,9 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             }
             OP(sp_fastbox_bi_ic): {
                 MVMint64 value = GET_REG(cur_op, 8).i64;
-                if (value >= -1 && value < 15) {
+                if (MVM_INTCACHE_RANGE_CHECK(value)) {
                     MVMint16 slot = GET_UI16(cur_op, 10);
-                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache->cache[slot][value + 1];
+                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache.cache[slot][value + MVM_INTCACHE_ZERO_OFFSET];
                 }
                 else {
                     MVMObject *obj = fastcreate(tc, cur_op);
@@ -6479,14 +6479,14 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (ba->u.smallint.flag == MVM_BIGINT_32_FLAG && bb->u.smallint.flag == MVM_BIGINT_32_FLAG) {
                     MVMint64 result = (MVMint64)ba->u.smallint.value + (MVMint64)bb->u.smallint.value;
                     if (MVM_IS_32BIT_INT(result)) {
-                        if (result < -1 || result >= 15) {
+                        if (MVM_INTCACHE_RANGE_CHECK(result)) {
+                            result_obj = tc->instance->int_const_cache.cache[GET_UI16(cur_op, 12)][result + MVM_INTCACHE_ZERO_OFFSET];
+                        }
+                        else {
                             result_obj = fastcreate(tc, cur_op);
                             bc = (MVMP6bigintBody *)((char *)result_obj + offset);
                             bc->u.smallint.value = (MVMint32)result;
                             bc->u.smallint.flag = MVM_BIGINT_32_FLAG;
-                        }
-                        else {
-                            result_obj = tc->instance->int_const_cache->cache[GET_UI16(cur_op, 12)][result + 1];
                         }
                     }
                 }
@@ -6510,14 +6510,14 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (ba->u.smallint.flag == MVM_BIGINT_32_FLAG && bb->u.smallint.flag == MVM_BIGINT_32_FLAG) {
                     MVMint64 result = (MVMint64)ba->u.smallint.value - (MVMint64)bb->u.smallint.value;
                     if (MVM_IS_32BIT_INT(result)) {
-                        if (result < -1 || result >= 15) {
+                        if (MVM_INTCACHE_RANGE_CHECK(result)) {
+                            result_obj = tc->instance->int_const_cache.cache[GET_UI16(cur_op, 12)][result + MVM_INTCACHE_ZERO_OFFSET];
+                        }
+                        else {
                             result_obj = fastcreate(tc, cur_op);
                             bc = (MVMP6bigintBody *)((char *)result_obj + offset);
                             bc->u.smallint.value = (MVMint32)result;
                             bc->u.smallint.flag = MVM_BIGINT_32_FLAG;
-                        }
-                        else {
-                            result_obj = tc->instance->int_const_cache->cache[GET_UI16(cur_op, 12)][result + 1];
                         }
                     }
                 }
@@ -6541,14 +6541,14 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (ba->u.smallint.flag == MVM_BIGINT_32_FLAG && bb->u.smallint.flag == MVM_BIGINT_32_FLAG) {
                     MVMint64 result = (MVMint64)ba->u.smallint.value * (MVMint64)bb->u.smallint.value;
                     if (MVM_IS_32BIT_INT(result)) {
-                        if (result < -1 || result >= 15) {
+                        if (MVM_INTCACHE_RANGE_CHECK(result)) {
+                            result_obj = tc->instance->int_const_cache.cache[GET_UI16(cur_op, 12)][result + MVM_INTCACHE_ZERO_OFFSET];
+                        }
+                        else {
                             result_obj = fastcreate(tc, cur_op);
                             bc = (MVMP6bigintBody *)((char *)result_obj + offset);
                             bc->u.smallint.value = (MVMint32)result;
                             bc->u.smallint.flag = MVM_BIGINT_32_FLAG;
-                        }
-                        else {
-                            result_obj = tc->instance->int_const_cache->cache[GET_UI16(cur_op, 12)][result + 1];
                         }
                     }
                 }

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -6286,17 +6286,17 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(sp_fastbox_i_ic): {
-                MVMint64 value = GET_REG(cur_op, 8).i64;
+                MVMint64 value = GET_REG(cur_op, 2).i64;
                 if (MVM_INTCACHE_RANGE_CHECK(value)) {
-                    MVMint16 slot = GET_UI16(cur_op, 10);
-                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache.cache[slot][value + MVM_INTCACHE_ZERO_OFFSET];
+                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache.cache[MVM_INTCACHE_P6INT_INDEX][value + MVM_INTCACHE_ZERO_OFFSET];
                 }
                 else {
-                    MVMObject *obj = fastcreate(tc, cur_op);
-                    *((MVMint64 *)((char *)obj + GET_UI16(cur_op, 6))) = value;
+                    MVMuint16 offset = tc->instance->int_const_cache.offsets[MVM_INTCACHE_P6INT_INDEX];
+                    MVMObject *obj = fastcreate_from_intcache(tc, MVM_INTCACHE_P6INT_INDEX);
+                    *((MVMint64 *)((char *)obj + offset)) = value;
                     GET_REG(cur_op, 0).o = obj;
                 }
-                cur_op += 12;
+                cur_op += 4;
                 goto NEXT;
             }
             OP(sp_fastbox_bi_ic): {

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -6300,14 +6300,14 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(sp_fastbox_bi_ic): {
-                MVMint64 value = GET_REG(cur_op, 8).i64;
+                MVMint64 value = GET_REG(cur_op, 2).i64;
                 if (MVM_INTCACHE_RANGE_CHECK(value)) {
-                    MVMint16 slot = GET_UI16(cur_op, 10);
-                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache.cache[slot][value + MVM_INTCACHE_ZERO_OFFSET];
+                    GET_REG(cur_op, 0).o = tc->instance->int_const_cache.cache[MVM_INTCACHE_P6BIGINT_INDEX][value + MVM_INTCACHE_ZERO_OFFSET];
                 }
                 else {
-                    MVMObject *obj = fastcreate(tc, cur_op);
-                    MVMP6bigintBody *body = (MVMP6bigintBody *)((char *)obj + GET_UI16(cur_op, 6));
+                    MVMuint16 offset = tc->instance->int_const_cache.offsets[MVM_INTCACHE_P6BIGINT_INDEX];
+                    MVMObject *obj = fastcreate_from_intcache(tc, MVM_INTCACHE_P6BIGINT_INDEX);
+                    MVMP6bigintBody *body = (MVMP6bigintBody *)((char *)obj + offset);
                     if (MVM_IS_32BIT_INT(value)) {
                         body->u.smallint.value = (MVMint32)value;
                         body->u.smallint.flag = MVM_BIGINT_32_FLAG;
@@ -6317,7 +6317,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     }
                     GET_REG(cur_op, 0).o = obj;
                 }
-                cur_op += 12;
+                cur_op += 4;
                 goto NEXT;
             }
             OP(sp_deref_get_i64): {

--- a/src/core/oplist
+++ b/src/core/oplist
@@ -1054,14 +1054,14 @@ sp_cas_o              .s w(obj) r(obj) r(obj) r(obj) :invokish :maycausedeopt
 sp_atomicload_o       .s w(obj) r(obj)
 sp_atomicstore_o      .s r(obj) r(obj) :invokish :maycausedeopt
 
-# Lowered big integer operations, where inputs and output type are consistent.
-# They start with the same operands as a fastcreate, which will be used if the
-# result can not be served from the cache. The second index is the offset of
-# the bigint structure within the body of the object. The third index is the
-# index into the box type cache, for objects that are in range.
-sp_add_I         .s w(obj) int16 sslot r(obj) r(obj) int16 int16 :pure
-sp_sub_I         .s w(obj) int16 sslot r(obj) r(obj) int16 int16 :pure
-sp_mul_I         .s w(obj) int16 sslot r(obj) r(obj) int16 int16 :pure
+# Lowered big integer operations, where inputs and output type are consistent
+# and the output type is in MVMIntConstCache. They no longer use fastcreate
+# directly, as the parameters that fastcreate would need are found from
+# MVMIntConstCache (ie stored once per process, instead of once per op)
+# The object from MVMIntConstCache is used, for results that in range.
+sp_add_I         .s w(obj) r(obj) r(obj) :pure
+sp_sub_I         .s w(obj) r(obj) r(obj) :pure
+sp_mul_I         .s w(obj) r(obj) r(obj) :pure
 
 sp_bool_I        .s w(int64) r(obj) int16 :pure
 

--- a/src/core/oplist
+++ b/src/core/oplist
@@ -1022,8 +1022,7 @@ sp_fastbox_bi    .s w(obj) int16 sslot int16 r(int64) :pure
 # bytecode. They do a lookup in the integer cache before performing a box
 # operation.
 sp_fastbox_i_ic  .s w(obj) r(int64) :pure
-# TODO next:
-sp_fastbox_bi_ic .s w(obj) int16 sslot int16 r(int64) int16 :pure
+sp_fastbox_bi_ic .s w(obj) r(int64) :pure
 
 # Follow a pointer at an offset to an object and get/store a value there.
 sp_deref_get_i64      .s w(int64) r(obj) int16 :pure

--- a/src/core/oplist
+++ b/src/core/oplist
@@ -1013,11 +1013,16 @@ sp_getvc_o       .s w(obj) r(obj) int16 sslot
 # the value as appropriate. The first two read operands have the same meaning
 # as in sp_fastcreate, the third is the offset in the object to box to, and
 # the final operand is the integer to box. The _ic variants include an extra
-# argument which is the type index in the integer cache; they do a lookup in
-# the integer cache before performing a box operation.
 sp_fastbox_i     .s w(obj) int16 sslot int16 r(int64) :pure
 sp_fastbox_bi    .s w(obj) int16 sslot int16 r(int64) :pure
-sp_fastbox_i_ic  .s w(obj) int16 sslot int16 r(int64) int16 :pure
+
+# The _ic variants are for types in the integer cache - as the type index into
+# the cache is known, the offset and the stable pointer can also be read
+# directly from the integer cache instead of needing to be stored in the
+# bytecode. They do a lookup in the integer cache before performing a box
+# operation.
+sp_fastbox_i_ic  .s w(obj) r(int64) :pure
+# TODO next:
 sp_fastbox_bi_ic .s w(obj) int16 sslot int16 r(int64) int16 :pure
 
 # Follow a pointer at an offset to an object and get/store a value there.

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -12716,7 +12716,7 @@ static const MVMOpInfo MVM_op_infos[] = {
     {
         MVM_OP_sp_add_I,
         "sp_add_I",
-        7,
+        3,
         1,
         0,
         0,
@@ -12725,12 +12725,12 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         0,
         0,
-        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_spesh_slot, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_int16 }
+        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj }
     },
     {
         MVM_OP_sp_sub_I,
         "sp_sub_I",
-        7,
+        3,
         1,
         0,
         0,
@@ -12739,12 +12739,12 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         0,
         0,
-        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_spesh_slot, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_int16 }
+        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj }
     },
     {
         MVM_OP_sp_mul_I,
         "sp_mul_I",
-        7,
+        3,
         1,
         0,
         0,
@@ -12753,7 +12753,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         0,
         0,
-        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_spesh_slot, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_int16 }
+        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_obj }
     },
     {
         MVM_OP_sp_bool_I,

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -12436,7 +12436,7 @@ static const MVMOpInfo MVM_op_infos[] = {
     {
         MVM_OP_sp_fastbox_i_ic,
         "sp_fastbox_i_ic",
-        6,
+        2,
         1,
         0,
         0,
@@ -12445,7 +12445,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         0,
         0,
-        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_spesh_slot, MVM_operand_int16, MVM_operand_read_reg | MVM_operand_int64, MVM_operand_int16 }
+        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_int64 }
     },
     {
         MVM_OP_sp_fastbox_bi_ic,

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -12450,7 +12450,7 @@ static const MVMOpInfo MVM_op_infos[] = {
     {
         MVM_OP_sp_fastbox_bi_ic,
         "sp_fastbox_bi_ic",
-        6,
+        2,
         1,
         0,
         0,
@@ -12459,7 +12459,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         0,
         0,
-        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_int16, MVM_operand_spesh_slot, MVM_operand_int16, MVM_operand_read_reg | MVM_operand_int64, MVM_operand_int16 }
+        { MVM_operand_write_reg | MVM_operand_obj, MVM_operand_read_reg | MVM_operand_int64 }
     },
     {
         MVM_OP_sp_deref_get_i64,

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2467,27 +2467,10 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         break;
     }
     case MVM_OP_sp_fastbox_i:
-    case MVM_OP_sp_fastbox_bi:
-    case MVM_OP_sp_fastbox_bi_ic: {
-        MVMint32 use_cache = op == MVM_OP_sp_fastbox_i_ic || op == MVM_OP_sp_fastbox_bi_ic;
+    case MVM_OP_sp_fastbox_bi: {
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 offset = ins->operands[3].lit_i16;
         MVMint16 val = ins->operands[4].reg.orig;
-        if (use_cache) {
-            MVMObject **cache = tc->instance->int_const_cache.cache[ins->operands[5].lit_i16];
-            MVMint16 dst = ins->operands[0].reg.orig;
-            | mov TMP1, WORK[val]
-            | cmp TMP1, 14
-            | jg >1
-            | cmp TMP1, -1
-            | jl >1
-            | inc TMP1
-            | mov64 TMP2, (MVMuint64)cache
-            | mov TMP2, [TMP2 + TMP1 * 8]
-            | mov WORK[dst], TMP2
-            | jmp >2
-            |1:
-        }
         emit_fastcreate(tc, compiler, jg, ins);
         | mov aword WORK[dst], RV;
         | mov TMP3, WORK[val];
@@ -2514,12 +2497,10 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
             | callp &MVM_p6bigint_store_as_mp_int;
             |4:
         }
-        if (use_cache) {
-            |2:
-        }
         break;
     }
-    case MVM_OP_sp_fastbox_i_ic: {
+    case MVM_OP_sp_fastbox_i_ic:
+    case MVM_OP_sp_fastbox_bi_ic: {
         MVMint16 type_index = op == MVM_OP_sp_fastbox_i_ic
             ? MVM_INTCACHE_P6INT_INDEX : MVM_INTCACHE_P6BIGINT_INDEX;
         MVMint16 dst = ins->operands[0].reg.orig;

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2461,7 +2461,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 offset = ins->operands[3].lit_i16;
         MVMint16 val = ins->operands[4].reg.orig;
         if (use_cache) {
-            MVMObject **cache = tc->instance->int_const_cache->cache[ins->operands[5].lit_i16];
+            MVMObject **cache = tc->instance->int_const_cache.cache[ins->operands[5].lit_i16];
             MVMint16 dst = ins->operands[0].reg.orig;
             | mov TMP1, WORK[val]
             | cmp TMP1, 14
@@ -2514,7 +2514,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 c = ins->operands[0].reg.orig;
         MVMint16 offset = ins->operands[5].lit_i16;
         MVMint16 val_offset = offset + 4;
-        MVMObject **cache = tc->instance->int_const_cache->cache[ins->operands[6].lit_i16];
+        MVMObject **cache = tc->instance->int_const_cache.cache[ins->operands[6].lit_i16];
 
         /* See if they're both smallint. */
         | mov TMP1, WORK[a];

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2467,7 +2467,6 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         break;
     }
     case MVM_OP_sp_fastbox_i:
-    case MVM_OP_sp_fastbox_i_ic:
     case MVM_OP_sp_fastbox_bi:
     case MVM_OP_sp_fastbox_bi_ic: {
         MVMint32 use_cache = op == MVM_OP_sp_fastbox_i_ic || op == MVM_OP_sp_fastbox_bi_ic;
@@ -2518,6 +2517,54 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         if (use_cache) {
             |2:
         }
+        break;
+    }
+    case MVM_OP_sp_fastbox_i_ic: {
+        MVMint16 type_index = op == MVM_OP_sp_fastbox_i_ic
+            ? MVM_INTCACHE_P6INT_INDEX : MVM_INTCACHE_P6BIGINT_INDEX;
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 offset = tc->instance->int_const_cache.offsets[type_index];
+        MVMObject **cache = tc->instance->int_const_cache.cache[type_index];
+        MVMint16 val = ins->operands[1].reg.orig;
+        | mov TMP1, WORK[val]
+        | cmp TMP1, 14
+        | jg >1
+        | cmp TMP1, -1
+        | jl >1
+        | inc TMP1
+        | mov64 TMP2, (MVMuint64)cache
+        | mov TMP2, [TMP2 + TMP1 * 8]
+        | mov WORK[dst], TMP2
+        | jmp >2
+        /* Not a singleton in the cache: */
+        |1:
+        emit_fastcreate_from_intcache(tc, compiler, jg, type_index);
+        | mov aword WORK[dst], RV;
+        | mov TMP3, WORK[val];
+        if (op == MVM_OP_sp_fastbox_i_ic) {
+            /* Normal integer */
+            | mov qword [RV+offset], TMP3;
+        }
+        else {
+            /* Big integer; if it's in smallint range we poke it in directly,
+             * and if not we do a function call to create a bigint. */
+            MVMuint16 val_offset = offset + 4;
+            | cmp TMP3, qword 2147483647LL
+            | jg >3
+            | cmp TMP3, qword -2147483648LL
+            | jl >3
+            | mov dword [RV+offset], MVM_BIGINT_32_FLAG
+            | mov dword [RV+val_offset], TMP3d
+            | jmp >4
+            |3:
+            | mov ARG1, TC
+            | mov ARG2, RV
+            | add ARG2, offset
+            | mov ARG3, TMP3
+            | callp &MVM_p6bigint_store_as_mp_int;
+            |4:
+        }
+        |2:
         break;
     }
     case MVM_OP_sp_add_I:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -392,6 +392,20 @@ static void emit_fastcreate(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
     | mov dword OBJECT:RV->header.owner, TMP1d; // does this even work?
 }
 
+static void emit_fastcreate_from_intcache(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg,
+                                          int type_index) {
+    MVMuint16 size = tc->instance->int_const_cache.sizes[type_index];
+    MVMSTable *stable = tc->instance->int_const_cache.stables[type_index];
+    | mov ARG1, TC;
+    | mov ARG2, size;
+    | callp &MVM_gc_allocate_nursery;
+    | mov64 TMP1, (MVMuint64)stable;
+    | mov aword OBJECT:RV->st, TMP1;  // st is 64 bit (pointer)
+    | mov word OBJECT:RV->header.size, size; // object size is 16 bit
+    | mov TMP1d, dword TC->thread_id;  // thread id is 32 bit
+    | mov dword OBJECT:RV->header.owner, TMP1d; // does this even work?
+}
+
 /* compile per instruction, can't really do any better yet */
 void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg,
                             MVMJitPrimitive * prim) {
@@ -2509,12 +2523,12 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
     case MVM_OP_sp_add_I:
     case MVM_OP_sp_sub_I:
     case MVM_OP_sp_mul_I: {
-        MVMint16 a = ins->operands[3].reg.orig;
-        MVMint16 b = ins->operands[4].reg.orig;
+        MVMint16 a = ins->operands[1].reg.orig;
+        MVMint16 b = ins->operands[2].reg.orig;
         MVMint16 c = ins->operands[0].reg.orig;
-        MVMint16 offset = ins->operands[5].lit_i16;
+        MVMint16 offset = tc->instance->int_const_cache.offsets[MVM_INTCACHE_P6BIGINT_INDEX];
         MVMint16 val_offset = offset + 4;
-        MVMObject **cache = tc->instance->int_const_cache.cache[ins->operands[6].lit_i16];
+        MVMObject **cache = tc->instance->int_const_cache.cache[MVM_INTCACHE_P6BIGINT_INDEX];
 
         /* See if they're both smallint. */
         | mov TMP1, WORK[a];
@@ -2554,7 +2568,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | jmp >3
         |2:
         | mov dword [rbp-0x30], TMP4d;
-        emit_fastcreate(tc, compiler, jg, ins);
+        emit_fastcreate_from_intcache(tc, compiler, jg, MVM_INTCACHE_P6BIGINT_INDEX);
         | mov aword WORK[c], RV;
         | mov TMP4d, dword [rbp-0x30];
         | mov dword [RV + offset], MVM_BIGINT_32_FLAG
@@ -2566,7 +2580,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
          * before storing the result value, in case they're aimed at the
          * same register. */
         |1:
-        emit_fastcreate(tc, compiler, jg, ins);
+        emit_fastcreate_from_intcache(tc, compiler, jg, MVM_INTCACHE_P6BIGINT_INDEX);
         | mov ARG1, TC;
         | mov ARG2, WORK[a];
         | add ARG2, offset

--- a/src/moar.c
+++ b/src/moar.c
@@ -203,7 +203,6 @@ MVMInstance * MVM_vm_create_instance(void) {
 
     /* Set up integer constant and string cache. */
     init_mutex(instance->mutex_int_const_cache, "int constant cache");
-    instance->int_const_cache = MVM_calloc(1, sizeof(MVMIntConstCache));
     instance->int_to_str_cache = MVM_calloc(MVM_INT_TO_STR_CACHE_SIZE, sizeof(MVMString *));
 
     /* Initialize Unicode database and NFG. */
@@ -748,7 +747,6 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
 
     /* Clean up integer constant and string cache. */
     uv_mutex_destroy(&instance->mutex_int_const_cache);
-    MVM_free(instance->int_const_cache);
     MVM_free(instance->int_to_str_cache);
 
     /* Clean up event loop mutex. */

--- a/src/spesh/facts.c
+++ b/src/spesh/facts.c
@@ -472,12 +472,16 @@ static void add_bb_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
         case MVM_OP_sp_fastbox_bi:
         case MVM_OP_sp_fastbox_i_ic:
         case MVM_OP_sp_fastbox_bi_ic:
+            create_facts_with_type(tc, g,
+                ins->operands[0].reg.orig, ins->operands[0].reg.i,
+                ((MVMSTable *)g->spesh_slots[ins->operands[2].lit_i16])->WHAT);
+            break;
         case MVM_OP_sp_add_I:
         case MVM_OP_sp_sub_I:
         case MVM_OP_sp_mul_I:
             create_facts_with_type(tc, g,
                 ins->operands[0].reg.orig, ins->operands[0].reg.i,
-                ((MVMSTable *)g->spesh_slots[ins->operands[2].lit_i16])->WHAT);
+                tc->instance->int_const_cache.stables[MVM_INTCACHE_P6BIGINT_INDEX]->WHAT);
             break;
         case MVM_OP_clone:
             copy_facts(tc, g,

--- a/src/spesh/facts.c
+++ b/src/spesh/facts.c
@@ -470,7 +470,6 @@ static void add_bb_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
         case MVM_OP_sp_fastcreate:
         case MVM_OP_sp_fastbox_i:
         case MVM_OP_sp_fastbox_bi:
-        case MVM_OP_sp_fastbox_bi_ic:
             create_facts_with_type(tc, g,
                 ins->operands[0].reg.orig, ins->operands[0].reg.i,
                 ((MVMSTable *)g->spesh_slots[ins->operands[2].lit_i16])->WHAT);
@@ -479,6 +478,11 @@ static void add_bb_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
             create_facts_with_type(tc, g,
                 ins->operands[0].reg.orig, ins->operands[0].reg.i,
                 tc->instance->int_const_cache.stables[MVM_INTCACHE_P6INT_INDEX]->WHAT);
+            break;
+        case MVM_OP_sp_fastbox_bi_ic:
+            create_facts_with_type(tc, g,
+                ins->operands[0].reg.orig, ins->operands[0].reg.i,
+                tc->instance->int_const_cache.stables[MVM_INTCACHE_P6BIGINT_INDEX]->WHAT);
             break;
         case MVM_OP_sp_add_I:
         case MVM_OP_sp_sub_I:

--- a/src/spesh/facts.c
+++ b/src/spesh/facts.c
@@ -470,11 +470,15 @@ static void add_bb_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
         case MVM_OP_sp_fastcreate:
         case MVM_OP_sp_fastbox_i:
         case MVM_OP_sp_fastbox_bi:
-        case MVM_OP_sp_fastbox_i_ic:
         case MVM_OP_sp_fastbox_bi_ic:
             create_facts_with_type(tc, g,
                 ins->operands[0].reg.orig, ins->operands[0].reg.i,
                 ((MVMSTable *)g->spesh_slots[ins->operands[2].lit_i16])->WHAT);
+            break;
+        case MVM_OP_sp_fastbox_i_ic:
+            create_facts_with_type(tc, g,
+                ins->operands[0].reg.orig, ins->operands[0].reg.i,
+                tc->instance->int_const_cache.stables[MVM_INTCACHE_P6INT_INDEX]->WHAT);
             break;
         case MVM_OP_sp_add_I:
         case MVM_OP_sp_sub_I:

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -2517,9 +2517,9 @@ static void optimize_bigint_binary_op(MVMThreadContext *tc, MVMSpeshGraph *g, MV
         }
     }
     if (common_type && REPR(common_type)->ID == MVM_REPR_ID_P6opaque) {
-        MVMuint16 offset = MVM_p6opaque_get_bigint_offset(tc, common_type->st);
         MVMint16 cache_type_index = MVM_intcache_type_index(tc, common_type->st->WHAT);
-        if (offset && cache_type_index >= 0) {
+        if (cache_type_index >= 0) {
+            assert(cache_type_index == MVM_INTCACHE_P6BIGINT_INDEX);
             /* Lower the op. */
             MVMSpeshOperand *orig_operands = ins->operands;
             switch (ins->info->opcode) {
@@ -2528,15 +2528,10 @@ static void optimize_bigint_binary_op(MVMThreadContext *tc, MVMSpeshGraph *g, MV
                 case MVM_OP_mul_I: ins->info = MVM_op_get_op(MVM_OP_sp_mul_I); break;
                 default: return;
             }
-            ins->operands = MVM_spesh_alloc(tc, g, 7 * sizeof(MVMSpeshOperand));
+            ins->operands = MVM_spesh_alloc(tc, g, 3 * sizeof(MVMSpeshOperand));
             ins->operands[0] = orig_operands[0];
-            ins->operands[1].lit_i16 = common_type->st->size;
-            ins->operands[2].lit_i16 = MVM_spesh_add_spesh_slot_try_reuse(tc, g,
-                    (MVMCollectable *)common_type->st);
-            ins->operands[3] = orig_operands[1];
-            ins->operands[4] = orig_operands[2];
-            ins->operands[5].lit_i16 = offset;
-            ins->operands[6].lit_i16 = cache_type_index;
+            ins->operands[1] = orig_operands[1];
+            ins->operands[2] = orig_operands[2];
             MVM_spesh_usages_delete_by_reg(tc, g, orig_operands[3], ins);
 
             /* Mark all facts as used. */


### PR DESCRIPTION
The IntConstCache stores singleton boxed objects for the values `-1 .. 14` for ints and bigints. It's used in most places that box integers (but not all). It has space to store four possible types, but we only ever use two. Some of the spesh opcodes (and the JIT) that use the cached singletons can also "fastcreate" boxed integer objects with values outside the cache range.

This branch changes the cache to store just two types, and at fixed array indexes, which makes some lookups simpler. It also extends the cache to store the relevant metadata used to "fastcreate" objects, and then provides "fastcreate" functionality in `MVM_repr_box_int`. Because the "fastcreate" metadata is now in the IntConstCache, it no longer needs to be stored in the spesh opcode stream, so that is now gone. It should be a memory **size** win after 3 inlined spesh ops.

I struggled to find any benchmark that shows any real difference (neither slowdown nor speedup). On reflection, I *think* that this is because

1. The JIT generated assembly is almost unchanged
2. We don't actually generate that many relevant arithmetic ops

So this somewhat **is** cherry-picking benchmarks, but with this Pascal's triangle code based on http://rosettacode.org/wiki/Pascal%27s_triangle#Raku:

    sub pascal ($n where $n >= 1) {
       my @last = 1;
       for 1 .. $n - 1 -> $row {
           @last = 1, |map({ @last[$_] + @last[$_ + 1] }, 0 .. $row - 2), 1;
       }
    }
    
    pascal 100 for 1..100;

on master, [dumbbench](https://metacpan.org/release/Dumbbench) says:

    MVM_JIT_DISABLE=1 ~/bin/dumbbench --initial=100 -- ./rakudo-m ../pascal
    cmd: Ran 105 iterations (1 outliers).
    cmd: Rounded run time per iteration: 2.3727e+00 +/- 3.1e-03 (0.1%)

whereas on this branch

    MVM_JIT_DISABLE=1 ~/bin/dumbbench --initial=100 -- ./rakudo-m ../pascal
    cmd: Ran 105 iterations (1 outliers).
    cmd: Rounded run time per iteration: 2.3433e+00 +/- 2.9e-03 (0.1%)

This PR obsoletes #1379. The bug described there with `does` is still present - Rakudo has not been changed to flag that code as a compile-time error.