### PR TITLE
Fix uninitialized registers after deopt from dispatch guards

### DIFF
--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1168,6 +1168,12 @@ MVMint32 find_predeopt_index(MVMThreadContext *tc, MVMSpeshIns *ins) {
     while (ins) {
         MVMSpeshAnn *ann = ins->annotations;
         while (ann) {
+            if (ann->type == MVM_SPESH_ANN_DEOPT_SYNTH)
+                return ann->data.deopt_idx;
+            ann = ann->next;
+        }
+        ann = ins->annotations;
+        while (ann) {
             if (ann->type == MVM_SPESH_ANN_DEOPT_PRE_INS)
                 return ann->data.deopt_idx;
             ann = ann->next;


### PR DESCRIPTION
A dispatch gets translated to a sequence of operations culminating in the
runbytecode instruction. The pre-deopt index of the original instruction will
be found on the runbytecode itself or any of the guards stacked up before it.
When looking for the pre-deopt index, we didn't take into account, that the
instruction holding a suitable deopt pre ins annotation may also itself have
a deopt synth annotation, i.e. that the proper deopt idx is found elsewhere.

This is important because while all of these deopt indexes will point at the
same deopt target (bytecode position), only the original one will be registered
for materializations. Thus by using the wrong deopt index, we didn't find the
materializations when deopting, leading to uninitialized registers which lead
to segfaults.

Fix by looking for deopt synth annotations first and giving preference to their
deopt indexes.