### PR TITLE
Correct the cur_op increment in sp_assertparamcheck and sp_bindcomplete

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -5677,11 +5677,11 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     MVMuint32 slot = GET_UI32(cur_op, 4);
                     MVMDispInlineCacheEntry **ice_ptr = MVM_disp_inline_cache_get_spesh(
                             sf, slot);
-                    cur_op += 6;
+                    cur_op += 8;
                     MVM_args_bind_failed(tc, ice_ptr);
                 }
                 else {
-                    cur_op += 6;
+                    cur_op += 8;
                 }
                 goto NEXT;
             }
@@ -5691,7 +5691,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMuint32 slot = GET_UI32(cur_op, 2);
                 MVMDispInlineCacheEntry **ice_ptr = MVM_disp_inline_cache_get_spesh(
                         sf, slot);
-                cur_op += 4;
+                cur_op += 6;
                 MVM_args_bind_succeeded(tc, ice_ptr);
                 goto NEXT;
             }


### PR DESCRIPTION
These two spesh ops had been leaving cur_op 2 bytes *before* the start of
the next op. However, this wasn't noticed (yet) on little endian systems
because the last part of each op was a uint32 literal which (for all code
compile during the build and spectest) was less than 65536. Hence on
*little* endian systems the last two bytes were always zero, which the
runloop (mis)interpreted as a no_op, and hence resynchronised itself.

However, on *big* endian systems the last two bytes are the low order bytes
of the value, and hence the runloop would treat the data value as an op and
attempt to execute it, with completely undefined results. Fortunately one
chanced-upon behaviour was to hit "Not Yet Implemented" or deprecated ops,
which throw exceptions, which caused the build to fail and the bug to be
discovered.