### PR TITLE
 Try to trap concurrent hash accesses.

### DIFF
--- a/src/core/fixedsizealloc.c
+++ b/src/core/fixedsizealloc.c
@@ -58,6 +58,13 @@ void MVM_fixed_size_create_thread(MVMThreadContext *tc) {
 void MVM_fixed_size_destroy(MVMFixedSizeAlloc *al) {
     int bin_no;
 
+    /* Free anything on the overflow lists. */
+    MVMFixedSizeAllocSafepointFreeListEntry *cur = al->free_at_next_safepoint_overflows;
+    while (cur) {
+        MVM_free(cur->to_free);
+        cur = cur->next;
+    }
+
     for (bin_no = 0; bin_no < MVM_FSA_BINS; bin_no++) {
         int page_no;
         int num_pages = al->size_classes[bin_no].num_pages;

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -439,6 +439,13 @@ struct MVMStrHashTableControl {
      * to cache it as we have the space. */
     MVMuint8 max_probe_distance_limit;
     MVMuint8 metadata_hash_bits;
+    /* This is set to 0 when the control structure is allocated. When the hash
+     * expands (and needs a new larger allocation) this is set to 1 in the
+     * soon-to-be-freed memory, and the memory is scheduled to be released at
+     * the next safe point. This way avoid C-level use-after-free if threads
+     * attempt to mutate the same hash concurrently, and hopefully can spot at
+     * least some cases and fault them, often enough for bugs to be noticed. */
+    volatile MVMuint8 stale;
 };
 
 struct MVMStrHashTable {

--- a/src/core/str_hash_table.h
+++ b/src/core/str_hash_table.h
@@ -474,6 +474,9 @@ MVM_STATIC_INLINE int MVM_str_hash_iterator_target_deleted(MVMThreadContext *tc,
      * deleted (and this is the only action on the hash since the iterator was
      * created) */
     struct MVMStrHashTableControl *control = hashtable->table;
+    if (MVM_UNLIKELY(control && control->stale)) {
+        MVM_oops(tc, "MVM_str_hash_iterator_target_deleted called with a stale hashtable pointer");
+    }
     return control && iterator.serial == control->serial - 1 &&
         iterator.pos == control->last_delete_at;
 }
@@ -490,6 +493,9 @@ MVM_STATIC_INLINE int MVM_str_hash_iterator_target_deleted(MVMThreadContext *tc,
 MVM_STATIC_INLINE int MVM_str_hash_at_end(MVMThreadContext *tc,
                                            MVMStrHashTable *hashtable,
                                            MVMStrHashIterator iterator) {
+    if (MVM_UNLIKELY(hashtable->table && hashtable->table->stale)) {
+        MVM_oops(tc, "MVM_str_hash_at_end called with a stale hashtable pointer");
+    }
 #if HASH_DEBUG_ITER
     struct MVMStrHashTableControl *control = hashtable->table;
     MVMuint64 ht_id = control ? control->ht_id : 0;


### PR DESCRIPTION
Previously MoarVM could well SEGV if two user threads access the same hash without locking. Now if it detects concurrent access it will oops instead with a diagnostic. It's not clear to me that we can really recover if we detect this, as concurrent write accesses might have already corrupted the hash structures too far for us to resolve problems.
