### PR TITLE
Eliminate hllbool/boot-boolify-boxed-int pairs in spesh

### DIFF
--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -534,14 +534,14 @@ static MVMDispSysCall boolify_bigint = {
 };
 
 /* boolify-boxed-int */
-static void boolify_boxed_int_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+void MVM_disp_syscall_boolify_boxed_int_impl(MVMThreadContext *tc, MVMArgs arg_info) {
     MVMObject *obj = get_obj_arg(arg_info, 0);
     MVMint64 unboxed = REPR(obj)->box_funcs.get_int(tc, STABLE(obj), obj, OBJECT_BODY(obj));
     MVM_args_set_result_int(tc, unboxed != 0, MVM_RETURN_CURRENT_FRAME);
 }
 static MVMDispSysCall boolify_boxed_int = {
     .c_name = "boolify-boxed-int",
-    .implementation = boolify_boxed_int_impl,
+    .implementation = MVM_disp_syscall_boolify_boxed_int_impl,
     .min_args = 1,
     .max_args = 1,
     .expected_kinds = { MVM_CALLSITE_ARG_OBJ },

--- a/src/disp/syscall.h
+++ b/src/disp/syscall.h
@@ -35,3 +35,4 @@ struct MVMDispSysCall {
 
 void MVM_disp_syscall_setup(MVMThreadContext *tc);
 MVMDispSysCall * MVM_disp_syscall_find(MVMThreadContext *tc, MVMString *name);
+void MVM_disp_syscall_boolify_boxed_int_impl(MVMThreadContext *tc, MVMArgs arg_info);

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -96,6 +96,12 @@ void MVM_spesh_copy_facts(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshOperan
                           MVMSpeshOperand from) {
     copy_facts(tc, g, to, from);
 }
+static int is_syscall(MVMThreadContext *tc, MVMSpeshFacts *facts,
+                      void (*syscall) (MVMThreadContext *tc, MVMArgs arg_info)) {
+    return facts->flags & MVM_SPESH_FACT_KNOWN_VALUE
+        && REPR(facts->value.o)->ID == MVM_REPR_ID_MVMCFunction
+        && ((MVMCFunction*)facts->value.o)->body.func == syscall;
+}
 
 static void MVM_spesh_turn_into_set(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns *ins) {
     ins->info = MVM_op_get_op(MVM_OP_set);
@@ -2482,7 +2488,10 @@ static void try_eliminate_one_box_unbox(MVMThreadContext *tc, MVMSpeshGraph *g, 
                                          MVMSpeshIns *box_ins, MVMSpeshIns *unbox_ins) {
     if (conflict_free(tc, g, bb, box_ins, unbox_ins, box_ins->operands[1].reg.orig, 1)) {
         /* Make unbox instruction no longer use the boxed value. */
-        MVM_spesh_usages_delete_by_reg(tc, g, unbox_ins->operands[1], unbox_ins);
+        for (int i = 1; i < unbox_ins->info->num_operands; i++) {
+            if ((unbox_ins->info->operands[i] & MVM_operand_rw_mask) == MVM_operand_read_reg)
+                MVM_spesh_usages_delete_by_reg(tc, g, unbox_ins->operands[i], unbox_ins);
+        }
 
         /* Use the unboxed version instead, rewriting to a set. */
         unbox_ins->operands[1] = box_ins->operands[1];
@@ -2525,6 +2534,48 @@ static void try_eliminate_box_unbox_pair(MVMThreadContext *tc, MVMSpeshGraph *g,
         MVM_spesh_manipulate_delete_ins(tc, g, bb, ins);
     }
 }
+static void walk_set_looking_for_unbool(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
+                                       MVMSpeshIns *box_ins, MVMSpeshIns *set_ins) {
+    MVMSpeshUseChainEntry *user_entry = MVM_spesh_get_facts(tc, g, set_ins->operands[0])->usage.users;
+    while (user_entry) {
+        MVMSpeshIns *user = user_entry->user;
+        const MVMOpInfo *opinfo = user->info;
+        MVMuint16 opcode = opinfo->opcode;
+
+        if (opcode == MVM_OP_sp_runcfunc_i) {
+            MVMSpeshFacts *dispatch_facts = MVM_spesh_get_facts(tc, g, user->operands[1]);
+            if (is_syscall(tc, dispatch_facts, MVM_disp_syscall_boolify_boxed_int_impl))
+                try_eliminate_one_box_unbox(tc, g, bb, box_ins, user);
+        }
+        else if (opcode == MVM_OP_set || (opcode == MVM_SSA_PHI && opinfo->num_operands == 2)) {
+            walk_set_looking_for_unbool(tc, g, bb, box_ins, user);
+        }
+        user_entry = user_entry->next;
+    }
+}
+static void try_eliminate_bool_unbool_pair(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
+                                         MVMSpeshIns *ins, PostInlinePassState *pips) {
+    MVMSpeshUseChainEntry *user_entry = MVM_spesh_get_facts(tc, g, ins->operands[0])->usage.users;
+    while (user_entry) {
+        MVMSpeshIns *user = user_entry->user;
+        const MVMOpInfo *opinfo = user->info;
+        MVMuint16 opcode = opinfo->opcode;
+
+        if (opcode == MVM_OP_sp_runcfunc_i) {
+            MVMSpeshFacts *dispatch_facts = MVM_spesh_get_facts(tc, g, user->operands[1]);
+            if (is_syscall(tc, dispatch_facts, MVM_disp_syscall_boolify_boxed_int_impl))
+                try_eliminate_one_box_unbox(tc, g, bb, ins, user);
+            else
+                return;
+        }
+        else if (opcode == MVM_OP_set || (opcode == MVM_SSA_PHI && opinfo->num_operands == 2)) {
+            walk_set_looking_for_unbool(tc, g, bb, ins, user);
+        }
+        user_entry = user_entry->next;
+    }
+    if (!MVM_spesh_usages_is_used(tc, g, ins->operands[0]))
+        MVM_spesh_manipulate_delete_ins(tc, g, bb, ins);
+}
 
 
 static void post_inline_visit_bb(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
@@ -2549,6 +2600,9 @@ static void post_inline_visit_bb(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpes
                 break;
             case MVM_OP_box_u:
                 try_eliminate_box_unbox_pair(tc, g, bb, ins, MVM_OP_unbox_u, MVM_OP_decont_u, pips);
+                break;
+            case MVM_OP_hllbool:
+                try_eliminate_bool_unbool_pair(tc, g, bb, ins, pips);
                 break;
             case MVM_OP_unbox_i:
             case MVM_OP_unbox_n:


### PR DESCRIPTION
No need to turn an int into an HLL bool just to turn it back to an int when
using it as a condition for jumps. Eliminate those pairs same as we do with
box/unbox.