### PR TITLE
Fix inlines missing synthetic deopt points

### DIFF
--- a/src/6model/reprs/MVMSpeshCandidate.c
+++ b/src/6model/reprs/MVMSpeshCandidate.c
@@ -74,6 +74,7 @@ void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     if (candidate->body.jitcode)
         MVM_jit_code_destroy(tc, candidate->body.jitcode);
     MVM_free(candidate->body.deopt_usage_info);
+    MVM_free(candidate->body.deopt_synths);
 }
 
 static const MVMStorageSpec storage_spec = {
@@ -112,6 +113,8 @@ static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data)
     size += sizeof(MVMCollectable *) * body->num_spesh_slots;
 
     size += sizeof(MVMint32) * body->num_deopts;
+
+    size += sizeof(MVMint32) * body->num_deopt_synths * 2; /* 2 values per entry */
 
     size += sizeof(MVMSpeshInline) * body->num_inlines;
 
@@ -277,6 +280,8 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
     candidate->body.bytecode_size = sc->bytecode_size;
     candidate->body.handlers      = sc->handlers;
     candidate->body.deopt_usage_info = sc->deopt_usage_info;
+    candidate->body.deopt_synths  = sc->deopt_synths;
+    candidate->body.num_deopt_synths = sc->num_deopt_synths;
     candidate->body.num_handlers  = sg->num_handlers;
     candidate->body.num_deopts    = sg->num_deopt_addrs;
     candidate->body.deopts        = sg->deopt_addrs;

--- a/src/6model/reprs/MVMSpeshCandidate.h
+++ b/src/6model/reprs/MVMSpeshCandidate.h
@@ -75,6 +75,9 @@ struct MVMSpeshCandidateBody {
      *  There is a trailing -1 bytecode offset to mark the end of the data.
      */
     MVMint32 *deopt_usage_info;
+
+    MVMint32 *deopt_synths;
+    MVMint32 num_deopt_synths;
 };
 
 struct MVMSpeshCandidate {

--- a/src/spesh/codegen.h
+++ b/src/spesh/codegen.h
@@ -11,6 +11,9 @@ struct MVMSpeshCode {
 
     /* Deopt usage info, which will be stored on the candidate. */
     MVMint32 *deopt_usage_info;
+
+    MVMint32 *deopt_synths;
+    MVMuint64 num_deopt_synths;
 };
 
 MVMSpeshCode * MVM_spesh_codegen(MVMThreadContext *tc, MVMSpeshGraph *g);

--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -602,6 +602,7 @@ static MVMSpeshBB * merge_graph(MVMThreadContext *tc, MVMSpeshGraph *inliner,
                 case MVM_SPESH_ANN_DEOPT_ONE_INS:
                 case MVM_SPESH_ANN_DEOPT_ALL_INS:
                 case MVM_SPESH_ANN_DEOPT_INLINE:
+                case MVM_SPESH_ANN_DEOPT_SYNTH:
                 case MVM_SPESH_ANN_DEOPT_OSR:
                     ann->data.deopt_idx += inliner->num_deopt_addrs;
                     tweak_guard_deopt_idx(ins, ann);


### PR DESCRIPTION
Since commit 3345ec36466dbae315b00960d3afedf121b08451 we have synthetic deopt
points on inserted guards. These deopt points take their index from an existing
deopt point they are linked with. This is important as otherwise we might miss
registers we need to restore when deoptimizing.

However these synth deopt points were not retained on spesh graphs created from
existing candidates for the purpose of inlining. So with these exactly what the
synth deopt points should protect us from was happening. We missed out on some
register usage and did not materialize objects optimized away by PEA.

Fix by collecting information about these synth deopt points when writing byte
code, retaining it in the spesh candidate and restoring it when creating a
control flow graph for inlining.