### PR TITLE
Fix JITed return from nested runloops

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -6207,7 +6207,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 /* trampoline back to this opcode */
                 cur_op -= 2;
                 MVM_jit_code_enter(tc, jc, cu);
-                if (MVM_UNLIKELY(!tc->cur_frame)) {
+                if (MVM_UNLIKELY(!tc->cur_frame || tc->stack_top->kind == MVM_CALLSTACK_RECORD_NESTED_RUNLOOP)) {
                     /* somehow unwound our top frame */
                     goto return_label;
                 }


### PR DESCRIPTION
When a callback frame is completely JIT compiled, including a return_o, we did
not notice that it's time to exit the runloop. MVM_callstack_unwind_frame will
already have set tc->cur_frame to the frame that called the native routine that
in turn ran the callback and returned 0 to signal that the runloop should end.
This 0 got forwarded by MVM_frame_try_return but JIT compiled code does not
look at this return value. Instead the sp_jit_enter op looked at tc->cur_frame
to determine whether to continue the runloop.

Fix by checking the stack top for a nested runloop entry in addition to
checking tc->cur_frame. Ideally JIT compiled code would just look at
MVM_frame_try_return's return value, just like the interpreter, but that will
require some more refactoring. So go with the easy solution for now to fix
the regression.