### PR TITLE
Cleanup of a bunch of Unicode hashes

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -405,6 +405,12 @@ struct MVMInstance {
     /* Normal Form Grapheme state (synthetics table, lookup, etc.). */
     MVMNFGState *nfg;
 
+    /* Unicode hashes. */
+    MVMUniHashTable property_codes_by_names_aliases;
+    MVMUniHashTable property_codes_by_seq_names;
+    MVMUniHashTable codepoints_by_name;
+    MVMUniHashTable *unicode_property_values_hashes;
+
     /************************************************************************
      * Type objects for built-in types and special values
      ************************************************************************/

--- a/src/moar.c
+++ b/src/moar.c
@@ -718,8 +718,15 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     uv_mutex_destroy(&instance->mutex_callsite_interns);
     cleanup_callsite_interns(instance);
 
-    /* Release this interpreter's hold on Unicode database */
-    MVM_unicode_release(instance->main_thread);
+    /* Clean up Unicode hashes. */
+    for (int i = 0; i < MVM_NUM_PROPERTY_CODES; i++) {
+        MVM_uni_hash_demolish(instance->main_thread, &instance->unicode_property_values_hashes[i]);
+    }
+    MVM_free_null(instance->unicode_property_values_hashes);
+
+    MVM_uni_hash_demolish(instance->main_thread, &instance->property_codes_by_names_aliases);
+    MVM_uni_hash_demolish(instance->main_thread, &instance->property_codes_by_seq_names);
+    MVM_uni_hash_demolish(instance->main_thread, &instance->codepoints_by_name);
 
     /* Clean up spesh mutexes and close any log. */
     uv_mutex_destroy(&instance->mutex_spesh_install);

--- a/src/strings/unicode.h
+++ b/src/strings/unicode.h
@@ -12,4 +12,3 @@ MVMCodepoint MVM_unicode_find_primary_composite(MVMThreadContext *tc, MVMCodepoi
 #define MVM_unicode_case_change_type_fold  3
 
 void MVM_unicode_init(MVMThreadContext *tc);
-void MVM_unicode_release(MVMThreadContext *tc);


### PR DESCRIPTION
Move static variables to be members of MVMInstance instead. This is
safer if there are multiple MoarVMs running in the same process. Instead
of needing to coordinate initializing/destroying these global variables,
each instance can be responsible for its own hashes.

Additionally, free on shutdown some of the generated-on-demand hashes
that weren't being freed before.

Now valgrind and heaptrack don't report any leaks for
`raku --full-cleanup -e 'my %expressions = D => "got D", M => "got M", l => "got l"; my $a; $a := "%D %M %l".subst(/"%"$<specifier>=<{ %expressions.keys.join("|") }>/, -> ( :$specifier ) { %expressions{$specifier} }, :g) for ^10'; say "\c[LATIN CAPITAL LETTER A]"`.

Fixes #1453