### PR TITLE
Free Uni property codes hashes with --full-cleanup

### DIFF
--- a/src/moar.c
+++ b/src/moar.c
@@ -721,6 +721,9 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     /* Release this interpreter's hold on Unicode database */
     MVM_unicode_release(instance->main_thread);
 
+    /* Clean up Unicode property codes hashes. */
+    MVM_unicode_property_codes_hashes_demolish(instance->main_thread);
+
     /* Clean up spesh mutexes and close any log. */
     uv_mutex_destroy(&instance->mutex_spesh_install);
     uv_cond_destroy(&instance->cond_spesh_sync);

--- a/src/strings/unicode.h
+++ b/src/strings/unicode.h
@@ -13,3 +13,4 @@ MVMCodepoint MVM_unicode_find_primary_composite(MVMThreadContext *tc, MVMCodepoi
 
 void MVM_unicode_init(MVMThreadContext *tc);
 void MVM_unicode_release(MVMThreadContext *tc);
+void MVM_unicode_property_codes_hashes_demolish(MVMThreadContext *tc);

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -905,6 +905,11 @@ static void generate_property_codes_by_seq_names(MVMThreadContext *tc) {
     }
 }
 
+void MVM_unicode_property_codes_hashes_demolish(MVMThreadContext *tc) {
+    MVM_uni_hash_demolish(tc, &property_codes_by_names_aliases);
+    MVM_uni_hash_demolish(tc, &property_codes_by_seq_names);
+}
+
 MVMint64 MVM_unicode_name_to_property_code(MVMThreadContext *tc, MVMString *name) {
     MVMuint64 size;
     char *cname = MVM_string_ascii_encode(tc, name, &size, 0);


### PR DESCRIPTION
Now valgrind and heaptrack don't report any leaks for
`raku --full-cleanup -e 'my %expressions = D => "got D", M => "got M", l => "got l"; my $a; $a := "%D %M %l".subst(/"%"$<specifier>=<{ %expressions.keys.join("|") }>/, -> ( :$specifier ) { %expressions{$specifier} }, :g) for ^10'`.

Fixes #1453