### PR TITLE
add dispatcher-drop-n-args to optimize allocations

### DIFF
--- a/src/6model/reprs/MVMCapture.h
+++ b/src/6model/reprs/MVMCapture.h
@@ -42,6 +42,6 @@ void MVM_capture_arg_by_flag_index(MVMThreadContext *tc, MVMObject *capture, MVM
 MVMint64 MVM_capture_is_literal_arg(MVMThreadContext *tc, MVMObject *capture, MVMuint32 idx);
 
 /* Operations for deriving a new MVMCapture from an existing one. */
-MVMObject * MVM_capture_drop_arg(MVMThreadContext *tc, MVMObject *capture, MVMuint32 idx);
+MVMObject * MVM_capture_drop_args(MVMThreadContext *tc, MVMObject *capture, MVMuint32 idx, MVMuint32 count);
 MVMObject * MVM_capture_insert_arg(MVMThreadContext *tc, MVMObject *capture, MVMuint32 idx,
         MVMCallsiteFlags kind, MVMRegister value);

--- a/src/core/callsite.c
+++ b/src/core/callsite.c
@@ -336,23 +336,26 @@ void MVM_callsite_cleanup_interns(MVMInstance *instance) {
 /* Produce a new callsite consisting of the current one with a positional
  * argument dropped. It will be interned if possible. */
 MVMCallsite * MVM_callsite_drop_positional(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx) {
+    return MVM_callsite_drop_positionals(tc, cs, idx, 1);
+}
+MVMCallsite * MVM_callsite_drop_positionals(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx, MVMuint32 count) {
     /* Can only do this with positional arguments and non-flattening callsite. */
-    if (idx >= cs->num_pos)
+    if (idx + count - 1 >= cs->num_pos)
         MVM_exception_throw_adhoc(tc, "Cannot drop positional in callsite: index out of range");
     if (cs->has_flattening)
         MVM_exception_throw_adhoc(tc, "Cannot transform a callsite with flattening args");
 
     /* Allocate a new callsite and set it up. */
     MVMCallsite *new_callsite = MVM_malloc(sizeof(MVMCallsite));
-    new_callsite->num_pos = cs->num_pos - 1;
-    new_callsite->flag_count = cs->flag_count - 1;
-    new_callsite->arg_count = cs->arg_count - 1;
+    new_callsite->num_pos = cs->num_pos - count;
+    new_callsite->flag_count = cs->flag_count - count;
+    new_callsite->arg_count = cs->arg_count - count;
     new_callsite->arg_flags = new_callsite->flag_count
         ? MVM_malloc(new_callsite->flag_count)
         : NULL;
     MVMuint32 from, to = 0;
     for (from = 0; from < cs->flag_count; from++) {
-        if (from != idx) {
+        if (from < idx || from >= idx + count) {
             new_callsite->arg_flags[to] = cs->arg_flags[from];
             to++;
         }

--- a/src/core/callsite.h
+++ b/src/core/callsite.h
@@ -121,6 +121,7 @@ void MVM_callsite_cleanup_interns(MVMInstance *instance);
 
 /* Callsite transformations. */
 MVMCallsite * MVM_callsite_drop_positional(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx);
+MVMCallsite * MVM_callsite_drop_positionals(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx, MVMuint32 count);
 MVMCallsite * MVM_callsite_insert_positional(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx,
         MVMCallsiteFlags flag);
 

--- a/src/disp/program.h
+++ b/src/disp/program.h
@@ -602,6 +602,8 @@ MVMObject * MVM_disp_program_record_index_lookup_table(MVMThreadContext *tc,
        MVMObject *lookup_hash, MVMObject *tracked_key);
 MVMObject * MVM_disp_program_record_capture_drop_arg(MVMThreadContext *tc, MVMObject *capture,
         MVMuint32 index);
+MVMObject * MVM_disp_program_record_capture_drop_args(MVMThreadContext *tc, MVMObject *capture,
+        MVMuint32 index, MVMuint32 count);
 MVMObject * MVM_disp_program_record_capture_insert_constant_arg(MVMThreadContext *tc,
         MVMObject *capture, MVMuint32 index, MVMCallsiteFlags kind, MVMRegister value);
 MVMint64 MVM_disp_program_record_capture_is_arg_literal(MVMThreadContext *tc,

--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -85,7 +85,7 @@ static MVMDispSysCall dispatcher_track_attr = {
 static void dispatcher_drop_arg_impl(MVMThreadContext *tc, MVMArgs arg_info) {
     MVMObject *capture = get_obj_arg(arg_info, 0);
     MVMint64 idx = get_int_arg(arg_info, 1);
-    MVMObject *derived = MVM_disp_program_record_capture_drop_arg(tc, capture, (MVMuint32)idx);
+    MVMObject *derived = MVM_disp_program_record_capture_drop_args(tc, capture, (MVMuint32)idx, 1);
     MVM_args_set_result_obj(tc, derived, MVM_RETURN_CURRENT_FRAME);
 }
 static MVMDispSysCall dispatcher_drop_arg = {
@@ -96,6 +96,24 @@ static MVMDispSysCall dispatcher_drop_arg = {
     .expected_kinds = { MVM_CALLSITE_ARG_OBJ, MVM_CALLSITE_ARG_INT },
     .expected_reprs = { MVM_REPR_ID_MVMCapture, 0 },
     .expected_concrete = { 1, 1 }
+};
+
+/* dispatcher-drop-n-args */
+static void dispatcher_drop_n_args_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+    MVMObject *capture = get_obj_arg(arg_info, 0);
+    MVMint64 idx   = get_int_arg(arg_info, 1);
+    MVMint64 count = get_int_arg(arg_info, 2);
+    MVMObject *derived = MVM_disp_program_record_capture_drop_args(tc, capture, (MVMuint32)idx, (MVMuint32)count);
+    MVM_args_set_result_obj(tc, derived, MVM_RETURN_CURRENT_FRAME);
+}
+static MVMDispSysCall dispatcher_drop_n_args = {
+    .c_name = "dispatcher-drop-n-args",
+    .implementation = dispatcher_drop_n_args_impl,
+    .min_args = 3,
+    .max_args = 3,
+    .expected_kinds = { MVM_CALLSITE_ARG_OBJ, MVM_CALLSITE_ARG_INT, MVM_CALLSITE_ARG_INT },
+    .expected_reprs = { MVM_REPR_ID_MVMCapture, 0, 0 },
+    .expected_concrete = { 1, 1, 1 }
 };
 
 /* dispatcher-insert-arg */
@@ -1037,6 +1055,7 @@ void MVM_disp_syscall_setup(MVMThreadContext *tc) {
     add_to_hash(tc, &dispatcher_track_arg);
     add_to_hash(tc, &dispatcher_track_attr);
     add_to_hash(tc, &dispatcher_drop_arg);
+    add_to_hash(tc, &dispatcher_drop_n_args);
     add_to_hash(tc, &dispatcher_insert_arg);
     add_to_hash(tc, &dispatcher_insert_arg_literal_obj);
     add_to_hash(tc, &dispatcher_insert_arg_literal_str);


### PR DESCRIPTION
Instead of creating a MVMCapture and MVMCallsite for each step of
removing arguments, we now offer a syscall that drops multiple arguments
that live at the same index in one go.

The result is that the transformations tree can now contain null entries
for the capture entry, which we have to interpret and deal with.