### PR TITLE
Container registry to MVMFixKeyHashTable

### DIFF
--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -739,7 +739,7 @@ static const MVMContainerConfigurer NativeRefContainerConfigurer = {
  * ***************************************************************************/
 
 /* Adds a container configurer to the registry. */
-void MVM_6model_add_container_config(MVMThreadContext *tc, MVMString *name,
+static void add_container_config(MVMThreadContext *tc, MVMString *name,
         const MVMContainerConfigurer *configurer) {
 
     if (!MVM_str_hash_key_is_valid(tc, name)) {
@@ -775,11 +775,11 @@ const MVMContainerConfigurer * MVM_6model_get_container_config(MVMThreadContext 
  * the various built-in container types. */
 void MVM_6model_containers_setup(MVMThreadContext *tc) {
     /* Add built-in configurations. */
-    MVM_6model_add_container_config(tc,
+    add_container_config(tc,
         MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "code_pair"), &CodePairContainerConfigurer);
-    MVM_6model_add_container_config(tc,
+    add_container_config(tc,
         MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "native_ref"), &NativeRefContainerConfigurer);
-    MVM_6model_add_container_config(tc,
+    add_container_config(tc,
         MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "value_desc_cont"), &ValueDescContainerConfigurer);
 }
 

--- a/src/6model/containers.h
+++ b/src/6model/containers.h
@@ -75,8 +75,7 @@ struct MVMContainerConfigurer {
 };
 
 /* Container registry is a hash mapping names of container configurations
- * to function tables. As it's global (accessed with a mutex held) its entries
- * can't inline the struct returned to the caller. Hence the indirection: */
+ * to function tables. */
 struct MVMContainerRegistry {
     struct MVMStrHashHandle hash_handle;
     const MVMContainerConfigurer *configurer;

--- a/src/6model/containers.h
+++ b/src/6model/containers.h
@@ -67,18 +67,12 @@ struct MVMContainerSpec {
 /* A container configurer knows how to attach a certain type of container
  * to an STable and configure it. */
 struct MVMContainerConfigurer {
+    MVMString *name;
     /* Sets this container spec in place for the specified STable. */
     void (*set_container_spec) (MVMThreadContext *tc, MVMSTable *st);
 
     /* Configures the container spec with the specified info. */
     void (*configure_container_spec) (MVMThreadContext *tc, MVMSTable *st, MVMObject *config);
-};
-
-/* Container registry is a hash mapping names of container configurations
- * to function tables. */
-struct MVMContainerRegistry {
-    struct MVMStrHashHandle hash_handle;
-    const MVMContainerConfigurer *configurer;
 };
 
 const MVMContainerConfigurer * MVM_6model_get_container_config(MVMThreadContext *tc, MVMString *name);

--- a/src/6model/containers.h
+++ b/src/6model/containers.h
@@ -82,7 +82,6 @@ struct MVMContainerRegistry {
     const MVMContainerConfigurer *configurer;
 };
 
-MVM_PUBLIC void MVM_6model_add_container_config(MVMThreadContext *tc, MVMString *name, const MVMContainerConfigurer *configurer);
 const MVMContainerConfigurer * MVM_6model_get_container_config(MVMThreadContext *tc, MVMString *name);
 void MVM_6model_containers_setup(MVMThreadContext *tc);
 MVMint64 MVM_6model_container_iscont_rw(MVMThreadContext *tc, MVMObject *cont);

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -246,7 +246,7 @@ struct MVMInstance {
     uv_mutex_t mutex_repr_registry;
 
     /* Container type registry. */
-    MVMStrHashTable       container_registry;
+    MVMFixKeyHashTable container_registry;
 
     /* Hash of all known serialization contexts. Marked for GC iff
      * the item is unresolved. Also, array of all SCs, used for the

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -245,9 +245,8 @@ struct MVMInstance {
     /* Mutex for REPR registration. */
     uv_mutex_t mutex_repr_registry;
 
-    /* Container type registry and mutex to protect it. */
+    /* Container type registry. */
     MVMStrHashTable       container_registry;
-    uv_mutex_t      mutex_container_registry;
 
     /* Hash of all known serialization contexts. Marked for GC iff
      * the item is unresolved. Also, array of all SCs, used for the

--- a/src/gc/roots.c
+++ b/src/gc/roots.c
@@ -118,15 +118,6 @@ void MVM_gc_root_add_instance_roots_to_worklist(MVMThreadContext *tc, MVMGCWorkl
         iterator = MVM_str_hash_next_nocheck(tc, weakhash, iterator);
     }
 
-    MVMStrHashTable *const containers = &tc->instance->container_registry;
-    iterator = MVM_str_hash_first(tc, containers);
-    while (!MVM_str_hash_at_end(tc, containers, iterator)) {
-        MVMContainerRegistry *registry = MVM_str_hash_current_nocheck(tc, containers, iterator);
-        add_collectable(tc, worklist, snapshot, registry->hash_handle.key,
-                        "Container configuration hash key");
-        iterator = MVM_str_hash_next_nocheck(tc, containers, iterator);
-    }
-
     add_collectable(tc, worklist, snapshot, tc->instance->cached_backend_config,
         "Cached backend configuration hash");
 

--- a/src/moar.c
+++ b/src/moar.c
@@ -190,7 +190,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     MVM_fixkey_hash_build(instance->main_thread, &instance->loaded_compunits, sizeof(MVMString *));
 
     /* Set up container registry. */
-    MVM_str_hash_build(instance->main_thread, &instance->container_registry, sizeof(MVMContainerRegistry), 0);
+    MVM_fixkey_hash_build(instance->main_thread, &instance->container_registry, 0);
 
     /* Set up persistent object ID hash mutex. */
     init_mutex(instance->mutex_object_ids, "object ID hash");
@@ -688,7 +688,7 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     MVM_fixkey_hash_demolish(instance->main_thread, &instance->loaded_compunits);
 
     /* Clean up Container registry. */
-    MVM_str_hash_demolish(instance->main_thread, &instance->container_registry);
+    MVM_fixkey_hash_demolish(instance->main_thread, &instance->container_registry);
     /* Clean up Hash of compiler objects keyed by name. */
     uv_mutex_destroy(&instance->mutex_compiler_registry);
 

--- a/src/moar.c
+++ b/src/moar.c
@@ -189,8 +189,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     init_mutex(instance->mutex_loaded_compunits, "loaded compunits");
     MVM_fixkey_hash_build(instance->main_thread, &instance->loaded_compunits, sizeof(MVMString *));
 
-    /* Set up container registry mutex. */
-    init_mutex(instance->mutex_container_registry, "container registry");
+    /* Set up container registry. */
     MVM_str_hash_build(instance->main_thread, &instance->container_registry, sizeof(MVMContainerRegistry), 0);
 
     /* Set up persistent object ID hash mutex. */
@@ -689,7 +688,6 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     MVM_fixkey_hash_demolish(instance->main_thread, &instance->loaded_compunits);
 
     /* Clean up Container registry. */
-    uv_mutex_destroy(&instance->mutex_container_registry);
     MVM_str_hash_demolish(instance->main_thread, &instance->container_registry);
     /* Clean up Hash of compiler objects keyed by name. */
     uv_mutex_destroy(&instance->mutex_compiler_registry);

--- a/src/types.h
+++ b/src/types.h
@@ -43,7 +43,6 @@ typedef struct MVMCompUnitBody MVMCompUnitBody;
 typedef struct MVMConcatState MVMConcatState;
 typedef struct MVMContainerConfigurer MVMContainerConfigurer;
 typedef struct MVMContainerSpec MVMContainerSpec;
-typedef struct MVMContainerRegistry MVMContainerRegistry;
 typedef struct MVMContext MVMContext;
 typedef struct MVMContextBody MVMContextBody;
 typedef struct MVMDecoder MVMDecoder;


### PR DESCRIPTION
### Remove `MVM_6model_add_container_config` from MoarVM's public API.

Rakudo eliminated its Scalar container descriptor in April 2020, which was the only remaining external user for this ( rakudo/rakudo@4221f8225fea).

### Simplify `add_container_config` and remove `mutex_container_registry`.

Modification of `container_registry` only happens during VM instance setup, which is single threaded - after this it is immutable. Hence it no longer needs a mutex to protect access, so remove `mutex_container_registry` and all the code that supports it.

### Convert `container_registry` to an MVMFixKeyHashTable

As the hash keys can now be permarooted, this eliminates an iterator loop from `MVM_gc_root_add_instance_roots_to_worklist`.
