### PR TITLE
Set "allocate in gen2" in 2 locations that create permarooted objects.

### DIFF
--- a/src/core/ext.c
+++ b/src/core/ext.c
@@ -52,8 +52,12 @@ int MVM_ext_load(MVMThreadContext *tc, MVMString *lib, MVMString *ext) {
 int MVM_ext_register_extop(MVMThreadContext *tc, const char *cname,
         MVMExtOpFunc func, MVMuint8 num_operands, MVMuint8 operands[],
         MVMExtOpSpesh *spesh, MVMExtOpFactDiscover *discover, MVMuint32 flags) {
+    /* This MVMString ends up being permarooted, so if we create it in gen2 we
+     * save some GC work */
+    MVM_gc_allocate_gen2_default_set(tc);
     MVMString *name = MVM_string_ascii_decode_nt(
             tc, tc->instance->VMString, cname);
+    MVM_gc_allocate_gen2_default_clear(tc);
 
     uv_mutex_lock(&tc->instance->mutex_extop_registry);
 

--- a/src/core/hll.c
+++ b/src/core/hll.c
@@ -150,7 +150,13 @@ MVMObject * MVM_hll_set_config(MVMThreadContext *tc, MVMString *name, MVMObject 
                 config, MVM_STORAGE_SPEC_BP_STR, MVM_NATIVEREF_MULTIDIM);
             set_max_inline_size(tc, config_hash, config);
 
+            /* Without this the integer objects are allocated in the nursery,
+             * which just makes work for the GC moving them around twice.
+             * The other call to MVM_intcache_for is from MVM_6model_bootstrap,
+             * which runs with MVM_gc_allocate_gen2_default_set. */
+            MVM_gc_allocate_gen2_default_set(tc);
             MVM_intcache_for(tc, config->int_box_type);
+            MVM_gc_allocate_gen2_default_clear(tc);
         });
 
     return config_hash;


### PR DESCRIPTION
These are the last two locations in the MoarVM source tree that directly
create objects that are passed to `MVM_gc_root_add_permanent_desc`.
Given that these objects will persist for the lifetime of the interpreter,
it makes sense to create them directly in gen2.