### PR TITLE
Some minor optimizations when creating backtraces

### DIFF
--- a/src/6model/reprs/MVMContinuation.c
+++ b/src/6model/reprs/MVMContinuation.c
@@ -50,7 +50,7 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
         MVMActiveHandler *cur_ah = ctx->body.active_handlers;
         while (cur_ah != NULL) {
             MVMActiveHandler *next_ah = cur_ah->next_handler;
-            MVM_free(cur_ah);
+            MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMActiveHandler), cur_ah);
             cur_ah = next_ah;
         }
     }

--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -560,9 +560,9 @@ MVMObject * MVM_exception_backtrace(MVMThreadContext *tc, MVMObject *ex_obj) {
             MVMBytecodeAnnotation *annot = MVM_bytecode_resolve_annotation(tc, &cur_frame->static_info->body,
                                                 offset > 0 ? offset - 1 : 0);
             MVMuint32             fshi   = annot ? (MVMint32)annot->filename_string_heap_index : -1;
-            char            *line_number = MVM_malloc(16);
+            char         line_number[11] = {0}; // 11 == 10 (max # of decimal digits in an MVMuint32) + 1 (NULL terminator)
             MVMString      *filename_str;
-            snprintf(line_number, 16, "%d", annot ? annot->line_number : 1);
+            snprintf(line_number, 11, "%d", annot ? annot->line_number : 1);
 
             /* annotations hash will contain "file" and "line" */
             annotations = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTHash);
@@ -579,7 +579,6 @@ MVMObject * MVM_exception_backtrace(MVMThreadContext *tc, MVMObject *ex_obj) {
             value = (MVMObject *)MVM_string_ascii_decode_nt(tc, tc->instance->VMString, line_number);
             value = MVM_repr_box_str(tc, MVM_hll_current(tc)->str_box_type, (MVMString *)value);
             MVM_repr_bind_key_o(tc, annotations, k_line, value);
-            MVM_free(line_number);
 
             /* row will contain "sub" and "annotations" */
             row = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTHash);

--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -359,7 +359,7 @@ static void run_handler(MVMThreadContext *tc, LocatedHandler lh, MVMObject *ex_o
 
     case MVM_EX_ACTION_INVOKE: {
         /* Create active handler record. */
-        MVMActiveHandler *ah = MVM_malloc(sizeof(MVMActiveHandler));
+        MVMActiveHandler *ah = MVM_fixed_size_alloc(tc, tc->instance->fsa, sizeof(MVMActiveHandler));
         MVMFrame *cur_frame = tc->cur_frame;
         MVMFrame *pres_frame;
         MVMObject *handler_code;
@@ -440,7 +440,7 @@ static void unwind_after_handler(MVMThreadContext *tc, void *sr_data) {
     }
     /* Clean up. */
     tc->active_handlers = ah->next_handler;
-    MVM_free(ah);
+    MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMActiveHandler), ah);
 
     /* Do the unwinding as needed. */
     if (exception && exception->body.return_after_unwind) {
@@ -462,7 +462,7 @@ static void cleanup_active_handler(MVMThreadContext *tc, void *sr_data) {
 
     /* Clean up. */
     tc->active_handlers = ah->next_handler;
-    MVM_free(ah);
+    MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMActiveHandler), ah);
 }
 
 char * MVM_exception_backtrace_line(MVMThreadContext *tc, MVMFrame *cur_frame,
@@ -838,7 +838,7 @@ void MVM_exception_resume(MVMThreadContext *tc, MVMObject *ex_obj) {
     /* Clear the current active handler. */
     ah = tc->active_handlers;
     tc->active_handlers = ah->next_handler;
-    MVM_free(ah);
+    MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMActiveHandler), ah);
 
     /* Unwind to the thrower of the exception; set PC and jit entry label. */
     MVM_frame_unwind_to(tc, target, ex->body.resume_addr, 0, NULL, ex->body.jit_resume_label);

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -87,7 +87,7 @@ void MVM_tc_destroy(MVMThreadContext *tc) {
     while (tc->active_handlers) {
         MVMActiveHandler *ah = tc->active_handlers;
         tc->active_handlers = ah->next_handler;
-        MVM_free(ah);
+        MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMActiveHandler), ah);
     }
 
     /* Free the native callback cache. Needs the fixed size allocator. */


### PR DESCRIPTION
By using a fixed size char array in one place and the FSA in another. The number of instructions reported by callgrind do vary a bit, even with `MVM_SPESH_BLOCKING=1`, but it seems to save ~17m instructions for:
```raku
my $a;
$a = do given "hi" {
	when 0      { "zero"    };
	when 1      { "one"     };
	when 2      { "two"     };
	when 3      { "three"   };
	when 4      { "four"    };
	when 5      { "five"    };
	when "hi"   { "hello"   };
	when * > 40 { "> 40"    };
	default     { "default" }
} for ^1_000;
say $a
```