### PR TITLE
Fix heap-use-after-free in t/spec/S17-promise/nonblocking-await.t

### DIFF
--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -882,7 +882,7 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
         /* Preserve the extras if the frame has been used in a ctx operation
          * and marked with caller info. */
         if (!(e->caller_deopt_idx || e->caller_jit_position)) {
-            MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMFrameExtra), e);
+            MVM_fixed_size_free_at_safepoint(tc, tc->instance->fsa, sizeof(MVMFrameExtra), e);
             returner->extra = NULL;
         }
     }


### PR DESCRIPTION
What happens is that we start a task on a worker thread. This
task then looks up a dynamic variable up the call chain and in
the lexical context. It can happen that we exit the caller frame
precisely in the moment that the task's frame walker is processing
this frame. When exiting we also clean up the frame extras which
among onther things holds the dynvar cache.
Using the _at_safepoint version defers freeing that structure, so
it won't happen that the thing gets freed while the frame walker
is still using it.

nine++ for finding out what caused the bug and explaining it