### PR TITLE
Fix another bug in MVM_str_hash_fsck().

### DIFF
--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -711,9 +711,10 @@ static MVMuint64 hash_fsck_internal(MVMThreadContext *tc, struct MVMStrHashTable
     MVMuint64 errors = 0;
     MVMuint64 seen = 0;
 
-    if (MVM_str_hash_entries(control) == NULL) {
+    if (!control || (control->cur_items == 0 && control->max_items == 0)) {
         if (display) {
-            fprintf(stderr, "%s NULL %p (empty)\n", prefix_hashes, control);
+            fprintf(stderr, "%s %p (empty%s)\n", prefix_hashes, control,
+                    control ? " optimisation" : "");
         }
         return 0;
     }


### PR DESCRIPTION
Calling `MVM_str_hash_entries` when just the control structure was allocated
(the empty hash optimisation) would trigger an assertion failure.

We need to check `control->cur_items` and `control->max_items` explicitly.
It also makes sense to check for `control` being NULL and handling that case
(instead of segfaulting).