### PR TITLE
Migrate special return to callstack and simplify return handling

### DIFF
--- a/src/core/callstack.c
+++ b/src/core/callstack.c
@@ -613,11 +613,15 @@ MVMFrame * MVM_callstack_unwind_frame(MVMThreadContext *tc, MVMuint8 exceptional
                 tc->stack_current_region = tc->stack_current_region->prev;
                 tc->stack_top = tc->stack_top->prev;
                 break;
-            case MVM_CALLSTACK_RECORD_FRAME:
-                exit_frame(tc, &(((MVMCallStackFrame *)tc->stack_top)->frame));
+            case MVM_CALLSTACK_RECORD_FRAME: {
+                MVMFrame *frame = &(((MVMCallStackFrame *)tc->stack_top)->frame);
+                if (frame->extra)
+                    MVM_fixed_size_free(tc, tc->instance->fsa, sizeof(MVMFrameExtra), frame->extra);
+                exit_frame(tc, frame);
                 tc->stack_current_region->alloc = (char *)tc->stack_top;
                 tc->stack_top = tc->stack_top->prev;
                 break;
+            }
             case MVM_CALLSTACK_RECORD_HEAP_FRAME: {
                 MVMFrame *frame = ((MVMCallStackHeapFrame *)tc->stack_top)->frame;
                 /* NULL out ->work, to indicate the frame is no longer in dynamic scope.

--- a/src/core/callstack.c
+++ b/src/core/callstack.c
@@ -573,7 +573,8 @@ static void exit_frame(MVMThreadContext *tc, MVMFrame *returner) {
        if (tc->jit_return_address != NULL) {
             /* on a JIT frame, exit to interpreter afterwards */
             MVMJitCode *jitcode = returner->spesh_cand->body.jitcode;
-            MVM_jit_code_set_current_position(tc, jitcode, returner, jitcode->exit_label);
+            assert(tc->cur_frame == returner);
+            MVM_jit_code_set_cur_frame_position(tc, jitcode, jitcode->exit_label);
             /* given that we might throw in the special-return, act as if we've
              * left the current frame (which is true) */
             tc->jit_return_address = NULL;

--- a/src/core/callstack.c
+++ b/src/core/callstack.c
@@ -732,6 +732,8 @@ MVMFrame * MVM_callstack_unwind_frame(MVMThreadContext *tc, MVMuint8 exceptional
                 MVM_panic(1, "Unknown call stack record type in unwind");
         }
     } while (tc->stack_top && !is_bytecode_frame(tc->stack_top->kind));
+    if (tc->num_finalizing && !exceptional && (!thunked || !*thunked) && MVM_gc_finalize_run_handler(tc))
+        *thunked = 1;
     return tc->stack_top ? MVM_callstack_record_to_frame(tc->stack_top) : NULL;
 }
 

--- a/src/core/callstack.h
+++ b/src/core/callstack.h
@@ -497,3 +497,6 @@ MVM_STATIC_INLINE MVMFrame * MVM_callstack_iter_current_frame(MVMThreadContext *
         MVMCallStackIterator *iter) {
     return MVM_callstack_record_to_frame(iter->current);
 }
+
+/* Migration to callstack-based special return in Rakudo extops. */
+#define MVM_CALLSTACK_SPECIAL_RETURN 1

--- a/src/core/callstack.h
+++ b/src/core/callstack.h
@@ -403,7 +403,7 @@ void MVM_callstack_continuation_append(MVMThreadContext *tc, MVMCallStackRegion 
         MVMCallStackRecord *stack_top, MVMObject *update_tag);
 MVMFrame * MVM_callstack_first_frame_in_region(MVMThreadContext *tc, MVMCallStackRegion *region);
 MVMCallStackDispatchRecord * MVM_callstack_find_topmost_dispatch_recording(MVMThreadContext *tc);
-MVMFrame * MVM_callstack_unwind_frame(MVMThreadContext *tc, MVMuint8 exceptional);
+MVMuint64 MVM_callstack_unwind_frame(MVMThreadContext *tc, MVMuint8 exceptional);
 void MVM_callstack_unwind_dispatch_record(MVMThreadContext *tc);
 void MVM_callstack_unwind_dispatch_run(MVMThreadContext *tc);
 void MVM_callstack_unwind_failed_dispatch_run(MVMThreadContext *tc);

--- a/src/core/callstack.h
+++ b/src/core/callstack.h
@@ -403,8 +403,8 @@ void MVM_callstack_continuation_append(MVMThreadContext *tc, MVMCallStackRegion 
         MVMCallStackRecord *stack_top, MVMObject *update_tag);
 MVMFrame * MVM_callstack_first_frame_in_region(MVMThreadContext *tc, MVMCallStackRegion *region);
 MVMCallStackDispatchRecord * MVM_callstack_find_topmost_dispatch_recording(MVMThreadContext *tc);
-MVMFrame * MVM_callstack_unwind_frame(MVMThreadContext *tc, MVMuint8 exceptional, MVMuint32 *thunked);
-void MVM_callstack_unwind_dispatch_record(MVMThreadContext *tc, MVMuint32 *thunked);
+MVMFrame * MVM_callstack_unwind_frame(MVMThreadContext *tc, MVMuint8 exceptional);
+void MVM_callstack_unwind_dispatch_record(MVMThreadContext *tc);
 void MVM_callstack_unwind_dispatch_run(MVMThreadContext *tc);
 void MVM_callstack_unwind_failed_dispatch_run(MVMThreadContext *tc);
 void MVM_callstack_mark_current_thread(MVMThreadContext *tc, MVMGCWorklist *worklist,

--- a/src/core/callstack.h
+++ b/src/core/callstack.h
@@ -334,13 +334,41 @@ struct MVMCallStackDeoptedResumeInit {
     MVMRegister *args;
 };
 
+/* Record to indicate the boundary of a nested runloop. */
 #define MVM_CALLSTACK_RECORD_NESTED_RUNLOOP 14
 struct MVMCallStackNestedRunloop {
     /* Commonalities of all records. */
     MVMCallStackRecord common;
 
-    /* The tag itself. */
+    /* The frame to stop at during unwinding. */
     MVMFrame *cur_frame;
+};
+
+/* Sometimes we wish to take a special action after execution of a frame.
+ * This is typically used when the VM needs to invoke something and then
+ * take action based upon the result, to avoid creating nested runloops
+ * (which would be a continuation barrier). The record has variable size; the
+ * fixed part here is followed by some state as required by the particular
+ * use of the mechanism. */
+#define MVM_CALLSTACK_RECORD_SPECIAL_RETURN 15
+struct MVMCallStackSpecialReturn {
+    /* Commonalities of all records. */
+    MVMCallStackRecord common;
+
+    /* If we want to invoke a special handler upon a return, this function
+     * pointer is set. */
+    MVMSpecialReturn special_return;
+
+    /* If we want to invoke a special handler upon unwinding, this function
+     * pointer is set. */
+    MVMSpecialReturn special_unwind;
+
+    /* Function pointer to something that will GC mark the special return
+     * data. */
+    MVMSpecialReturnMark mark_data;
+
+    /* The size of the special return data following this record. */
+    size_t data_size;
 };
 
 /* Functions for working with the call stack. */
@@ -352,6 +380,9 @@ MVMCallStackHeapFrame * MVM_callstack_allocate_heap_frame(MVMThreadContext *tc,
         MVMuint32 work_size);
 MVMint32 MVM_callstack_ensure_work_and_env_space(MVMThreadContext *tc, MVMuint32 needed_work,
         MVMuint32 needed_env);
+void * MVM_callstack_allocate_special_return(MVMThreadContext *tc,
+        MVMSpecialReturn special_return, MVMSpecialReturn special_unwind,
+        MVMSpecialReturnMark mark_data, size_t data_size);
 MVMCallStackDispatchRecord * MVM_callstack_allocate_dispatch_record(MVMThreadContext *tc);
 MVMCallStackDispatchRun * MVM_callstack_allocate_dispatch_run(MVMThreadContext *tc,
         MVMuint32 num_temps);

--- a/src/core/callstack.h
+++ b/src/core/callstack.h
@@ -380,7 +380,7 @@ MVMCallStackHeapFrame * MVM_callstack_allocate_heap_frame(MVMThreadContext *tc,
         MVMuint32 work_size);
 MVMint32 MVM_callstack_ensure_work_and_env_space(MVMThreadContext *tc, MVMuint32 needed_work,
         MVMuint32 needed_env);
-void * MVM_callstack_allocate_special_return(MVMThreadContext *tc,
+MVM_PUBLIC void * MVM_callstack_allocate_special_return(MVMThreadContext *tc,
         MVMSpecialReturn special_return, MVMSpecialReturn special_unwind,
         MVMSpecialReturnMark mark_data, size_t data_size);
 MVMCallStackDispatchRecord * MVM_callstack_allocate_dispatch_record(MVMThreadContext *tc);

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -935,24 +935,7 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
     }
     if (thunked)
         return 1;
-
-    /* Switch back to the caller frame if there is one. */
-    if (caller && (returner != tc->thread_entry_frame || tc->nested_interpreter)) {
-        if (returner == tc->thread_entry_frame && tc->cur_frame == caller) {
-            tc->cur_frame = NULL;
-            return 0;
-        }
-        else {
-            /* We're either somewhere in a nested call or already up in the top
-               most frame but still need to run some finalizer, so keep the
-               runloop running */
-            return 1;
-        }
-    }
-    else {
-        tc->cur_frame = NULL;
-        return 0;
-    }
+    return caller != NULL;
 }
 
 /* Attempt to return from the current frame. Returns non-zero if we can,

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1036,7 +1036,7 @@ MVMuint64 MVM_frame_try_return(MVMThreadContext *tc) {
         }
 
         cur_frame->flags |= MVM_FRAME_FLAG_EXIT_HAND_RUN;
-        MVM_frame_special_return(tc, cur_frame, remove_after_handler, NULL, NULL, NULL);
+        MVM_callstack_allocate_special_return(tc, remove_after_handler, NULL, NULL, 0);
         MVMCallStackArgsFromC *args_record = MVM_callstack_allocate_args_from_c(tc,
                 MVM_callsite_get_common(tc, MVM_CALLSITE_ID_OBJ_OBJ));
         args_record->args.source[0].o = cur_frame->code_ref;
@@ -1064,8 +1064,8 @@ typedef struct {
     MVMuint32  rel_addr;
     void      *jit_return_label;
 } MVMUnwindData;
-static void mark_unwind_data(MVMThreadContext *tc, MVMFrame *frame, MVMGCWorklist *worklist) {
-    MVMUnwindData *ud  = (MVMUnwindData *)frame->extra->special_return_data;
+static void mark_unwind_data(MVMThreadContext *tc, void *sr_data, MVMGCWorklist *worklist) {
+    MVMUnwindData *ud  = (MVMUnwindData *)sr_data;
     MVM_gc_worklist_add(tc, worklist, &(ud->frame));
 }
 static void continue_unwind(MVMThreadContext *tc, void *sr_data) {
@@ -1074,11 +1074,7 @@ static void continue_unwind(MVMThreadContext *tc, void *sr_data) {
     MVMuint8 *abs_addr = ud->abs_addr;
     MVMuint32 rel_addr = ud->rel_addr;
     void *jit_return_label = ud->jit_return_label;
-    MVM_free(sr_data);
     MVM_frame_unwind_to(tc, frame, abs_addr, rel_addr, NULL, jit_return_label);
-}
-static void free_unwind_data(MVMThreadContext *tc, void *sr_data) {
-    MVM_free(sr_data);
 }
 void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_addr,
                          MVMuint32 rel_addr, MVMObject *return_value, void *jit_return_label) {
@@ -1127,15 +1123,12 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
                     MVM_exception_throw_adhoc(tc, "Thread entry point frame cannot have an exit handler");
 
                 MVMHLLConfig *hll = MVM_hll_current(tc);
-                {
-                    MVMUnwindData *ud = MVM_malloc(sizeof(MVMUnwindData));
-                    ud->frame = frame;
-                    ud->abs_addr = abs_addr;
-                    ud->rel_addr = rel_addr;
-                    ud->jit_return_label = jit_return_label;
-                    MVM_frame_special_return(tc, cur_frame, continue_unwind,
-                        free_unwind_data, ud, mark_unwind_data);
-                }
+                MVMUnwindData *ud = MVM_callstack_allocate_special_return(tc,
+                        continue_unwind, NULL, mark_unwind_data, sizeof(MVMUnwindData));
+                ud->frame = frame;
+                ud->abs_addr = abs_addr;
+                ud->rel_addr = rel_addr;
+                ud->jit_return_label = jit_return_label;
                 cur_frame->flags |= MVM_FRAME_FLAG_EXIT_HAND_RUN;
                 MVMCallStackArgsFromC *args_record = MVM_callstack_allocate_args_from_c(tc,
                         MVM_callsite_get_common(tc, MVM_CALLSITE_ID_OBJ_OBJ));

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -910,13 +910,6 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
     /* Clean up any allocations for argument working area. */
     MVM_args_proc_cleanup(tc, &returner->params);
 
-    /* NULL out ->work, to indicate the frame is no longer in dynamic scope.
-     * This is used by the GC to avoid marking stuff (this is needed for
-     * safety as otherwise we'd read freed memory), as well as by exceptions to
-     * ensure the target of an exception throw is indeed still in dynamic
-     * scope. */
-    returner->work = NULL;
-
     /* Unwind call stack entries. From this, we find out the caller. This may
      * actually *not* be the caller in the frame, because of lazy deopt. Also
      * it may invoke something else, in which case we go no further and just

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -895,7 +895,7 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
 
     /* For frames on the callstack, nothing more to do other than unwind. */
     if (MVM_FRAME_IS_ON_CALLSTACK(tc, returner))
-        return MVM_callstack_unwind_frame(tc, unwind) != NULL;
+        return MVM_callstack_unwind_frame(tc, unwind);
 
     /* Heap promoted frames can stay around, but we may or may not need to
      * clear up ->extra and ->caller. */
@@ -913,13 +913,13 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
     else {
         need_caller = 0;
     }
-    MVMFrame *caller;
+    MVMuint64 outcome;
     MVMROOT(tc, returner, {
-        caller = MVM_callstack_unwind_frame(tc, unwind);
+        outcome = MVM_callstack_unwind_frame(tc, unwind);
     });
     if (!need_caller)
         returner->caller = NULL;
-    return caller != NULL;
+    return outcome;
 }
 
 /* Attempt to return from the current frame. Returns non-zero if we can,

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -914,20 +914,17 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
      * actually *not* be the caller in the frame, because of lazy deopt. Also
      * it may invoke something else, in which case we go no further and just
      * return to the runloop. */
-    MVMuint32 thunked = 0;
     MVMFrame *caller;
     if (MVM_FRAME_IS_ON_CALLSTACK(tc, returner)) {
-        caller = MVM_callstack_unwind_frame(tc, unwind, &thunked);
+        caller = MVM_callstack_unwind_frame(tc, unwind);
     }
     else {
         MVMROOT(tc, returner, {
-            caller = MVM_callstack_unwind_frame(tc, unwind, &thunked);
+            caller = MVM_callstack_unwind_frame(tc, unwind);
         });
         if (!need_caller)
             returner->caller = NULL;
     }
-    if (thunked)
-        return 1;
     return caller != NULL;
 }
 

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -938,11 +938,6 @@ static MVMuint64 remove_one_frame(MVMThreadContext *tc, MVMuint8 unwind) {
 
     /* Switch back to the caller frame if there is one. */
     if (caller && (returner != tc->thread_entry_frame || tc->nested_interpreter)) {
-        *(tc->interp_cur_op) = caller->return_address;
-        *(tc->interp_bytecode_start) = MVM_frame_effective_bytecode(caller);
-        *(tc->interp_reg_base) = caller->work;
-        *(tc->interp_cu) = caller->static_info->body.cu;
-
         /* Handle any special return hooks. */
         if (caller->extra) {
             MVMFrameExtra *e = caller->extra;

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -1810,16 +1810,6 @@ void MVM_frame_special_return(MVMThreadContext *tc, MVMFrame *f,
     e->mark_special_return_data = mark_special_return_data;
 }
 
-/* Clears any special return data on a frame. */
-void MVM_frame_clear_special_return(MVMThreadContext *tc, MVMFrame *f) {
-    if (f->extra) {
-        f->extra->special_return = NULL;
-        f->extra->special_unwind = NULL;
-        f->extra->special_return_data = NULL;
-        f->extra->mark_special_return_data = NULL;
-    }
-}
-
 /* Gets the code object of the caller, provided there is one. Works even in
  * the face that the caller was an inline (however, the current frame that is
  * using the op must not be itself inlined). */

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -13,8 +13,6 @@
 typedef void (* MVMSpecialReturn)(MVMThreadContext *tc, void *data);
 
 /* Function pointer for marking the special return handler data. */
-typedef void (* MVMSpecialReturnDataMark)(MVMThreadContext *tc, MVMFrame *frame,
-                                          MVMGCWorklist *worklist); /* XXX Legacy */
 typedef void (* MVMSpecialReturnMark)(MVMThreadContext *tc, void *data,
                                       MVMGCWorklist *worklist);
 
@@ -96,20 +94,6 @@ struct MVMFrame {
 /* Extra data that a handful of call frames optionally need. It is needed
  * only while the frame is in dynamic scope; after that it can go away. */
 struct MVMFrameExtra {
-    /* If we want to invoke a special handler upon a return to this
-     * frame, this function pointer is set. */
-    MVMSpecialReturn special_return;
-
-    /* If we want to invoke a special handler upon unwinding past a
-     * frame, this function pointer is set. */
-    MVMSpecialReturn special_unwind;
-
-    /* Data slot for the special return handler function. */
-    void *special_return_data;
-
-    /* Flag for if special_return_data need to be GC marked. */
-    MVMSpecialReturnDataMark mark_special_return_data;
-
     /* Cache for dynlex lookup; if the name is non-null, the cache is valid
      * and the register can be accessed directly to find the contextual. */
     MVMString   *dynlex_cache_name;
@@ -199,7 +183,4 @@ MVM_PUBLIC MVMRegister * MVM_frame_try_get_lexical(MVMThreadContext *tc, MVMFram
 MVMuint16 MVM_frame_translate_to_primspec(MVMThreadContext *tc, MVMuint16 kind);
 MVMuint16 MVM_frame_lexical_primspec(MVMThreadContext *tc, MVMFrame *f, MVMString *name);
 MVMFrameExtra * MVM_frame_extra(MVMThreadContext *tc, MVMFrame *f);
-MVM_PUBLIC void MVM_frame_special_return(MVMThreadContext *tc, MVMFrame *f,
-    MVMSpecialReturn special_return, MVMSpecialReturn special_unwind,
-    void *special_return_data, MVMSpecialReturnDataMark mark_special_return_data);
 MVMObject * MVM_frame_caller_code(MVMThreadContext *tc);

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -202,5 +202,4 @@ MVMFrameExtra * MVM_frame_extra(MVMThreadContext *tc, MVMFrame *f);
 MVM_PUBLIC void MVM_frame_special_return(MVMThreadContext *tc, MVMFrame *f,
     MVMSpecialReturn special_return, MVMSpecialReturn special_unwind,
     void *special_return_data, MVMSpecialReturnDataMark mark_special_return_data);
-MVM_PUBLIC void MVM_frame_clear_special_return(MVMThreadContext *tc, MVMFrame *f);
 MVMObject * MVM_frame_caller_code(MVMThreadContext *tc);

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -14,7 +14,9 @@ typedef void (* MVMSpecialReturn)(MVMThreadContext *tc, void *data);
 
 /* Function pointer for marking the special return handler data. */
 typedef void (* MVMSpecialReturnDataMark)(MVMThreadContext *tc, MVMFrame *frame,
-                                          MVMGCWorklist *worklist);
+                                          MVMGCWorklist *worklist); /* XXX Legacy */
+typedef void (* MVMSpecialReturnMark)(MVMThreadContext *tc, void *data,
+                                      MVMGCWorklist *worklist);
 
 /* This represents an call frame, aka invocation record. It may exist either on
  * the heap, in which case its header will have the MVM_CF_FRAME flag set, or

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -1668,12 +1668,11 @@ static MVMuint64 request_invoke_code(MVMThreadContext *dtc, cmp_ctx_t *ctx, requ
         }
 
         /* Set up return handling for after call. */
-        DebugserverInvocationSpecialReturnData *srd = MVM_calloc(sizeof(DebugserverInvocationSpecialReturnData), 1);
-        srd->id = argument->id;
-        MVM_frame_special_return(tc, tc->cur_frame,
+        DebugserverInvocationSpecialReturnData *srd = MVM_callstack_allocate_special_return(tc,
             debugserver_invocation_special_return,
             debugserver_invocation_special_unwind,
-            (void *)srd, NULL);
+            NULL, sizeof(DebugserverInvocationSpecialReturnData));
+        srd->id = argument->id;
         tc->cur_frame->return_value = &srd->return_target;
         tc->cur_frame->return_type = MVM_RETURN_ALLOMORPH;
         tc->cur_frame->return_address = *(tc->interp_cur_op);

--- a/src/disp/program.h
+++ b/src/disp/program.h
@@ -651,8 +651,7 @@ void MVM_disp_program_record_tracked_code(MVMThreadContext *tc, MVMObject *track
         MVMObject *capture);
 void MVM_disp_program_record_tracked_c_code(MVMThreadContext *tc, MVMObject *tracked,
         MVMObject *capture);
-MVMuint32 MVM_disp_program_record_end(MVMThreadContext *tc, MVMCallStackDispatchRecord* record,
-        MVMuint32 *thunked);
+MVMuint32 MVM_disp_program_record_end(MVMThreadContext *tc, MVMCallStackDispatchRecord* record);
 
 /* Functions to run dispatch programs. */
 MVMint64 MVM_disp_program_run(MVMThreadContext *tc, MVMDispProgram *dp,

--- a/src/gc/finalize.c
+++ b/src/gc/finalize.c
@@ -83,14 +83,14 @@ void MVM_finalize_walk_queues(MVMThreadContext *tc, MVMuint8 gen) {
 }
 
 /* Try to run a finalization handler. Returns a true value if we do so */
-MVMint32 MVM_gc_finalize_run_handler(MVMThreadContext *tc) {
+void MVM_gc_finalize_run_handler(MVMThreadContext *tc) {
     /* Make sure there is a current frame, that we aren't hanging on to an
      * exception handler result (which the finalizer could overwrite), and
      * that there's a HLL handler to run. */
     if (!tc->cur_frame)
-        return 0;
+        return;
     if (tc->last_handler_result)
-        return 0;
+        return;
     MVMCode *handler = MVM_hll_current(tc)->finalize_handler;
     if (handler) {
         /* Drain the finalizing queue to an array. */
@@ -106,7 +106,5 @@ MVMint32 MVM_gc_finalize_run_handler(MVMThreadContext *tc) {
                 MVM_callsite_get_common(tc, MVM_CALLSITE_ID_OBJ));
         args_record->args.source[0].o = drain;
         MVM_frame_dispatch_from_c(tc, handler, args_record, NULL, MVM_RETURN_VOID);
-        return 1;
     }
-    return 0;
 }

--- a/src/gc/finalize.h
+++ b/src/gc/finalize.h
@@ -1,4 +1,4 @@
 void MVM_gc_finalize_set(MVMThreadContext *tc, MVMObject *type, MVMint64 finalize);
 void MVM_gc_finalize_add_to_queue(MVMThreadContext *tc, MVMObject *obj);
 void MVM_finalize_walk_queues(MVMThreadContext *tc, MVMuint8 gen);
-MVMint32 MVM_gc_finalize_run_handler(MVMThreadContext *tc);
+void MVM_gc_finalize_run_handler(MVMThreadContext *tc);

--- a/src/gc/finalize.h
+++ b/src/gc/finalize.h
@@ -1,3 +1,4 @@
 void MVM_gc_finalize_set(MVMThreadContext *tc, MVMObject *type, MVMint64 finalize);
 void MVM_gc_finalize_add_to_queue(MVMThreadContext *tc, MVMObject *obj);
 void MVM_finalize_walk_queues(MVMThreadContext *tc, MVMuint8 gen);
+MVMint32 MVM_gc_finalize_run_handler(MVMThreadContext *tc);

--- a/src/gc/roots.c
+++ b/src/gc/roots.c
@@ -420,8 +420,6 @@ void MVM_gc_root_add_frame_roots_to_worklist(MVMThreadContext *tc, MVMGCWorklist
     /* Mark frame extras if needed. */
     if (cur_frame->extra) {
         MVMFrameExtra *e = cur_frame->extra;
-        if (e->special_return_data && e->mark_special_return_data)
-            e->mark_special_return_data(tc, cur_frame, worklist);
         if (e->dynlex_cache_name)
             MVM_gc_worklist_add(tc, worklist, &e->dynlex_cache_name);
         MVM_gc_worklist_add(tc, worklist, &e->exit_handler_result);

--- a/src/jit/interface.h
+++ b/src/jit/interface.h
@@ -6,6 +6,30 @@ MVM_STATIC_INLINE MVMuint8 * MVM_frame_effective_bytecode(MVMFrame *f) {
     return f->static_info->body.bytecode;
 }
 
+/* Debugging assertion to check if JIT code is within a region. */
+MVM_STATIC_INLINE void MVM_jit_code_assert_within_region(MVMThreadContext *tc, MVMJitCode *code,
+        void *address) {
+#if MVM_JIT_DEBUG
+    MVMint32 ofs = (char*)address - (char*)code->func_ptr;
+    if ((0 <= ofs) && (ofs < code->size))
+        return;
+    MVM_panic(1, "JIT: address out of range for code!\n"
+              "(label %p, func_ptr %p, code size %lui, offset %li, seq nr %i)",
+              address, code->func_ptr, code->size, ofs, code->seq_nr);
+#endif
+}
+
+/* Set the position in the currently executing frame. Done as a static inline
+ * since in non-debug builds this is pretty much a single memory write, so the
+ * call cost would dominate. */
+MVM_STATIC_INLINE void MVM_jit_code_set_cur_frame_position(MVMThreadContext *tc, MVMJitCode *code,
+        void *position) {
+    MVM_jit_code_assert_within_region(tc, code, position);
+    assert(tc->jit_return_address != NULL);
+    /* this overwrites the address on the stack that MVM_frame_invoke_code will ret to! */
+    *tc->jit_return_address = position;
+}
+
 void MVM_jit_code_enter(MVMThreadContext *tc, MVMJitCode *code, MVMCompUnit *cu);
 void * MVM_jit_code_get_current_position(MVMThreadContext *tc, MVMJitCode *code, MVMFrame *frame);
 void MVM_jit_code_set_current_position(MVMThreadContext *tc, MVMJitCode *code, MVMFrame *frame, void *position);

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -614,10 +614,6 @@ static void process_workitems(MVMThreadContext *tc, MVMHeapSnapshotState *ss) {
 
                 if (frame->extra) {
                     MVMFrameExtra *e = frame->extra;
-                    if (e->special_return_data && e->mark_special_return_data) {
-                        e->mark_special_return_data(tc, frame, ss->gcwl);
-                        process_gc_worklist(tc, ss, "Special return data");
-                    }
                     MVM_profile_heap_add_collectable_rel_const_cstr(tc, ss,
                         (MVMCollectable *)e->dynlex_cache_name,
                         "Dynamic lexical cache name");

--- a/src/spesh/deopt.c
+++ b/src/spesh/deopt.c
@@ -422,9 +422,15 @@ void MVM_spesh_deopt_during_unwind(MVMThreadContext *tc) {
         fprintf(stderr, "    Deopt %u -> %u without uninlining\n", deopt_offset, deopt_target);
 #endif
         tc->cur_frame = top_frame;
-
         finish_frame_deopt(tc, frame);
     }
+
+    /* Sync interpreter so it's ready to continue running this deoptimized
+     * frame. */
+    *(tc->interp_cur_op) = tc->cur_frame->return_address;
+    *(tc->interp_bytecode_start) = MVM_frame_effective_bytecode(tc->cur_frame);
+    *(tc->interp_reg_base) = tc->cur_frame->work;
+    *(tc->interp_cu) = tc->cur_frame->static_info->body.cu;
 
     /* Update the record to indicate we're no long in need of deopt. */
     record->kind = record->orig_kind;

--- a/src/types.h
+++ b/src/types.h
@@ -33,6 +33,7 @@ typedef struct MVMCallStackBindControl MVMCallStackBindControl;
 typedef struct MVMCallStackArgsFromC MVMCallStackArgsFromC;
 typedef struct MVMCallStackDeoptedResumeInit MVMCallStackDeoptedResumeInit;
 typedef struct MVMCallStackNestedRunloop MVMCallStackNestedRunloop;
+typedef struct MVMCallStackSpecialReturn MVMCallStackSpecialReturn;
 typedef struct MVMCallStackRegion MVMCallStackRegion;
 typedef struct MVMCallStackIterator MVMCallStackIterator;
 typedef struct MVMCFunction MVMCFunction;


### PR DESCRIPTION
Work on `new-disp` introduced new callstack unwind logic, but conservatively tried not to touch the overall workflow of frame unwinding too much. However, once we more fully embrace the new callstack model, simplifications ore on offer.

A prerequisite for that is changing the special return mechanism to use callstack unwinding rather than a check in `remove_one_frame`. There is a further benefit to this: we also can allocate space for any data associated with special return handlers on the callstack rather than using the FSA or `malloc`.

One usage of the special return mechanism was for running finalizers. This was the only use that did not install the special return handler on the currently executing frame, and thus was not possible to port use the new mechanism, which installs the special return record on the callstack. After playing with a few ideas, the simplest one - with relatively low cost - turned out to be just checking if anything needs finalizing, and trying to run a handler if so. This is probably more robust than what it replaces, since we don't go trying to find a frame to put the handler on down the call chain.

With the special return handling migrated, it then became possible to greatly simplify `remove_one_frame`, it could now rely on the unwinding process to leave the interpreter in the correct state. The "thunked" flag could also go away thanks to this. Interpreter boundary checks went away thanks to having a callstack record type to mark such boundaries. Some work was also eliminated for callstack frames. Finally, an inlining and check elimination the compiler failed to do decreases the cost of returning from JIT-compiled frames.

This seems to be worth ~5% off a recursive Fibonacci benchmark.