### PR TITLE
Mark nqp::radix as :pure

### DIFF
--- a/src/core/oplist
+++ b/src/core/oplist
@@ -294,7 +294,7 @@ findnotcclass       w(int64) r(int64) r(str) r(int64) r(int64) :pure
 nfafromstatelist    w(obj) r(obj) r(obj)
 nfarunproto         w(obj) r(obj) r(str) r(int64)
 nfarunalt           r(obj) r(str) r(int64) r(obj) r(obj) r(obj)
-radix               w(obj) r(int64) r(str) r(int64) r(int64) :useshll
+radix               w(obj) r(int64) r(str) r(int64) r(int64) :pure :useshll
 encode              w(obj) r(str) r(str) r(obj)
 decode              w(str) r(obj) r(str)
 istrue_s            w(int64) r(str) :pure

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -3877,7 +3877,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         MVM_OP_radix,
         "radix",
         5,
-        0,
+        1,
         0,
         0,
         0,


### PR DESCRIPTION
I suspect this was just overlooked in
ed9db7251d18d15bbf645e0a8b6cdb2654a32ece (where nqp::radix_I *was* marked
:pure).

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.