### PR TITLE
Use correct size for size argument to send()/write()

### DIFF
--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -74,13 +74,13 @@ static void perform_write(MVMThreadContext *tc, MVMIOFileData *data, char *buf, 
     while (bytes > 0) {
         int r;
         do {
-            r = write(data->fd, buf, (int)bytes);
+            r = write(data->fd, buf, bytes > 0x40000000 ? 0x40000000 : bytes);
         } while (r == -1 && errno == EINTR);
         if (r == -1) {
             int save_errno = errno;
             MVM_gc_mark_thread_unblocked(tc);
-            MVM_exception_throw_adhoc(tc, "Failed to write bytes to filehandle: %s",
-                strerror(save_errno));
+            MVM_exception_throw_adhoc(tc, "Failed to write %"PRId64" bytes to filehandle: %s",
+                bytes, strerror(save_errno));
         }
         bytes_written += r;
         buf += r;

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -190,7 +190,7 @@ MVMint64 socket_write_bytes(MVMThreadContext *tc, MVMOSHandle *h, char *buf, MVM
     while (bytes > 0) {
         int r;
         do {
-            r = send(data->handle, buf, (int)bytes, 0);
+            r = send(data->handle, buf, bytes > 0x40000000 ? 0x40000000 : bytes, 0);
         } while(r == -1 && errno == EINTR);
         if (MVM_IS_SOCKET_ERROR(r)) {
             MVM_gc_mark_thread_unblocked(tc);


### PR DESCRIPTION
In 3734a1dcf876fd583c8ee2bfd3f6991a186dc16d it was changed to cast to
`int`, but that can go negative for large values, which causes a 'Bad
address' error. `raku -e 'say "H" x 2147483647' | wc` now correctly
reports 2147483648 characters written. Fixes the second error reported
in https://github.com/rakudo/rakudo/issues/2197#issuecomment-822633751,
but not the original error of that issue.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.