### PR TITLE
Lego JIT of getcurhllsym

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -434,6 +434,8 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_usecompileehllconfig: return MVM_hll_enter_compilee_mode;
     case MVM_OP_usecompilerhllconfig: return MVM_hll_leave_compilee_mode;
 
+    case MVM_OP_getcurhllsym: return MVM_hll_sym_get;
+
     default:
         MVM_oops(tc, "JIT: No function for op %d in op_to_func (%s)", opcode, MVM_op_get_op(opcode)->name);
     }
@@ -3970,6 +3972,16 @@ start:
     case MVM_OP_usecompilerhllconfig: {
         MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } } };
         jg_append_call_c(tc, jg, op_to_func(tc, op), 1, args, MVM_JIT_RV_VOID, -1);
+        break;
+    }
+    case MVM_OP_getcurhllsym: {
+        MVMint16 dst = ins->operands[0].reg.orig;
+        MVMint16 sym = ins->operands[1].reg.orig;
+        MVMString *hll_name = jg->sg->sf->body.cu->body.hll_name;
+        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
+                                 { MVM_JIT_LITERAL_PTR, { (uintptr_t)hll_name } },
+                                 { MVM_JIT_REG_VAL, { sym } } };
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 3, args, MVM_JIT_RV_PTR, dst);
         break;
     }
     default: {


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.
`use nqp; my $a; $a := nqp::getcurhllsym("GLOBAL") for ^10_000_000; say now - INIT now; say $a` decreases from ~0.67s to ~0.54s and a spesh log of some random code doesn't show any lego jit bails for getcurhllsym after. Oddly, a profile of the above code shows more frames after (but they're all jitted and runtime is less).
Before: In total, 8555 call frames were entered and exited by the profiled code. Inlining eliminated the need to create 9995362 call frames (that's 99.91%).
After: In total, 10400 call frames were entered and exited by the profiled code. Inlining eliminated the need to create 9993505 call frames (that's 99.9%).