### PR TITLE
Free filename if exception when loading bytecode

### DIFF
--- a/src/core/compunit.h
+++ b/src/core/compunit.h
@@ -1,5 +1,5 @@
 MVMCompUnit * MVM_cu_from_bytes(MVMThreadContext *tc, MVMuint8 *bytes, MVMuint32 size);
-MVMCompUnit * MVM_cu_map_from_file(MVMThreadContext *tc, const char *filename);
+MVMCompUnit * MVM_cu_map_from_file(MVMThreadContext *tc, const char *filename, MVMint32 free_filename);
 MVMCompUnit * MVM_cu_map_from_file_handle(MVMThreadContext *tc, uv_file fd, MVMuint64 pos);
 MVMuint16 MVM_cu_callsite_add(MVMThreadContext *tc, MVMCompUnit *cu, MVMCallsite *cs);
 MVMuint32 MVM_cu_string_add(MVMThreadContext *tc, MVMCompUnit *cu, MVMString *str);

--- a/src/core/loadbytecode.c
+++ b/src/core/loadbytecode.c
@@ -105,10 +105,7 @@ void MVM_load_bytecode(MVMThreadContext *tc, MVMString *filename) {
     /* Otherwise, load from disk. */
     MVMROOT(tc, filename, {
         char *c_filename = MVM_string_utf8_c8_encode_C_string(tc, filename);
-        /* XXX any exception from MVM_cu_map_from_file needs to be handled
-         *     and c_filename needs to be freed */
-        MVMCompUnit *cu = MVM_cu_map_from_file(tc, c_filename);
-        MVM_free(c_filename);
+        MVMCompUnit *cu = MVM_cu_map_from_file(tc, c_filename, 1);
         cu->body.filename = filename;
         MVM_gc_write_barrier_hit(tc, (MVMCollectable *)cu);
 

--- a/src/moar.c
+++ b/src/moar.c
@@ -489,7 +489,7 @@ static void run_deserialization_frame(MVMThreadContext *tc, MVMCompUnit *cu) {
 void MVM_vm_run_file(MVMInstance *instance, const char *filename) {
     /* Map the compilation unit into memory and dissect it. */
     MVMThreadContext *tc = instance->main_thread;
-    MVMCompUnit      *cu = MVM_cu_map_from_file(tc, filename);
+    MVMCompUnit      *cu = MVM_cu_map_from_file(tc, filename, 0);
 
     /* The call to MVM_string_utf8_decode() may allocate, invalidating the
        location cu->body.filename */


### PR DESCRIPTION
Because sometimes the given filename is malloced and sometimes it's from
argv, we also have to add a flag for whether it should be freed.