### PR TITLE
Dispatcher replace arg syscall

### DIFF
--- a/src/6model/reprs/MVMCapture.c
+++ b/src/6model/reprs/MVMCapture.c
@@ -429,7 +429,7 @@ MVMObject * MVM_capture_insert_arg(MVMThreadContext *tc, MVMObject *capture_obj,
  *
  * The callsite argument type is expected to be the same. */
 MVMObject * MVM_capture_replace_arg(MVMThreadContext *tc, MVMObject *capture_obj, MVMuint32 idx,
-        MVMRegister value) {
+        MVMCallsiteEntry kind, MVMRegister value) {
     MVMCapture *capture = validate_capture(tc, capture_obj);
     if (idx > capture->body.callsite->num_pos)
         MVM_exception_throw_adhoc(tc, "Capture argument index out of range");
@@ -437,9 +437,9 @@ MVMObject * MVM_capture_replace_arg(MVMThreadContext *tc, MVMObject *capture_obj
     /* Allocate a new capture before we begin; this is the only GC allocation
      * we do. */
     MVMCallsite *callsite = capture->body.callsite;
-    MVMCallsite *new_callsite = MVM_callsite_copy(tc, capture->body.callsite);
+    MVMCallsite *new_callsite = MVM_callsite_replace_positional(tc, capture->body.callsite, idx, kind);
     MVMObject *new_capture;
-    MVMCallsiteEntry kind = new_callsite->arg_flags[idx];
+    new_callsite->arg_flags[idx] = kind;
     MVMROOT(tc, capture, {
         if (kind & (MVM_CALLSITE_ARG_OBJ | MVM_CALLSITE_ARG_STR)) {
             MVMROOT(tc, value.o, {

--- a/src/6model/reprs/MVMCapture.c
+++ b/src/6model/reprs/MVMCapture.c
@@ -423,3 +423,45 @@ MVMObject * MVM_capture_insert_arg(MVMThreadContext *tc, MVMObject *capture_obj,
     ((MVMCapture *)new_capture)->body.args = new_args;
     return new_capture;
 }
+
+/* Produce a new capture by taking the current one and replacing a designated
+ * argument with a new value.
+ *
+ * The callsite argument type is expected to be the same. */
+MVMObject * MVM_capture_replace_arg(MVMThreadContext *tc, MVMObject *capture_obj, MVMuint32 idx,
+        MVMRegister value) {
+    MVMCapture *capture = validate_capture(tc, capture_obj);
+    if (idx > capture->body.callsite->num_pos)
+        MVM_exception_throw_adhoc(tc, "Capture argument index out of range");
+
+    /* Allocate a new capture before we begin; this is the only GC allocation
+     * we do. */
+    MVMCallsite *callsite = capture->body.callsite;
+    MVMCallsite *new_callsite = MVM_callsite_copy(tc, capture->body.callsite);
+    MVMObject *new_capture;
+    MVMCallsiteEntry kind = new_callsite->arg_flags[idx];
+    MVMROOT(tc, capture, {
+        if (kind & (MVM_CALLSITE_ARG_OBJ | MVM_CALLSITE_ARG_STR)) {
+            MVMROOT(tc, value.o, {
+                new_capture = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTCapture);
+            });
+        }
+        else {
+            new_capture = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTCapture);
+        }
+    });
+
+    /* Form a new arguments buffer, replacing the specified argument. */
+    MVMRegister *new_args = MVM_fixed_size_alloc(tc, tc->instance->fsa,
+            callsite->flag_count * sizeof(MVMRegister));
+    MVMuint32 from = 0;
+    for (from = 0; from < capture->body.callsite->flag_count; from++) {
+        new_args[from] = capture->body.args[from];
+    }
+    new_args[idx] = value;
+
+    /* Form new capture object. */
+    ((MVMCapture *)new_capture)->body.callsite = new_callsite;
+    ((MVMCapture *)new_capture)->body.args = new_args;
+    return new_capture;
+}

--- a/src/6model/reprs/MVMCapture.h
+++ b/src/6model/reprs/MVMCapture.h
@@ -46,4 +46,4 @@ MVMObject * MVM_capture_drop_args(MVMThreadContext *tc, MVMObject *capture, MVMu
 MVMObject * MVM_capture_insert_arg(MVMThreadContext *tc, MVMObject *capture, MVMuint32 idx,
         MVMCallsiteFlags kind, MVMRegister value);
 MVMObject * MVM_capture_replace_arg(MVMThreadContext *tc, MVMObject *capture_obj, MVMuint32 idx,
-        MVMRegister value);
+        MVMCallsiteEntry kind, MVMRegister value);

--- a/src/6model/reprs/MVMCapture.h
+++ b/src/6model/reprs/MVMCapture.h
@@ -45,3 +45,5 @@ MVMint64 MVM_capture_is_literal_arg(MVMThreadContext *tc, MVMObject *capture, MV
 MVMObject * MVM_capture_drop_args(MVMThreadContext *tc, MVMObject *capture, MVMuint32 idx, MVMuint32 count);
 MVMObject * MVM_capture_insert_arg(MVMThreadContext *tc, MVMObject *capture, MVMuint32 idx,
         MVMCallsiteFlags kind, MVMRegister value);
+MVMObject * MVM_capture_replace_arg(MVMThreadContext *tc, MVMObject *capture_obj, MVMuint32 idx,
+        MVMRegister value);

--- a/src/core/callsite.c
+++ b/src/core/callsite.c
@@ -396,6 +396,7 @@ MVMCallsite * MVM_callsite_drop_positionals(MVMThreadContext *tc, MVMCallsite *c
 
 /* Produce a new callsite consisting of the current one with a positional
  * argument inserted. It will be interned if possible. */
+/* TODO figure out if we want interning here or not */
 MVMCallsite * MVM_callsite_insert_positional(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx,
         MVMCallsiteFlags flag) {
     /* Can only do this with positional arguments and non-flattening callsite. */
@@ -421,6 +422,38 @@ MVMCallsite * MVM_callsite_insert_positional(MVMThreadContext *tc, MVMCallsite *
     }
     if (from == idx)
         new_callsite->arg_flags[to] = flag;
+    new_callsite->has_flattening = 0;
+    new_callsite->is_interned = 0;
+
+    if (cs->arg_names)
+        copy_nameds(tc, new_callsite, cs);
+    else
+        new_callsite->arg_names = NULL;
+
+    return new_callsite;
+}
+
+/* Produce a new callsite consisting of the current one with a positional
+ * argument inserted. */
+MVMCallsite * MVM_callsite_replace_positional(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx,
+        MVMCallsiteFlags flag) {
+    /* Can only do this with positional arguments and non-flattening callsite. */
+    if (idx > cs->num_pos)
+        MVM_exception_throw_adhoc(tc, "Cannot replace positional in callsite: index out of range");
+    if (cs->has_flattening)
+        MVM_exception_throw_adhoc(tc, "Cannot transform a callsite with flattening args");
+
+    /* Allocate a new callsite and set it up. */
+    MVMCallsite *new_callsite = MVM_malloc(sizeof(MVMCallsite));
+    new_callsite->num_pos = cs->num_pos;
+    new_callsite->flag_count = cs->flag_count;
+    new_callsite->arg_count = cs->arg_count;
+    new_callsite->arg_flags = MVM_malloc(new_callsite->flag_count);
+    MVMuint32 i = 0;
+    for (i = 0; i < cs->flag_count; i++) {
+        new_callsite->arg_flags[i] = cs->arg_flags[i];
+    }
+    new_callsite->arg_flags[idx] = flag;
     new_callsite->has_flattening = 0;
     new_callsite->is_interned = 0;
 

--- a/src/core/callsite.h
+++ b/src/core/callsite.h
@@ -124,7 +124,8 @@ MVMCallsite * MVM_callsite_drop_positional(MVMThreadContext *tc, MVMCallsite *cs
 MVMCallsite * MVM_callsite_drop_positionals(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx, MVMuint32 count);
 MVMCallsite * MVM_callsite_insert_positional(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx,
         MVMCallsiteFlags flag);
-
+MVMCallsite * MVM_callsite_replace_positional(MVMThreadContext *tc, MVMCallsite *cs, MVMuint32 idx,
+        MVMCallsiteFlags flag);
 /* Check if the callsite has nameds. */
 MVM_STATIC_INLINE MVMuint32 MVM_callsite_has_nameds(MVMThreadContext *tc, const MVMCallsite *cs) {
     return cs->num_pos != cs->flag_count;

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -1279,7 +1279,7 @@ MVMObject * MVM_disp_program_record_capture_replace_literal_arg(MVMThreadContext
         .transformation = MVMDispProgramRecordingDrop,
         .index = idx,
     };
-    MVM_VECTOR_INIT(dropped_arg_record.captures, 0);
+    MVM_VECTOR_INIT(dropped_arg_record.captures, 1);
     MVMDispProgramRecordingCapture *update = p.path[MVM_VECTOR_ELEMS(p.path) - 1];
     MVM_VECTOR_PUSH(update->captures, dropped_arg_record);
     MVM_VECTOR_PUSH(p.path, &update->captures[MVM_VECTOR_ELEMS(update->captures) - 1]);

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -1236,7 +1236,8 @@ MVMObject * MVM_disp_program_record_capture_replace_arg(MVMThreadContext *tc,
     MVM_VECTOR_PUSH(update->captures, dropped_arg_record);
     MVM_VECTOR_PUSH(p.path, &update->captures[MVM_VECTOR_ELEMS(update->captures) - 1]);
 
-    MVMObject *new_capture = MVM_capture_replace_arg(tc, capture, idx, ((MVMTracked *)tracked)->body.value);
+    MVMTracked *trackobj = (MVMTracked *)tracked;
+    MVMObject *new_capture = MVM_capture_replace_arg(tc, capture, idx, trackobj->body.kind, trackobj->body.value);
 
     /* After that, create an entry as if we had just added an argument.
      * This one also gets to have the actual capture. */
@@ -1283,7 +1284,7 @@ MVMObject * MVM_disp_program_record_capture_replace_literal_arg(MVMThreadContext
     MVM_VECTOR_PUSH(update->captures, dropped_arg_record);
     MVM_VECTOR_PUSH(p.path, &update->captures[MVM_VECTOR_ELEMS(update->captures) - 1]);
 
-    MVMObject *new_capture = MVM_capture_replace_arg(tc, capture, idx, value);
+    MVMObject *new_capture = MVM_capture_replace_arg(tc, capture, idx, kind, value);
 
     /* After that, create an entry as if we had just added an argument.
      * This one also gets to have the actual capture. */

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -1255,6 +1255,52 @@ MVMObject * MVM_disp_program_record_capture_replace_arg(MVMThreadContext *tc,
     return new_capture;
 }
 
+/* Record that we insert a tracked value into a capture. Also perform the insert
+ * on the value that was read. */
+MVMObject * MVM_disp_program_record_capture_replace_literal_arg(MVMThreadContext *tc,
+        MVMObject *capture, MVMuint32 idx, MVMCallsiteFlags kind, MVMRegister value) {
+    /* Lookup the index of the tracked value. */
+    MVMCallStackDispatchRecord *record = MVM_callstack_find_topmost_dispatch_recording(tc);
+
+    /* Also look up the path to the incoming capture. */
+    CapturePath p;
+    MVM_VECTOR_INIT(p.path, 8);
+    calculate_capture_path(tc, record, capture, &p);
+
+    /* Obtain a new value index for the constant. */
+    MVMuint32 value_index = value_index_constant(tc, &(record->rec), kind, value);
+
+    /* First, create an entry as if we had dropped the argument.
+     * We save the work of creating the capture here, because it is not
+     * used by anything - it is anonymous and can not be addressed. */
+    MVMDispProgramRecordingCapture dropped_arg_record = {
+        .capture = NULL,
+        .transformation = MVMDispProgramRecordingDrop,
+        .index = idx,
+    };
+    MVM_VECTOR_INIT(dropped_arg_record.captures, 0);
+    MVMDispProgramRecordingCapture *update = p.path[MVM_VECTOR_ELEMS(p.path) - 1];
+    MVM_VECTOR_PUSH(update->captures, dropped_arg_record);
+    MVM_VECTOR_PUSH(p.path, &update->captures[MVM_VECTOR_ELEMS(update->captures) - 1]);
+
+    MVMObject *new_capture = MVM_capture_replace_arg(tc, capture, idx, value);
+
+    /* After that, create an entry as if we had just added an argument.
+     * This one also gets to have the actual capture. */
+    MVMDispProgramRecordingCapture new_capture_record = {
+        .capture = new_capture,
+        .transformation = MVMDispProgramRecordingInsert,
+        .index = idx,
+        .value_index = value_index
+    };
+    MVM_VECTOR_INIT(new_capture_record.captures, 0);
+    update = p.path[MVM_VECTOR_ELEMS(p.path) - 1];
+    MVM_VECTOR_PUSH(update->captures, new_capture_record);
+    MVM_VECTOR_DESTROY(p.path);
+
+    /* Evaluate to the new capture, for the running dispatch function. */
+    return new_capture;
+}
 
 /* Record that we insert a new constant argument from a capture. Also perform the
  * insert, resulting in a new capture without a new argument inserted at the

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -1210,6 +1210,52 @@ MVMObject * MVM_disp_program_record_capture_insert_arg(MVMThreadContext *tc,
     return new_capture;
 }
 
+/* Record that we insert a tracked value into a capture. Also perform the insert
+ * on the value that was read. */
+MVMObject * MVM_disp_program_record_capture_replace_arg(MVMThreadContext *tc,
+        MVMObject *capture, MVMuint32 idx, MVMObject *tracked) {
+    /* Lookup the index of the tracked value. */
+    MVMCallStackDispatchRecord *record = MVM_callstack_find_topmost_dispatch_recording(tc);
+    MVMuint32 value_index = find_tracked_value_index(tc, &(record->rec), tracked);
+
+    /* Also look up the path to the incoming capture. */
+    CapturePath p;
+    MVM_VECTOR_INIT(p.path, 8);
+    calculate_capture_path(tc, record, capture, &p);
+
+    /* First, create an entry as if we had dropped the argument.
+     * We save the work of creating the capture here, because it is not
+     * used by anything - it is anonymous and can not be addressed. */
+    MVMDispProgramRecordingCapture dropped_arg_record = {
+        .capture = NULL,
+        .transformation = MVMDispProgramRecordingDrop,
+        .index = idx,
+    };
+    MVM_VECTOR_INIT(dropped_arg_record.captures, 0);
+    MVMDispProgramRecordingCapture *update = p.path[MVM_VECTOR_ELEMS(p.path) - 1];
+    MVM_VECTOR_PUSH(update->captures, dropped_arg_record);
+    MVM_VECTOR_PUSH(p.path, &update->captures[MVM_VECTOR_ELEMS(update->captures) - 1]);
+
+    MVMObject *new_capture = MVM_capture_replace_arg(tc, capture, idx, ((MVMTracked *)tracked)->body.value);
+
+    /* After that, create an entry as if we had just added an argument.
+     * This one also gets to have the actual capture. */
+    MVMDispProgramRecordingCapture new_capture_record = {
+        .capture = new_capture,
+        .transformation = MVMDispProgramRecordingInsert,
+        .index = idx,
+        .value_index = value_index
+    };
+    MVM_VECTOR_INIT(new_capture_record.captures, 0);
+    update = p.path[MVM_VECTOR_ELEMS(p.path) - 1];
+    MVM_VECTOR_PUSH(update->captures, new_capture_record);
+    MVM_VECTOR_DESTROY(p.path);
+
+    /* Evaluate to the new capture, for the running dispatch function. */
+    return new_capture;
+}
+
+
 /* Record that we insert a new constant argument from a capture. Also perform the
  * insert, resulting in a new capture without a new argument inserted at the
  * given index. */
@@ -2182,8 +2228,11 @@ static void emit_args_ops(MVMThreadContext *tc, MVMCallStackDispatchRecord *reco
                  * If we insert at index 2, then we get:
                  *   arg1, arg2, inserted, arg3, arg4
                  * So the untouched tail is length 2, or more generally,
-                 * (capture length - (index + 1)). */
-                MVMuint32 locally_untouched = cur_callsite->flag_count - (p.path[i]->index + 1);
+                 * (capture length - (index + 1)).
+                 *
+                 * If there have been any skipped drops, those are subtracted
+                 * straight from the locally untouched tail length. */
+                MVMuint32 locally_untouched = cur_callsite->flag_count - (p.path[i]->index + 1) - skipped_drops;
                 if (locally_untouched < untouched_tail_length)
                     untouched_tail_length = locally_untouched;
                 break;

--- a/src/disp/program.h
+++ b/src/disp/program.h
@@ -629,6 +629,8 @@ MVMObject * MVM_disp_program_record_capture_insert_arg(MVMThreadContext *tc,
         MVMObject *capture, MVMuint32 index, MVMObject *tracked);
 MVMObject * MVM_disp_program_record_capture_replace_arg(MVMThreadContext *tc,
         MVMObject *capture, MVMuint32 idx, MVMObject *tracked);
+MVMObject * MVM_disp_program_record_capture_replace_literal_arg(MVMThreadContext *tc,
+        MVMObject *capture, MVMuint32 idx, MVMCallsiteFlags kind, MVMRegister value);
 void MVM_disp_program_record_set_resume_init_args(MVMThreadContext *tc, MVMObject *capture);
 MVMObject * MVM_disp_program_record_get_resume_init_args(MVMThreadContext *tc);
 void MVM_disp_program_record_set_resume_state(MVMThreadContext *tc, MVMObject *tracked);

--- a/src/disp/program.h
+++ b/src/disp/program.h
@@ -627,6 +627,8 @@ MVMint64 MVM_disp_program_record_capture_is_arg_literal(MVMThreadContext *tc,
         MVMObject *capture, MVMuint32 index);
 MVMObject * MVM_disp_program_record_capture_insert_arg(MVMThreadContext *tc,
         MVMObject *capture, MVMuint32 index, MVMObject *tracked);
+MVMObject * MVM_disp_program_record_capture_replace_arg(MVMThreadContext *tc,
+        MVMObject *capture, MVMuint32 idx, MVMObject *tracked);
 void MVM_disp_program_record_set_resume_init_args(MVMThreadContext *tc, MVMObject *capture);
 MVMObject * MVM_disp_program_record_get_resume_init_args(MVMThreadContext *tc);
 void MVM_disp_program_record_set_resume_state(MVMThreadContext *tc, MVMObject *tracked);

--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -170,6 +170,25 @@ static MVMDispSysCall dispatcher_replace_arg = {
     .expected_concrete = { 1, 1, 1 }
 };
 
+/* dispatcher-replace-arg-literal-obj */
+static void dispatcher_replace_arg_literal_obj_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+    MVMObject *capture = get_obj_arg(arg_info, 0);
+    MVMint64 idx = get_int_arg(arg_info, 1);
+    MVMRegister insertee = { .o = get_obj_arg(arg_info, 2) };
+    MVMObject *derived = MVM_disp_program_record_capture_replace_literal_arg(tc, capture,
+            (MVMuint32)idx, MVM_CALLSITE_ARG_OBJ, insertee);
+    MVM_args_set_result_obj(tc, derived, MVM_RETURN_CURRENT_FRAME);
+}
+static MVMDispSysCall dispatcher_replace_arg_literal_obj = {
+    .c_name = "dispatcher-replace-arg-literal-obj",
+    .implementation = dispatcher_replace_arg_literal_obj_impl,
+    .min_args = 3,
+    .max_args = 3,
+    .expected_kinds = { MVM_CALLSITE_ARG_OBJ, MVM_CALLSITE_ARG_INT, MVM_CALLSITE_ARG_OBJ },
+    .expected_reprs = { MVM_REPR_ID_MVMCapture, 0, 0 },
+    .expected_concrete = { 1, 1, 0 }
+};
+
 
 /* dispatcher-insert-arg-literal-obj */
 static void dispatcher_insert_arg_literal_obj_impl(MVMThreadContext *tc, MVMArgs arg_info) {
@@ -1129,6 +1148,7 @@ void MVM_disp_syscall_setup(MVMThreadContext *tc) {
     add_to_hash(tc, &dispatcher_drop_n_args);
     add_to_hash(tc, &dispatcher_insert_arg);
     add_to_hash(tc, &dispatcher_replace_arg);
+    add_to_hash(tc, &dispatcher_replace_arg_literal_obj);
     add_to_hash(tc, &dispatcher_insert_arg_literal_obj);
     add_to_hash(tc, &dispatcher_insert_arg_literal_str);
     add_to_hash(tc, &dispatcher_insert_arg_literal_int);

--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -151,6 +151,26 @@ static MVMDispSysCall dispatcher_insert_arg = {
     .expected_concrete = { 1, 1, 1 }
 };
 
+/* dispatcher-replace-arg */
+static void dispatcher_replace_arg_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+    MVMObject *capture = get_obj_arg(arg_info, 0);
+    MVMint64 idx = get_int_arg(arg_info, 1);
+    MVMObject *tracked = get_obj_arg(arg_info, 2);
+    MVMObject *derived = MVM_disp_program_record_capture_replace_arg(tc, capture,
+            (MVMuint32)idx, tracked);
+    MVM_args_set_result_obj(tc, derived, MVM_RETURN_CURRENT_FRAME);
+}
+static MVMDispSysCall dispatcher_replace_arg = {
+    .c_name = "dispatcher-replace-arg",
+    .implementation = dispatcher_replace_arg_impl,
+    .min_args = 3,
+    .max_args = 3,
+    .expected_kinds = { MVM_CALLSITE_ARG_OBJ, MVM_CALLSITE_ARG_INT, MVM_CALLSITE_ARG_OBJ },
+    .expected_reprs = { MVM_REPR_ID_MVMCapture, 0, MVM_REPR_ID_MVMTracked },
+    .expected_concrete = { 1, 1, 1 }
+};
+
+
 /* dispatcher-insert-arg-literal-obj */
 static void dispatcher_insert_arg_literal_obj_impl(MVMThreadContext *tc, MVMArgs arg_info) {
     MVMObject *capture = get_obj_arg(arg_info, 0);
@@ -1108,6 +1128,7 @@ void MVM_disp_syscall_setup(MVMThreadContext *tc) {
     add_to_hash(tc, &dispatcher_drop_arg);
     add_to_hash(tc, &dispatcher_drop_n_args);
     add_to_hash(tc, &dispatcher_insert_arg);
+    add_to_hash(tc, &dispatcher_replace_arg);
     add_to_hash(tc, &dispatcher_insert_arg_literal_obj);
     add_to_hash(tc, &dispatcher_insert_arg_literal_str);
     add_to_hash(tc, &dispatcher_insert_arg_literal_int);


### PR DESCRIPTION
Lets us replace a single argument with a tracked value or a literal object value.

This saves the creation of one BOOTCapture when you used to drop and then insert with the same index.

The replace-arg syscall when inserted into the nqp dispatchers saves just 20 captures in `rakudo -e ''` but the replace-arg-literal-obj syscall saves about 1.5k.