### PR TITLE
Define _GNU_SOURCE for GNU builds

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -230,7 +230,7 @@ if ($args{'has-sha'}) {
 }
 else { $config{shaincludedir} = '3rdparty/sha1' }
 
-# After upgrading from libuv from 0.11.18 to 0.11.29 we see very weird erros
+# After upgrading from libuv from 0.11.18 to 0.11.29 we see very weird errors
 # when the old libuv files are still around. Running a `make realclean` in
 # case we spot an old file and the Makefile is already there.
 if (-e '3rdparty/libuv/src/unix/threadpool' . $defaults{obj}
@@ -430,6 +430,9 @@ push @cflags, '-DWORDS_BIGENDIAN' if $config{be}; # 3rdparty/sha1 needs it and i
 push @cflags, '-DMVM_HEAPSNAPSHOT_FORMAT=' . $config{heapsnapformat};
 push @cflags, $ENV{CFLAGS} if $ENV{CFLAGS};
 push @cflags, $ENV{CPPFLAGS} if $ENV{CPPFLAGS};
+
+push @cflags, '-D_GNU_SOURCE'; # mainly for libuv
+
 $config{cflags} = join ' ', uniq(@cflags);
 
 # generate LDFLAGS

--- a/Configure.pl
+++ b/Configure.pl
@@ -431,7 +431,7 @@ push @cflags, '-DMVM_HEAPSNAPSHOT_FORMAT=' . $config{heapsnapformat};
 push @cflags, $ENV{CFLAGS} if $ENV{CFLAGS};
 push @cflags, $ENV{CPPFLAGS} if $ENV{CPPFLAGS};
 
-push @cflags, '-D_GNU_SOURCE'; # mainly for libuv
+push @cflags, '-D_GNU_SOURCE' unless $args{'has-libuv'}; # quells warnings with gcc and libuv
 
 $config{cflags} = join ' ', uniq(@cflags);
 

--- a/src/moar.h
+++ b/src/moar.h
@@ -5,7 +5,9 @@
 /* pthread_setname_np only exists if we set _GNU_SOURCE extremely early.
  * We will need to be vgilant to not accidentally use gnu extensions in
  * other places without checking properly. */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #endif
 
 #include <stdarg.h>

--- a/src/platform/memmem.h
+++ b/src/platform/memmem.h
@@ -12,7 +12,9 @@ void *memmem(const void *h0, size_t k, const void *n0, size_t l);
 #else
 /* On systems that use glibc, you must define _GNU_SOURCE before including string.h
  * to get access to memmem. */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <string.h>
 #endif
 

--- a/src/platform/random.c
+++ b/src/platform/random.c
@@ -16,7 +16,9 @@
     #if defined(SYS_getrandom)
     /* With glibc you are supposed to declare _GNU_SOURCE to use the
      * syscall function */
-        #define _GNU_SOURCE
+        #ifndef _GNU_SOURCE
+            #define _GNU_SOURCE
+        #endif
         #define GRND_NONBLOCK 0x01
         #include <unistd.h>
         #define MVM_random_use_getrandom_syscall 1


### PR DESCRIPTION
The definition results in quelling the compile warnings for libuv on Debian Buster with gcc

The changed MoarVM source files have #ifndef/#endif guards added to prevent redefinition warnings
