### PR TITLE
getlexperinvtype_o is now inlinable

### DIFF
--- a/src/core/oplist
+++ b/src/core/oplist
@@ -653,7 +653,7 @@ asyncwritebytes     w(obj) r(obj) r(obj) r(obj) r(obj) r(obj)
 DEPRECATED_16       w(obj) r(obj) r(obj) r(obj) r(obj)
 asyncreadbytes      w(obj) r(obj) r(obj) r(obj) r(obj) r(obj)
 getlexstatic_o      w(obj) r(str) :pure :noinline :specializable :cache
-getlexperinvtype_o  w(obj) r(str) :pure :noinline :logged :specializable
+getlexperinvtype_o  w(obj) r(str) :pure :logged :specializable
 execname            w(str)
 const_i64_16        w(int64) int16 :pure :confprog
 const_i64_32        w(int64) int32 :pure :confprog

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -9530,7 +9530,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         1,
         0,
-        1,
+        0,
         0,
         0,
         1,


### PR DESCRIPTION
"getlexperinvtype_o basically just calls MVM_frame_find_lexical_by_name
which in https://github.com/MoarVM/MoarVM/commit/e2e63d08342eb60f518ed5edf143b477626de81f
was converted to using the frame walker which correctly handles inlining. So
the reason for marking this op :noinline might actually be gone."
                                             - nine, #moarvm, 2021/11/10 18:39:19

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.