### PR TITLE
Deprecate now unused graphs_s op

### DIFF
--- a/lib/MAST/Ops.nqp
+++ b/lib/MAST/Ops.nqp
@@ -3950,7 +3950,7 @@ BEGIN {
     'repeat_s', 209,
     'substr_s', 210,
     'index_s', 211,
-    'graphs_s', 212,
+    'DEPRECATED_40', 212,
     'codes_s', 213,
     'getcp_s', 214,
     'indexcp_s', 215,
@@ -4776,7 +4776,7 @@ BEGIN {
     'repeat_s',
     'substr_s',
     'index_s',
-    'graphs_s',
+    'DEPRECATED_40',
     'codes_s',
     'getcp_s',
     'indexcp_s',
@@ -6938,7 +6938,7 @@ BEGIN {
         my uint $index2 := nqp::unbox_u($op2); nqp::writeuint($bytecode, nqp::add_i($elems, 6), $index2, 5);
         my uint $index3 := nqp::unbox_u($op3); nqp::writeuint($bytecode, nqp::add_i($elems, 8), $index3, 5);
     },
-    'graphs_s', sub ($op0, $op1) {
+    'DEPRECATED_40', sub ($op0, $op1) {
         my $bytecode := $*MAST_FRAME.bytecode;
         my uint $elems := nqp::elems($bytecode);
         nqp::writeuint($bytecode, $elems, 212, 5);

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -1620,10 +1620,6 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     GET_REG(cur_op, 2).s, GET_REG(cur_op, 4).s, GET_REG(cur_op, 6).i64);
                 cur_op += 8;
                 goto NEXT;
-            OP(graphs_s):
-                GET_REG(cur_op, 0).i64 = MVM_string_graphs(tc, GET_REG(cur_op, 2).s);
-                cur_op += 4;
-                goto NEXT;
             OP(codes_s):
                 GET_REG(cur_op, 0).i64 = MVM_string_codes(tc, GET_REG(cur_op, 2).s);
                 cur_op += 4;
@@ -6675,6 +6671,8 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVM_exception_throw_adhoc(tc, "The time_i op was removed in MoarVM 2021.04.");
             OP(DEPRECATED_39):
                 MVM_exception_throw_adhoc(tc, "The time_n op was removed in MoarVM 2021.04.");
+            OP(DEPRECATED_40):
+                MVM_exception_throw_adhoc(tc, "The graphs_s op was removed in MoarVM 2021.04.");
             OP(coverage_log): {
                 MVMString *filename = MVM_cu_string(tc, cu, GET_UI32(cur_op, 0));
                 MVMuint32 lineno    = GET_UI32(cur_op, 4);

--- a/src/core/oplabels.h
+++ b/src/core/oplabels.h
@@ -213,7 +213,7 @@ static const void * const LABELS[] = {
     &&OP_repeat_s,
     &&OP_substr_s,
     &&OP_index_s,
-    &&OP_graphs_s,
+    &&OP_DEPRECATED_40,
     &&OP_codes_s,
     &&OP_getcp_s,
     &&OP_indexcp_s,

--- a/src/core/oplist
+++ b/src/core/oplist
@@ -268,8 +268,7 @@ concat_s            w(str) r(str) r(str) :pure :confprog
 repeat_s            w(str) r(str) r(int64) :pure :confprog
 substr_s            w(str) r(str) r(int64) r(int64) :pure :confprog
 index_s             w(int64) r(str) r(str) r(int64) :pure :confprog
-# graphs_s will be DEPRECATED!
-graphs_s            w(int64) r(str) :pure
+DEPRECATED_40       w(int64) r(str) :pure
 codes_s             w(int64) r(str) :pure :confprog
 getcp_s             w(int64) r(str) r(int64) :pure :confprog
 indexcp_s           w(int64) r(str) r(int64) :pure :confprog

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -2970,8 +2970,8 @@ static const MVMOpInfo MVM_op_infos[] = {
         { MVM_operand_write_reg | MVM_operand_int64, MVM_operand_read_reg | MVM_operand_str, MVM_operand_read_reg | MVM_operand_str, MVM_operand_read_reg | MVM_operand_int64 }
     },
     {
-        MVM_OP_graphs_s,
-        "graphs_s",
+        MVM_OP_DEPRECATED_40,
+        "DEPRECATED_40",
         2,
         1,
         0,

--- a/src/core/ops.h
+++ b/src/core/ops.h
@@ -213,7 +213,7 @@
 #define MVM_OP_repeat_s 209
 #define MVM_OP_substr_s 210
 #define MVM_OP_index_s 211
-#define MVM_OP_graphs_s 212
+#define MVM_OP_DEPRECATED_40 212
 #define MVM_OP_codes_s 213
 #define MVM_OP_getcp_s 214
 #define MVM_OP_indexcp_s 215

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -529,13 +529,6 @@
       (carg $2 ptr)
       (carg $3 int)) int_sz))
 
-(template: graphs_s
-  (call (^func &MVM_string_graphs)
-    (arglist
-      (carg (tc) ptr)
-      (carg $1 ptr)) int_sz))
-
-
 (template: codes_s
   (call (^func &MVM_string_codes)
     (arglist

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -279,7 +279,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_eqatic_s: return MVM_string_equal_at_ignore_case;
     case MVM_OP_eqatim_s: return MVM_string_equal_at_ignore_mark;
     case MVM_OP_eqaticim_s: return MVM_string_equal_at_ignore_case_ignore_mark;
-    case MVM_OP_chars: case MVM_OP_graphs_s: return MVM_string_graphs;
+    case MVM_OP_chars: return MVM_string_graphs;
     case MVM_OP_chr: return MVM_string_chr;
     case MVM_OP_codes_s: return MVM_string_codes;
     case MVM_OP_getcp_s: return MVM_string_get_grapheme_at;
@@ -3092,7 +3092,6 @@ start:
         break;
     }
     case MVM_OP_chars:
-    case MVM_OP_graphs_s:
     case MVM_OP_codes_s:
     case MVM_OP_flip: {
         MVMint16 src = ins->operands[1].reg.orig;


### PR DESCRIPTION
It was removed from NQP in
https://github.com/Raku/nqp/commit/a161dbde7d190155d7521b9bee8f82e88b69d945