### PR TITLE
Lego jit implementation of nqp::abs_i

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1654,6 +1654,7 @@ start:
     case MVM_OP_blshift_i:
     case MVM_OP_brshift_i:
     case MVM_OP_pow_i:
+    case MVM_OP_abs_i:
     case MVM_OP_add_n:
     case MVM_OP_sub_n:
     case MVM_OP_mul_n:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1283,6 +1283,16 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov WORK[dst], TMP1;
         break;
     }
+    case MVM_OP_abs_i: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 src = ins->operands[1].reg.orig;
+        | mov TMP1, WORK[src];
+        | mov TMP2, TMP1;
+        | neg TMP1;
+        | cmovl TMP1, TMP2;
+        | mov WORK[dst], TMP1;
+        break;
+    }
     case MVM_OP_extend_i8: {
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 src = ins->operands[1].reg.orig;


### PR DESCRIPTION
This was seen to cause bails in a profile/spesh log of a simple
Text::Diff::Sift4 benchmark.

NQP builds ok and passes `make m-test` and Rakudo build ok and passes `make m-test m-spectest`.