### PR TITLE
Use callp instead of call in jit of new(mixin)type

### DIFF
--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2285,7 +2285,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 name = ins->operands[2].reg.orig;
         | mov ARG1, TC;
         | mov ARG2, aword WORK[name];
-        | call &MVM_repr_get_by_name;
+        | callp &MVM_repr_get_by_name;
         | mov FUNCTION, REPR:RV->type_object_for;
         | mov ARG1, TC;
         | mov ARG2, aword WORK[how];
@@ -2299,7 +2299,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 name = ins->operands[2].reg.orig;
         | mov ARG1, TC;
         | mov ARG2, aword WORK[name];
-        | call &MVM_repr_get_by_name;
+        | callp &MVM_repr_get_by_name;
         | mov FUNCTION, REPR:RV->type_object_for;
         | mov ARG1, TC;
         | mov ARG2, aword WORK[how];


### PR DESCRIPTION
Callp should be used with function pointers, but we've just been lucky
so far (probably because these aren't very hot ops).