### PR TITLE
Respect --full-cleanup in nqp::exit

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -211,6 +211,9 @@ struct MVMInstance {
     MVM_VECTOR_DECL(void *, free_at_safepoint);
     uv_mutex_t mutex_free_at_safepoint;
 
+    /* Whether the --full-cleanup flag was passed. */
+    MVMuint32 full_cleanup;
+
     /************************************************************************
      * Object system
      ************************************************************************/

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -3815,7 +3815,12 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             OP(exit): {
                 MVMint64 exit_code = GET_REG(cur_op, 0).i64;
-                MVM_io_flush_standard_handles(tc);
+                if (tc->instance->full_cleanup) {
+                    MVM_vm_destroy_instance(tc->instance);
+                }
+                else {
+                    MVM_io_flush_standard_handles(tc);
+                }
                 exit(exit_code);
             }
             OP(cwd):

--- a/src/main.c
+++ b/src/main.c
@@ -301,6 +301,8 @@ int wmain(int argc, wchar_t *wargv[])
         }
     }
 
+    instance->full_cleanup = full_cleanup;
+
     if (dump) MVM_vm_dump_file(instance, input_file);
     else MVM_vm_run_file(instance, input_file);
 


### PR DESCRIPTION
If --full-cleanup was passed, but we are exiting via an nqp::exit call,
still do the cleanup. To do this we need to know in the interpreter if
--full-cleanup was in fact passed, so add a flag to MVMInstance for it.

The change in src/main.c needs to be replicated in the NQP and Rakudo runners for it to actually work for them, but that will only be done after this PR is merged and a bump is done so they see the new field in MVMInstance.