### PR TITLE
Free loaded libs during full cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -260,6 +260,6 @@ stages:
         - script: |
             valgrind --leak-check=full ../$(INSTALL_DIR)/bin/raku --full-cleanup -e '' 2>valgrind.log
             cat valgrind.log
-            ../$(INSTALL_DIR)/bin/raku -ne 'BEGIN my @lost; @lost.push($0) if /"lost: " (\d+)/; END exit @lost.elems != 3 || all(@lost) != 0' valgrind.log
+            grep 'in use at exit: 0 bytes in 0 blocks' valgrind.log
           condition: and(succeeded(), eq( variables['CHECK_LEAKS'], 'yes' ), ne( variables['COVERAGE'], 'yes' ), eq( variables['Agent.OS'], 'Linux' ))
           displayName: Check for memory leaks

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -131,3 +131,9 @@ MVM_STATIC_INLINE void *MVM_fixkey_hash_fetch_nocheck(MVMThreadContext *tc,
 void *MVM_fixkey_hash_lvalue_fetch_nocheck(MVMThreadContext *tc,
                                            MVMFixKeyHashTable *hashtable,
                                            MVMString *key);
+
+/* Executes the given callback function on each element of the hashtable.
+ * Passes the callback (tc, entry, arg) */
+void MVM_fixkey_hash_foreach(MVMThreadContext *tc, MVMFixKeyHashTable *hashtable,
+                             void (*callback)(MVMThreadContext *, void *, void *),
+                             void *arg);


### PR DESCRIPTION
In MVM_vm_destroy_instance call MVM_nativecall_free_lib` for each DLL.

As diagnosed by @MasterDuke17, doing this gets us to a completely clean report from `valgrind` when running `rakudo --full-cleanup  -e ''`