### PR TITLE
Quell compiler warnings on Linux with gcc

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3355,7 +3355,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (REPR(maybe_cu)->ID == MVM_REPR_ID_MVMCompUnit) {
                     MVMCompUnit *cu = (MVMCompUnit *)maybe_cu;
                     if (cu->body.mainline_frame) {
-                        MVMObject *coderef;
+                        MVMObject *coderef = 0;
                         for (MVMuint32 i = 0; i < cu->body.num_frames; i++) {
                             if (((MVMCode*)cu->body.coderefs[i])->body.sf == cu->body.mainline_frame) {
                                 coderef = cu->body.coderefs[i];

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3355,7 +3355,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (REPR(maybe_cu)->ID == MVM_REPR_ID_MVMCompUnit) {
                     MVMCompUnit *cu = (MVMCompUnit *)maybe_cu;
                     if (cu->body.mainline_frame) {
-                        MVMObject *coderef = 0;
+                        MVMObject *coderef = NULL;
                         for (MVMuint32 i = 0; i < cu->body.num_frames; i++) {
                             if (((MVMCode*)cu->body.coderefs[i])->body.sf == cu->body.mainline_frame) {
                                 coderef = cu->body.coderefs[i];

--- a/src/strings/decode_stream.h
+++ b/src/strings/decode_stream.h
@@ -93,21 +93,43 @@ struct MVMDecodeStreamSeparators {
  * demand the actual encodings themselves work out (multi-grapheme separators
  * are handled in the decode stream logic itself). */
 MVM_STATIC_INLINE MVMint32 MVM_string_decode_stream_maybe_sep(MVMThreadContext *tc, MVMDecodeStreamSeparators *sep_spec, MVMGrapheme32 g) {
-#ifdef _GNU_SOURCE
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+/* Take care of each Linux compilers' warnings to be ignored.  Note both
+   compilers define '__GNUC__', so macro '__clang__' needs to be tested first to
+   disambiguate the two.
+*/
+#if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wuninitialized"
+#elif defined(__GNUC__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
     if (sep_spec && g <= sep_spec->max_final_grapheme) {
-#ifdef _GNU_SOURCE
-#pragma GCC diagnostic pop
+/* Each compiler had one push, so each requires one pop. */
+#if defined(__clang__)
+    #pragma clang diagnostic pop
+#elif defined(__GNUC__)
+    #pragma GCC diagnostic pop
 #endif
         MVMint32 i;
         for (i = 0; i < sep_spec->num_seps; i++)
-#ifdef _GNU_SOURCE
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+/* Take care of each Linux compilers' warnings to be ignored.  Note both
+   compilers define '__GNUC__', so macro '__clang__' needs to be tested first to
+   disambiguate the two.
+*/
+#if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wuninitialized"
+#elif defined(__GNUC__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
             if (sep_spec->final_graphemes[i] == g)
-#ifdef _GNU_SOURCE
-#pragma GCC diagnostic pop
+/* Each compiler had one push, so each requires one pop. */
+#if defined(__clang__)
+    #pragma clang diagnostic pop
+#elif defined(__GNUC__)
+    #pragma GCC diagnostic pop
 #endif
                 return 1;
     }

--- a/src/strings/decode_stream.h
+++ b/src/strings/decode_stream.h
@@ -93,10 +93,22 @@ struct MVMDecodeStreamSeparators {
  * demand the actual encodings themselves work out (multi-grapheme separators
  * are handled in the decode stream logic itself). */
 MVM_STATIC_INLINE MVMint32 MVM_string_decode_stream_maybe_sep(MVMThreadContext *tc, MVMDecodeStreamSeparators *sep_spec, MVMGrapheme32 g) {
+#ifdef _GNU_SOURCE
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     if (sep_spec && g <= sep_spec->max_final_grapheme) {
+#ifdef _GNU_SOURCE
+#pragma GCC diagnostic pop
+#endif
         MVMint32 i;
         for (i = 0; i < sep_spec->num_seps; i++)
+#ifdef _GNU_SOURCE
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
             if (sep_spec->final_graphemes[i] == g)
+#ifdef _GNU_SOURCE
+#pragma GCC diagnostic pop
+#endif
                 return 1;
     }
     return 0;

--- a/src/strings/shiftjis.c
+++ b/src/strings/shiftjis.c
@@ -350,7 +350,7 @@ MVMuint32 MVM_string_shiftjis_decodestream(MVMThreadContext *tc, MVMDecodeStream
         MVMuint8 *bytes = (MVMuint8 *)cur_bytes->bytes;
         while (pos < cur_bytes->length || repl_pos) {
             MVMGrapheme32 graph;
-            MVMCodepoint codepoint;
+            MVMCodepoint codepoint = 0;
             MVMuint8 byte;
             int graph_is_set = 0;
             int handler_rtrn = 0;

--- a/src/strings/shiftjis.c
+++ b/src/strings/shiftjis.c
@@ -429,7 +429,7 @@ MVMuint32 MVM_string_shiftjis_decodestream(MVMThreadContext *tc, MVMDecodeStream
             last_accept_bytes = cur_bytes;
             last_accept_pos   = pos;
             total++;
-            if (MVM_string_decode_stream_maybe_sep(tc, seps, codepoint)) {
+            if (handler_rtrn == DECODE_CODEPOINT && MVM_string_decode_stream_maybe_sep(tc, seps, codepoint)) { 
                 reached_stopper = 1;
                 goto done;
             }

--- a/src/strings/shiftjis.c
+++ b/src/strings/shiftjis.c
@@ -350,7 +350,7 @@ MVMuint32 MVM_string_shiftjis_decodestream(MVMThreadContext *tc, MVMDecodeStream
         MVMuint8 *bytes = (MVMuint8 *)cur_bytes->bytes;
         while (pos < cur_bytes->length || repl_pos) {
             MVMGrapheme32 graph;
-            MVMCodepoint codepoint = 0;
+            MVMCodepoint codepoint;
             MVMuint8 byte;
             int graph_is_set = 0;
             int handler_rtrn = 0;


### PR DESCRIPTION
Ensure two reference variables are initialized before use