### PR TITLE
Fix another potential deadlock when starting to profile

### DIFF
--- a/src/profiler/profile.c
+++ b/src/profiler/profile.c
@@ -28,6 +28,7 @@ void MVM_profile_start(MVMThreadContext *tc, MVMObject *config) {
             tc->instance->profiling_overhead = (MVMuint64) ((e - s) / 1000) * 0.9;
 
             /* Disable profiling and discard the data we just collected. */
+            MVM_gc_mark_thread_blocked(tc);
             uv_mutex_lock(&(tc->instance->mutex_spesh_sync));
             while (tc->instance->spesh_working != 0)
                 uv_cond_wait(&(tc->instance->cond_spesh_sync), &(tc->instance->mutex_spesh_sync));
@@ -37,6 +38,7 @@ void MVM_profile_start(MVMThreadContext *tc, MVMObject *config) {
             MVM_profile_instrumented_free_data(tc);
 
             uv_mutex_unlock(&(tc->instance->mutex_spesh_sync));
+            MVM_gc_mark_thread_unblocked(tc);
 
             /* Now start profiling for real. */
             MVM_profile_instrumented_start(tc, config);


### PR DESCRIPTION
Very much like commit 9429bdc. The difference here was that
MVM_profile_start waited for tc->instance->cond_spesh_sync
without marking the thread blocked. A deadlock can occur if
the spesh thread is at this point waiting for the other
thread to join the GC run.

Fix by marking the thread blocked while waiting for the mutex and cond var.