### PR TITLE
Change CI job strategy from matrix to parallel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
     # leaves little space for the name.
     - job: T
       strategy:
-       matrix:
+       parallel: 10
          Win_MVM:
            IMAGE_NAME: 'windows-2019'
            RAKUDO_OPTIONS: ''


### PR DESCRIPTION
We aren't passing multiple options to the matrix strategy for it to do
all combinations of, so this might give us more control about how the
jobs start (e.g., start the Windows jobs first since they're slower).