### PR TITLE
msinttypes no longer needed in $PREFIX\include

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -594,13 +594,6 @@ unless (defined $config{jit_obj}) {
     $config{dasm_flags}   = '';
 }
 
-
-if ($config{cc} eq 'cl') {
-    $config{install}   .= "\t\$(MKPATH) \"\$(DESTDIR)\$(PREFIX)/include/msinttypes\"\n"
-                        . "\t\$(CP) 3rdparty/msinttypes/*.h \"\$(DESTDIR)\$(PREFIX)/include/msinttypes\"\n";
-    push @hllincludes, 'msinttypes';
-}
-
 if ($^O eq 'aix' && $config{ptr_size} == 4) {
     $config{ldflags} = join(',', $config{ldflags}, '-bmaxdata:0x80000000');
 }


### PR DESCRIPTION
It isn't actually being put in the include paths for NQP/Rakudo, and if
you do add it, it causes problems with the libuv include.