### PR TITLE
Fix some bugs in the various hash_fsck functions.

### DIFF
--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -418,7 +418,7 @@ MVMuint64 MVM_fixkey_hash_fsck(MVMThreadContext *tc, MVMFixKeyHashTable *hashtab
         ++metadata;
         entry_raw -= sizeof(MVMString ***);
     }
-    if (*metadata != 1) {
+    if (*metadata != 0) {
         ++errors;
         if (display) {
             fprintf(stderr, "%s    %02x!\n", prefix_hashes, *metadata);

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -796,10 +796,8 @@ static MVMuint64 hash_fsck_internal(MVMThreadContext *tc, struct MVMStrHashTable
                 if (offset < 1) {
                     wrong_order = '<';
                 } else if (offset > control->max_probe_distance) {
-                    ++errors;
                     wrong_order = '>';
                 } else if (offset > prev_offset + 1) {
-                    ++errors;
                     wrong_order = '!';
                 } else {
                     wrong_order = ' ';
@@ -859,7 +857,7 @@ static MVMuint64 hash_fsck_internal(MVMThreadContext *tc, struct MVMStrHashTable
         ++metadata;
         entry_raw -= control->entry_size;
     }
-    if (*metadata != 1) {
+    if (*metadata != 0) {
         ++errors;
         if (display) {
             fprintf(stderr, "%s    %02x!\n", prefix_hashes, *metadata);

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -373,10 +373,8 @@ static MVMuint64 uni_hash_fsck_internal(struct MVMUniHashTableControl *control, 
             if (offset < 1) {
                 wrong_order = '<';
             } else if (offset > control->max_probe_distance) {
-                ++errors;
                 wrong_order = '>';
             } else if (offset > prev_offset + 1) {
-                ++errors;
                 wrong_order = '!';
             } else {
                 wrong_order = ' ';
@@ -395,7 +393,7 @@ static MVMuint64 uni_hash_fsck_internal(struct MVMUniHashTableControl *control, 
         ++metadata;
         entry_raw -= sizeof(struct MVMUniHashEntry);
     }
-    if (*metadata != 1) {
+    if (*metadata != 0) {
         ++errors;
         if (display) {
             fprintf(stderr, "%s    %02x!\n", prefix_hashes, *metadata);


### PR DESCRIPTION
They were still assuming that the metadata sentinel byte needed to be 1,
and reporting an error if it was not. This should have been changed as
part of commit b432533e90f175a7 in Oct 2020:
    The hash metadata sentinel byte can be 0 - it does not need to be 1.

Also, no need to increment `errors` when `wrong_order` is set, as there is
code to increment it later. This bug is not as serious because it only
causes fsck to return the wrong count of errors found for a hash that has
errors. It was introduced in Oct 2020 as part of commit 99aab70ebcd65f21:
    `MVM_str_hash_fsck` now checks (and faults) max_prove_distance violations.