### PR TITLE
Correctly clean up disp programs in cleanup_entry

### DIFF
--- a/src/disp/inline_cache.c
+++ b/src/disp/inline_cache.c
@@ -615,7 +615,7 @@ void cleanup_entry(MVMThreadContext *tc, MVMDispInlineCacheEntry *entry, MVMuint
         MVMuint32 num_dps = ((MVMDispInlineCacheEntryPolymorphicDispatch *)entry)->num_dps;
         MVMuint32 dpi;
         if (destroy_dps)
-            for (dpi = 0; dpi > num_dps; dpi++)
+            for (dpi = 0; dpi < num_dps; dpi++)
                 MVM_disp_program_destroy(tc, ((MVMDispInlineCacheEntryPolymorphicDispatch *)entry)->dps[dpi]);
         MVM_fixed_size_free_at_safepoint(tc, tc->instance->fsa,
                 num_dps * sizeof(MVMDispProgram *),
@@ -627,7 +627,7 @@ void cleanup_entry(MVMThreadContext *tc, MVMDispInlineCacheEntry *entry, MVMuint
         MVMuint32 num_dps = ((MVMDispInlineCacheEntryPolymorphicDispatchFlattening *)entry)->num_dps;
         MVMuint32 dpi;
         if (destroy_dps)
-            for (dpi = 0; dpi > num_dps; dpi++)
+            for (dpi = 0; dpi < num_dps; dpi++)
                 MVM_disp_program_destroy(tc, ((MVMDispInlineCacheEntryPolymorphicDispatchFlattening *)entry)->dps[dpi]);
         MVM_fixed_size_free_at_safepoint(tc, tc->instance->fsa,
                 num_dps * sizeof(MVMCallsite *),


### PR DESCRIPTION
Destroying the dispatch programs in inline cache entries when destroying
static frames was introduced in 6b50be1f8a7c9c81fbd85e7fe44467405d1979c6,
but there was a typo in the case of polymorphic entries.

`valgrind --leak-check=full ./install/bin/raku --full-cleanup -e ''` now just reports `definitely lost: 2,024 bytes in 1 blocks`.