### PR TITLE
Disable GCC pragmas when using MSVC

### DIFF
--- a/src/io/signals.c
+++ b/src/io/signals.c
@@ -129,12 +129,16 @@ static const MVMAsyncTaskOps op_table = {
 #define GEN_ENUMS(v)   v,
 #define GEN_STRING(v) #v,
 
+#ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 static enum {
     PROCESS_SIGS(GEN_ENUMS)
 } MVM_sig_names;
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
+#endif
 
 
 static char const * const SIG_WANTED[NUM_SIG_WANTED] = {

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1,11 +1,15 @@
 /* -*-C-*- */
 #include "moar.h"
 #include "jit/internal.h"
+#ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
 #include "dasm_x86.h"
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 
 #ifdef _MSC_VER
 #pragma warning( disable : 4129 )

--- a/src/jit/x64/tiles.dasc
+++ b/src/jit/x64/tiles.dasc
@@ -1,5 +1,7 @@
 /* -*-C-*- */
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 #define DIE(...) do { MVM_oops(tc, __VA_ARGS__); } while (0)
 
 /* NB: The rax/eax/ax/al/ah register is *reserved* for internal use in tiles by

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -913,16 +913,20 @@ void serialize_attribute_stream(MVMThreadContext *tc, MVMHeapSnapshotCollection 
          * warning aside, strncpy seems like exactly the right tool for the job
          * as we want at most 8 bytes and don't care for any trailing \0, but
          * are OK with zero padding at the end. */
+#ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
         strncpy(namebuf, name, 8);
+#ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #pragma clang diagnostic pop
 #pragma GCC diagnostic pop
+#endif
         fwrite(namebuf, 8, 1, fh);
     }
 


### PR DESCRIPTION
Otherwise they cause warnings when building on Windows.