### PR TITLE
Fix spesh missing writes to containers

### DIFF
--- a/src/spesh/args.c
+++ b/src/spesh/args.c
@@ -22,12 +22,6 @@ static void add_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMint32 slot,
 
     /* Add any decontainerized type info. */
     if (type_tuple_entry.decont_type) {
-        g->facts[orig][i].decont_type  = type_tuple_entry.decont_type;
-        g->facts[orig][i].flags       |= MVM_SPESH_FACT_KNOWN_DECONT_TYPE;
-        if (type_tuple_entry.decont_type_concrete)
-            g->facts[orig][i].flags |= MVM_SPESH_FACT_DECONT_CONCRETE;
-        else
-            g->facts[orig][i].flags |= MVM_SPESH_FACT_DECONT_TYPEOBJ;
         if (type_tuple_entry.rw_cont)
             g->facts[orig][i].flags |= MVM_SPESH_FACT_RW_CONT;
     }


### PR DESCRIPTION
When containers get passed as arguments (i.e. read/write arguments), we collect
statistics on these containers' contents and create facts from them. These
facts are guarded by the arg guard tree which is used for selecting spesh
candidates, so a candidate relying on these facts will only be run, when the
facts hold.

However we also propagated these facts futher and used them for optimizations.
The problem is that containers are mutable so while the facts are guaranteed
to be correct at the invocation of a frame, they may change during the frame's
runtime when for example a new value gets assigned to the container.

This led to spesh optimizing away a method lookup and replacing it with a
spesh slot holding the wrong class' method.

Fix by just not propagating facts about deconted values into the frame's
registers. We do collect statistics from the decont ops within the frames
and can still optimizing based on those and we add proper guards on them.