### PR TITLE
Store `key_right_shift - metadata_hash_bits` in the hashtable

### DIFF
--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -1,7 +1,6 @@
 #include "moar.h"
 
 #define FIXKEY_INITIAL_SIZE_LOG2 3
-#define FIXKEY_INITIAL_KEY_RIGHT_SHIFT (8 * sizeof(MVMuint64) - 3)
 
 void hash_demolish_internal(MVMThreadContext *tc,
                             struct MVMFixKeyHashTableControl *control) {
@@ -43,8 +42,8 @@ void MVM_fixkey_hash_demolish(MVMThreadContext *tc, MVMFixKeyHashTable *hashtabl
 
 MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThreadContext *tc,
                                                                          MVMuint16 entry_size,
-                                                                         MVMuint8 key_right_shift,
                                                                          MVMuint8 official_size_log2) {
+    MVMuint8 key_right_shift = 8 * sizeof(MVMuint64) - official_size_log2;
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_FIXKEY_HASH_LOAD_FACTOR;
     MVMuint8 max_probe_distance_limit;
@@ -86,7 +85,6 @@ void MVM_fixkey_hash_build(MVMThreadContext *tc, MVMFixKeyHashTable *hashtable, 
     }
     hashtable->table = hash_allocate_common(tc,
                                             entry_size,
-                                            FIXKEY_INITIAL_KEY_RIGHT_SHIFT,
                                             FIXKEY_INITIAL_SIZE_LOG2);
 }
 
@@ -257,7 +255,6 @@ static struct MVMFixKeyHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
 
     control = hash_allocate_common(tc,
                                    control_orig->entry_size,
-                                   control_orig->key_right_shift - 1,
                                    control_orig->official_size_log2 + 1);
 
     MVMuint8 *entry_raw = entry_raw_orig;

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -43,7 +43,6 @@ void MVM_fixkey_hash_demolish(MVMThreadContext *tc, MVMFixKeyHashTable *hashtabl
 MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThreadContext *tc,
                                                                          MVMuint16 entry_size,
                                                                          MVMuint8 official_size_log2) {
-    MVMuint8 key_right_shift = 8 * sizeof(MVMuint64) - official_size_log2;
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_FIXKEY_HASH_LOAD_FACTOR;
     MVMuint8 max_probe_distance_limit;
@@ -70,7 +69,8 @@ MVM_STATIC_INLINE struct MVMFixKeyHashTableControl *hash_allocate_common(MVMThre
     MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
     control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
-    control->key_right_shift = key_right_shift;
+    MVMuint8 bucket_right_shift = 8 * sizeof(MVMuint64) - official_size_log2;
+    control->key_right_shift = bucket_right_shift - control->metadata_hash_bits;
     control->entry_size = entry_size;
 
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
@@ -239,6 +239,7 @@ static struct MVMFixKeyHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         } while (--loop_count);
         assert(control->metadata_hash_bits);
         --control->metadata_hash_bits;
+        ++control->key_right_shift;
 
         control->max_probe_distance = new_probe_distance;
         /* Reset this to its proper value. */
@@ -373,6 +374,9 @@ MVMuint64 MVM_fixkey_hash_fsck(MVMThreadContext *tc, MVMFixKeyHashTable *hashtab
     MVMuint8 *metadata = MVM_fixkey_hash_metadata(control);
     MVMuint32 bucket = 0;
     MVMint64 prev_offset = 0;
+    MVMuint8 bucket_right_shift
+        = control->key_right_shift + control->metadata_hash_bits;
+
     while (bucket < entries_in_use) {
         if (!*metadata) {
             /* empty slot. */
@@ -394,7 +398,7 @@ MVMuint64 MVM_fixkey_hash_fsck(MVMThreadContext *tc, MVMFixKeyHashTable *hashtab
                     fprintf(stderr, "%s%3X!!\n", prefix_hashes, bucket);
                 } else {
                     MVMuint64 hash_val = MVM_string_hash_code(tc, *entry);
-                    MVMuint32 ideal_bucket = hash_val >> control->key_right_shift;
+                    MVMuint32 ideal_bucket = hash_val >> bucket_right_shift;
                     MVMint64 offset = 1 + bucket - ideal_bucket;
                     int wrong_bucket = offset != *metadata;
                     int wrong_order = offset < 1 || offset > prev_offset + 1;

--- a/src/core/fixkey_hash_table_funcs.h
+++ b/src/core/fixkey_hash_table_funcs.h
@@ -67,8 +67,7 @@ MVM_fixkey_hash_create_loop_state(MVMThreadContext *tc,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    unsigned int used_hash_bits
-        = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
+    unsigned int used_hash_bits = hash_val >> control->key_right_shift;
     retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
     MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
     if (!control->metadata_hash_bits) {

--- a/src/core/index_hash_table.c
+++ b/src/core/index_hash_table.c
@@ -26,8 +26,8 @@ void MVM_index_hash_demolish(MVMThreadContext *tc, MVMIndexHashTable *hashtable)
 
 
 MVM_STATIC_INLINE struct MVMIndexHashTableControl *hash_allocate_common(MVMThreadContext *tc,
-                                                                        MVMuint8 key_right_shift,
                                                                         MVMuint8 official_size_log2) {
+    MVMuint8 key_right_shift = 8 * sizeof(MVMuint64) - official_size_log2;
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_INDEX_HASH_LOAD_FACTOR;
     MVMuint8 max_probe_distance_limit;
@@ -88,9 +88,7 @@ void MVM_index_hash_build(MVMThreadContext *tc,
         }
     }
 
-    hashtable->table = hash_allocate_common(tc,
-                                            (8 * sizeof(MVMuint64) - initial_size_base2),
-                                            initial_size_base2);
+    hashtable->table = hash_allocate_common(tc, initial_size_base2);
 }
 
 MVM_STATIC_INLINE void hash_insert_internal(MVMThreadContext *tc,
@@ -252,9 +250,7 @@ static struct MVMIndexHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
 
     struct MVMIndexHashTableControl *control_orig = control;
 
-    control = hash_allocate_common(tc,
-                                   control_orig->key_right_shift - 1,
-                                   control_orig->official_size_log2 + 1);
+    control = hash_allocate_common(tc, control_orig->official_size_log2 + 1);
 
     MVMuint8 *entry_raw = entry_raw_orig;
     MVMuint8 *metadata = metadata_orig;

--- a/src/core/index_hash_table_funcs.h
+++ b/src/core/index_hash_table_funcs.h
@@ -102,8 +102,7 @@ MVM_index_hash_create_loop_state(MVMThreadContext *tc,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    unsigned int used_hash_bits
-        = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
+    unsigned int used_hash_bits = hash_val >> control->key_right_shift;
     retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
     MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
     if (!control->metadata_hash_bits) {

--- a/src/core/ptr_hash_table.c
+++ b/src/core/ptr_hash_table.c
@@ -27,7 +27,6 @@ void MVM_ptr_hash_demolish(MVMThreadContext *tc, MVMPtrHashTable *hashtable) {
 
 MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadContext *tc,
                                                                       MVMuint8 official_size_log2) {
-    MVMuint8 key_right_shift = 8 * sizeof(uintptr_t) - official_size_log2;
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_PTR_HASH_LOAD_FACTOR;
     MVMuint8 max_probe_distance_limit;
@@ -54,7 +53,8 @@ MVM_STATIC_INLINE struct MVMPtrHashTableControl *hash_allocate_common(MVMThreadC
     MVMuint8 initial_probe_distance = (1 << (8 - MVM_HASH_INITIAL_BITS_IN_METADATA)) - 1;
     control->max_probe_distance = max_probe_distance_limit > initial_probe_distance ? initial_probe_distance : max_probe_distance_limit;
     control->max_probe_distance_limit = max_probe_distance_limit;
-    control->key_right_shift = key_right_shift;
+    MVMuint8 bucket_right_shift = 8 * sizeof(uintptr_t) - official_size_log2;
+    control->key_right_shift = bucket_right_shift - control->metadata_hash_bits;
 
     MVMuint8 *metadata = (MVMuint8 *)(control + 1);
     memset(metadata, 0, metadata_size);
@@ -203,6 +203,7 @@ static struct MVMPtrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         } while (--loop_count);
         assert(control->metadata_hash_bits);
         --control->metadata_hash_bits;
+        ++control->key_right_shift;
 
         control->max_probe_distance = new_probe_distance;
         /* Reset this to its proper value. */

--- a/src/core/ptr_hash_table_funcs.h
+++ b/src/core/ptr_hash_table_funcs.h
@@ -84,7 +84,7 @@ MVM_ptr_hash_create_loop_state(struct MVMPtrHashTableControl *control,
     retval.max_probe_distance = control->max_probe_distance;
 
     unsigned int used_hash_bits
-        = MVM_ptr_hash_code(key) >> (control->key_right_shift - control->metadata_hash_bits);
+        = MVM_ptr_hash_code(key) >> control->key_right_shift;
     retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
     MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
     if (!control->metadata_hash_bits) {

--- a/src/core/str_hash_table.c
+++ b/src/core/str_hash_table.c
@@ -114,8 +114,8 @@ void MVM_str_hash_demolish(MVMThreadContext *tc, MVMStrHashTable *hashtable) {
 
 MVM_STATIC_INLINE struct MVMStrHashTableControl *hash_allocate_common(MVMThreadContext *tc,
                                                                       MVMuint8 entry_size,
-                                                                      MVMuint8 key_right_shift,
                                                                       MVMuint8 official_size_log2) {
+    MVMuint8 key_right_shift = 8 * sizeof(MVMuint64) - official_size_log2;
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_STR_HASH_LOAD_FACTOR;
     MVMuint8 max_probe_distance_limit;
@@ -187,10 +187,7 @@ void MVM_str_hash_build(MVMThreadContext *tc,
             initial_size_base2 = STR_MIN_SIZE_BASE_2;
         }
 
-        control = hash_allocate_common(tc,
-                                       entry_size,
-                                       (8 * sizeof(MVMuint64) - initial_size_base2),
-                                       initial_size_base2);
+        control = hash_allocate_common(tc, entry_size, initial_size_base2);
     }
 
 #if HASH_DEBUG_ITER
@@ -337,7 +334,6 @@ static struct MVMStrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
         control_orig->stale = 1;
         control = hash_allocate_common(tc,
                                        control_orig->entry_size,
-                                       (8 * sizeof(MVMuint64) - STR_MIN_SIZE_BASE_2),
                                        STR_MIN_SIZE_BASE_2);
 #if HASH_DEBUG_ITER
         control->ht_id = control_orig->ht_id;
@@ -405,7 +401,6 @@ static struct MVMStrHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
     control_orig->stale = 1;
     control = hash_allocate_common(tc,
                                    entry_size,
-                                   control_orig->key_right_shift - 1,
                                    control_orig->official_size_log2 + 1);
 
 

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -161,8 +161,7 @@ MVM_str_hash_create_loop_state(MVMThreadContext *tc,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    unsigned int used_hash_bits
-        = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
+    unsigned int used_hash_bits = hash_val >> control->key_right_shift;
     retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
     MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
     if (!control->metadata_hash_bits) {

--- a/src/core/uni_hash_table.c
+++ b/src/core/uni_hash_table.c
@@ -26,8 +26,8 @@ void MVM_uni_hash_demolish(MVMThreadContext *tc, MVMUniHashTable *hashtable) {
 
 
 MVM_STATIC_INLINE struct MVMUniHashTableControl *hash_allocate_common(MVMThreadContext *tc,
-                                                                      MVMuint8 key_right_shift,
                                                                       MVMuint8 official_size_log2) {
+    MVMuint8 key_right_shift = 8 * sizeof(MVMuint32) - official_size_log2;
     MVMuint32 official_size = 1 << (MVMuint32)official_size_log2;
     MVMuint32 max_items = official_size * MVM_UNI_HASH_LOAD_FACTOR;
     MVMuint8 max_probe_distance_limit;
@@ -78,9 +78,7 @@ void MVM_uni_hash_build(MVMThreadContext *tc,
         }
     }
 
-    hashtable->table = hash_allocate_common(tc,
-                                            (8 * sizeof(MVMuint32) - initial_size_base2),
-                                            initial_size_base2);
+    hashtable->table = hash_allocate_common(tc, initial_size_base2);
 }
 
 static MVMuint64 uni_hash_fsck_internal(struct MVMUniHashTableControl *control, MVMuint32 mode);
@@ -244,9 +242,7 @@ static struct MVMUniHashTableControl *maybe_grow_hash(MVMThreadContext *tc,
 
     struct MVMUniHashTableControl *control_orig = control;
 
-    control = hash_allocate_common(tc,
-                                   control_orig->key_right_shift - 1,
-                                   control_orig->official_size_log2 + 1);
+    control = hash_allocate_common(tc, control_orig->official_size_log2 + 1);
 
     MVMuint8 *entry_raw = entry_raw_orig;
     MVMuint8 *metadata = metadata_orig;

--- a/src/core/uni_hash_table_funcs.h
+++ b/src/core/uni_hash_table_funcs.h
@@ -68,8 +68,7 @@ MVM_uni_hash_create_loop_state(struct MVMUniHashTableControl *control,
     retval.probe_distance_shift = control->metadata_hash_bits;
     retval.max_probe_distance = control->max_probe_distance;
 
-    unsigned int used_hash_bits
-        = hash_val >> (control->key_right_shift - control->metadata_hash_bits);
+    unsigned int used_hash_bits = hash_val >> control->key_right_shift;
     retval.probe_distance = retval.metadata_increment | (used_hash_bits & retval.metadata_hash_mask);
     MVMHashNumItems bucket = used_hash_bits >> control->metadata_hash_bits;
     if (!control->metadata_hash_bits) {


### PR DESCRIPTION
Instead of storing `key_right_shift` (the shift for just the hash bucket) and computing the subtraction each time in `create_loop_state`. This saves one arithmetic operation in a fairly hot function.
