### PR TITLE
Remove counter productive NULL checks in decont ops

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -2770,7 +2770,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMObject *obj = GET_REG(cur_op, 2).o;
                 MVMRegister *r = &GET_REG(cur_op, 0);
                 cur_op += 4;
-                if (obj && IS_CONCRETE(obj) && STABLE(obj)->container_spec) {
+                if (IS_CONCRETE(obj) && STABLE(obj)->container_spec) {
                     STABLE(obj)->container_spec->fetch(tc, obj, r);
                 }
                 else {
@@ -5575,7 +5575,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMObject *obj = GET_REG(cur_op, 2).o;
                 MVMRegister *r = &GET_REG(cur_op, 0);
                 cur_op += 4;
-                if (obj && IS_CONCRETE(obj) && STABLE(obj)->container_spec)
+                if (IS_CONCRETE(obj) && STABLE(obj)->container_spec)
                     STABLE(obj)->container_spec->fetch(tc, obj, r);
                 else
                     r->o = obj;

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -1714,7 +1714,6 @@
 
 (template: decont!
   (ifv (any
-         (zr $1)
          (^is_type_obj $1)
          (zr (^getf (^stable $1) MVMSTable container_spec)))
     (store \$0 $1 ptr_sz)
@@ -2800,7 +2799,6 @@
 
 (template: sp_decont!
   (ifv (all
-         (nz $1)
          (^is_conc_obj $1)
          (nz (^getf (^stable $1) MVMSTable container_spec)))
     (callv (^getf (^getf (^stable $1) MVMSTable container_spec) MVMContainerSpec fetch)

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1833,9 +1833,6 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         MVMint16 dst = ins->operands[0].reg.orig;
         MVMint16 src = ins->operands[1].reg.orig;
         | mov TMP5, WORK[src];
-        | test TMP5, TMP5;
-        // obj is null
-        | jz >1;
         | test_type_object TMP5;
         // object is type object (not concrete)
         | jnz >1;


### PR DESCRIPTION
Object registers must never contain NULL values, so there should be no reason
to check for NULL values when deconting. Historically bugs in other parts of
the code have caused NULL values to appear in registers and these checks have
worked around these bugs. But in truth they just hide them and make it more
difficult to debug, so better to remove them. This might cost some stability in
the short term, but should enable us to fix the underlying bugs for good.