### PR TITLE
Set sc.idx during deserialization to avoid costly lookup later

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -2283,6 +2283,7 @@ static void stub_stable(MVMThreadContext *tc, MVMSerializationReader *reader, MV
 
     /* Set the STable's SC. */
     MVM_sc_set_stable_sc(tc, st, reader->root.sc);
+    MVM_sc_set_idx_in_sc((MVMCollectable*) st, i);
 
     /* Set STable read position, and set current read buffer to the
      * location of the REPR data. */
@@ -2356,6 +2357,7 @@ static void stub_object(MVMThreadContext *tc, MVMSerializationReader *reader, MV
 
     /* Set the object's SC. */
     MVM_sc_set_obj_sc(tc, obj, reader->root.sc);
+    MVM_sc_set_idx_in_sc((MVMCollectable*)obj, i);
 }
 
 /* Deserializes a context. */


### PR DESCRIPTION
When we deserialize a collectable, we actually already know which SC it
belongs to and the index in this SC. So far we've already told the the
collectable about the SC, but not about the index. So the first call to
MVM_sc_find_object_idx had to do a linear search of the SC to find the index.
Fix by setting the idx field in the collectable header on deserialization.

This brings installation of rakudo core modules down from 7.89s to 7.21s
and reduces CPU time of rakudo make test from 138.98s to 134.27s.