### PR TITLE
Make smrt_intify specializable like other smrt_* ops

### DIFF
--- a/src/core/oplist
+++ b/src/core/oplist
@@ -879,7 +879,7 @@ serializetobuf      w(obj) r(obj) r(obj) r(obj)
 readint             w(int64) r(obj) r(uint64) r(uint64)
 readuint            w(uint64) r(obj) r(uint64) r(uint64)
 readnum             w(num64) r(obj) r(uint64) r(uint64)
-smrt_intify         w(int64) r(obj) :pure :invokish :maycausedeopt :confprog
+smrt_intify         w(int64) r(obj) :pure :invokish :maycausedeopt :confprog :specializable
 uname               w(obj) :pure
 freemem             w(int64) :pure
 totalmem            w(int64) :pure

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -11478,7 +11478,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         1,
         0,
-        0,
+        1,
         { MVM_operand_write_reg | MVM_operand_int64, MVM_operand_read_reg | MVM_operand_obj }
     },
     {


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.