### PR TITLE
Fix spesh optimizing away still needed label register

### DIFF
--- a/src/spesh/facts.c
+++ b/src/spesh/facts.c
@@ -768,6 +768,12 @@ static void tweak_block_handler_usage(MVMThreadContext *tc, MVMSpeshGraph *g) {
             operand.reg.i = 1;
             MVM_spesh_usages_add_for_handler_by_reg(tc, g, operand);
         }
+        if (g->sf->body.handlers[i].category_mask & MVM_EX_CAT_LABELED) {
+            MVMSpeshOperand operand;
+            operand.reg.orig = g->sf->body.handlers[i].label_reg;
+            operand.reg.i = 1;
+            MVM_spesh_usages_add_for_handler_by_reg(tc, g, operand);
+        }
     }
 }
 

--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -778,10 +778,14 @@ static void build_cfg(MVMThreadContext *tc, MVMSpeshGraph *g, MVMStaticFrame *sf
 static MVMint32 is_handler_reg(MVMThreadContext *tc, MVMSpeshGraph *g, MVMuint16 reg) {
     MVMuint32 num_handlers = g->num_handlers;
     MVMuint32 i;
-    for (i = 0; i < num_handlers; i++)
+    for (i = 0; i < num_handlers; i++) {
         if (g->handlers[i].action == MVM_EX_ACTION_INVOKE)
             if (g->handlers[i].block_reg == reg)
                 return 1;
+        if (g->handlers[i].category_mask & MVM_EX_CAT_LABELED)
+            if (g->handlers[i].label_reg == reg)
+                return 1;
+    }
     return 0;
 }
 static void insert_object_null_instructions(MVMThreadContext *tc, MVMSpeshGraph *g) {


### PR DESCRIPTION
Objects representing loop labels are kept in a register and may be used by loop
handlers (like next LABEL). Spesh did not take this relationship into account,
just saw a register that was written to, but not otherwise used and optimized
the writers of this register away. Fix by giving a handler's label_reg the same
treatment as block_reg.

Fixes Rakudo issue #4456