### PR TITLE
Improve the jit implementation of nqp::abs_i

### DIFF
--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1287,9 +1287,8 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 src = ins->operands[1].reg.orig;
         | mov TMP1, WORK[src];
-        | mov TMP2, TMP1;
         | neg TMP1;
-        | cmovl TMP1, TMP2;
+        | cmovl TMP1, WORK[src];
         | mov WORK[dst], TMP1;
         break;
     }


### PR DESCRIPTION
We don't need to copy the source twice, it's faster just to refer back
to it in the cmovl.

My test case was (so doing `nqp::abs_i` of a negative number and a positive one in the loop):
`MVM_SPESH_BLOCKING=1 valgrind --tool=callgrind nqp-m -e 'my int $a := nqp::time; my int $i := -100_000_000; my int $b; my int $c; while $i++ < 0 { $b := nqp::abs_i($i); $c := nqp::abs_i($a); }; say(nqp::div_n(nqp::time - $a, 1e9)); say($a); say($b); say($c);'`

master reported ~3,083,800,000 instructions, with this patch it was ~2,883,800,000.