### PR TITLE
Fix JITed ordfirst/ordat/ordbaseat returning 4294967295 instead of -1

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -638,18 +638,20 @@
       (carg $1 int)) ptr_sz))
 
 (template: ordfirst
-  (call (^func &MVM_string_ord_at)
-    (arglist
-      (carg (tc) ptr)
-      (carg $1 ptr)
-      (carg (^zero) int)) int_sz))
+  (scast
+    (call (^func &MVM_string_ord_at)
+      (arglist
+        (carg (tc) ptr)
+        (carg $1 ptr)
+        (carg (^zero) int)) int_sz) int_sz 4))
 
 (template: ordat
-  (call (^func &MVM_string_ord_at)
-    (arglist
-      (carg (tc) ptr)
-      (carg $1 ptr)
-      (carg $2 int)) int_sz))
+  (scast
+    (call (^func &MVM_string_ord_at)
+      (arglist
+        (carg (tc) ptr)
+        (carg $1 ptr)
+        (carg $2 int)) int_sz) int_sz 4))
 
 (template: rindexfrom
   (call (^func &MVM_string_index_from_end)

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2311,6 +2311,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         } else {
             | callp &MVM_string_ord_at;
         }
+        | cdqe;
         | mov qword WORK[dst], RV;
         break;
     }


### PR DESCRIPTION
MVM_string_ord_at returns a MVMGrapheme32 which is a 32 bit signed integer.
However we treated it as a 64 bit integer without proper sign extension, which
turned a -1 into 4294967295. Fix by sign extend the result to a full 64 bit
signed integer.