### PR TITLE
Simplify cloning NQP and Rakudo repos in CI jobs

### DIFF
--- a/tools/build/checkout-repos-for-test.pl
+++ b/tools/build/checkout-repos-for-test.pl
@@ -50,9 +50,7 @@ sub checkout_rev {
     my ($name, $type, $downstream_file) = @_;
     my $back = cwd();
     if ($type eq 'master') {
-        exec_and_check('git', 'clone', $repos{$name}, $name, "Cloning $name failed.");
-        chdir $name;
-        exec_and_check('git', 'checkout', '-f', 'master', "Checking out $name master failed.");
+        exec_and_check('git', 'clone', '--depth', 250, '--branch', 'master', $repos{$name}, $name, "Cloning $name and checking out 'master' failed.");
     }
     elsif ($type eq 'downstream') {
         die "Can't do downstream checkout for $name" unless $downstream_file;


### PR DESCRIPTION
Since we build them at HEAD we don't need the full history. Also do the
clone and checkout of 'master' in a single command.