### PR TITLE
Fix deadlock by untimely GC in multi-threaded programs

### DIFF
--- a/src/spesh/worker.c
+++ b/src/spesh/worker.c
@@ -193,10 +193,12 @@ static void worker(MVMThreadContext *tc, MVMCallsite *callsite, MVMRegister *arg
 
                     /* If needed, signal sending thread that it can continue. */
                     if (sl->body.block_mutex) {
+                        MVM_gc_mark_thread_blocked(tc);
                         uv_mutex_lock(sl->body.block_mutex);
                         MVM_store(&(sl->body.completed), 1);
                         uv_cond_signal(sl->body.block_condvar);
                         uv_mutex_unlock(sl->body.block_mutex);
+                        MVM_gc_mark_thread_unblocked(tc);
                     }
                     {
                         MVMSpeshLogEntry *entries = sl->body.entries;


### PR DESCRIPTION
In send_log we're marking the thread blocked while holding the
sl->body.block_mutex. In the spesh worker we're trying to lock the
sl->body.block_mutex without the thread being marked blocked for GC.
Now if some other thread at that point has decided that a GC run is in order,
send_log will wait for the GC run. But the GC run cannot start until the spesh
thread joins in. Which will never happen, since that's still waiting for
the sl->body.block_mutex.

Fix by marking the spesh worker thread blocked while waiting for block_mutex.
This way, the GC can proceed and send_log can unlock the mutex afterwards.