### PR TITLE
All bits in the union returned by `make_temp_reg` should be initialised

### DIFF
--- a/src/spesh/manipulate.c
+++ b/src/spesh/manipulate.c
@@ -319,6 +319,10 @@ static MVMSpeshOperand make_temp_reg(MVMThreadContext *tc, MVMSpeshGraph *g, MVM
                 g->temps[i].i++;
 
                 /* Produce and return result. */
+                /* Ensure that all the bits in the union are initialised.
+                 * Code in `optimize_bb_switch` evaluates `lit_i64 != -1`
+                 * before calling `MVM_spesh_manipulate_release_temp_reg` */
+                result.lit_i64 = 0;
                 result.reg.orig = orig;
                 result.reg.i = g->temps[i].used_i = g->temps[i].i;
                 return result;
@@ -328,6 +332,9 @@ static MVMSpeshOperand make_temp_reg(MVMThreadContext *tc, MVMSpeshGraph *g, MVM
 
     /* Make sure we've space in the temporaries store. */
     ensure_more_temps(tc, g);
+
+    /* Again, ensure that all the bits in the union are initialised. */
+    result.lit_i64 = 0;
 
     /* Allocate temporary and set up result. */
     g->temps[g->num_temps].orig   = result.reg.orig = g->num_locals;


### PR DESCRIPTION
`make_temp_reg` returns `MVMSpeshOperand`, which is a union between various
types and structs, all of which are 64 bits or smaller.

Code in `optimize_bb_switch` evaluates `lit_i64 != -1` before calling
`MVM_spesh_manipulate_release_temp_reg`. The struct within the union returned
from `make_temp_reg` is only 48 bits, so take care to ensure that the other
16 bits are initialised, else valgrind (correctly) complains that
"Conditional jump or move depends on uninitialised value(s)".

(To be fair, technically the subsequent code shouldn't be reading the union
using a different member than it was written with. If compilers are going to
get exacting about this - ie infer that writing the `lit_i64` member can be
completely eliminated - then we will need to change the struct within the
union to be exactly 64 bits in total.)