### PR TITLE
Convert temp allocations into alloca

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -530,7 +530,7 @@ static void write_hash_str_var(MVMThreadContext *tc, MVMSerializationWriter *wri
         MVMint32 is_malloced = 0;
         MVMuint32 keys_size = sizeof(MVMString *) * elems;
         MVMString **keys;
-        if (keys_size > 3000) {
+        if (keys_size > MAX_ALLOCA_SIZE) {
             keys = MVM_malloc(keys_size);
             is_malloced = 1;
         }

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -527,7 +527,16 @@ static void write_hash_str_var(MVMThreadContext *tc, MVMSerializationWriter *wri
     MVM_serialization_write_int(tc, writer, elems);
 
     if (elems) {
-        MVMString **keys = MVM_malloc(sizeof(MVMString *) * elems);
+        MVMint32 is_malloced = 0;
+        MVMuint32 keys_size = sizeof(MVMString *) * elems;
+        MVMString **keys;
+        if (keys_size > 3000) {
+            keys = MVM_malloc(keys_size);
+            is_malloced = 1;
+        }
+        else {
+            keys = alloca(keys_size);
+        }
         MVMObject *iter = MVM_iter(tc, hash);
         MVMuint64 i = 0;
 
@@ -541,7 +550,8 @@ static void write_hash_str_var(MVMThreadContext *tc, MVMSerializationWriter *wri
             MVM_serialization_write_str(tc, writer, keys[i]);
             MVM_serialization_write_ref(tc, writer, MVM_repr_at_key_o(tc, hash, keys[i]));
         }
-        MVM_free(keys);
+        if (is_malloced)
+            MVM_free(keys);
     }
 }
 

--- a/src/core/alloc.h
+++ b/src/core/alloc.h
@@ -1,3 +1,7 @@
+/* Size chosen based on https://logs.liz.nl/moarvm/2017-10-03.html
+ * tl;dr we don't want to allocate more than one page of stack. */
+#define MAX_ALLOCA_SIZE 3000
+
 MVM_STATIC_INLINE void * MVM_malloc(size_t size) {
 #ifdef MVM_USE_MIMALLOC
     void *ptr = mi_malloc(size);

--- a/src/core/validation.c
+++ b/src/core/validation.c
@@ -563,6 +563,7 @@ terminate_seq:
 void MVM_validate_static_frame(MVMThreadContext *tc,
         MVMStaticFrame *static_frame) {
     MVMStaticFrameBody *fb = &static_frame->body;
+    MVMint32 is_calloced = 0;
     Validator val[1];
 
     val->tc        = tc;
@@ -573,7 +574,14 @@ void MVM_validate_static_frame(MVMThreadContext *tc,
     val->bc_size   = fb->bytecode_size;
     val->src_cur_op = fb->bytecode;
     val->src_bc_end = fb->bytecode + fb->bytecode_size;
-    val->labels    = MVM_calloc(1, fb->bytecode_size);
+    if (fb->bytecode_size > 3000) {
+        val->labels    = MVM_calloc(1, fb->bytecode_size);
+        is_calloced = 1;
+    }
+    else {
+        val->labels    = alloca(fb->bytecode_size);
+        memset(val->labels, 0, fb->bytecode_size);
+    }
     val->cur_info  = NULL;
     val->cur_mark  = NULL;
     val->cur_instr = 0;
@@ -625,7 +633,8 @@ void MVM_validate_static_frame(MVMThreadContext *tc,
     validate_final_return(val);
 
     /* Validation successful. Clear up instruction offsets. */
-    MVM_free(val->labels);
+    if (is_calloced)
+        MVM_free(val->labels);
 
     /* Mark frame validated. */
     static_frame->body.validated = 1;

--- a/src/core/validation.c
+++ b/src/core/validation.c
@@ -574,7 +574,7 @@ void MVM_validate_static_frame(MVMThreadContext *tc,
     val->bc_size   = fb->bytecode_size;
     val->src_cur_op = fb->bytecode;
     val->src_bc_end = fb->bytecode + fb->bytecode_size;
-    if (fb->bytecode_size > 3000) {
+    if (fb->bytecode_size > MAX_ALLOCA_SIZE) {
         val->labels    = MVM_calloc(1, fb->bytecode_size);
         is_calloced = 1;
     }

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -2574,7 +2574,7 @@ static void emit_args_ops(MVMThreadContext *tc, MVMCallStackDispatchRecord *reco
             Action action;
             MVMuint32 index;
         } ArgProduction;
-        ArgProduction *arg_prod = MVM_malloc(num_to_produce * sizeof(ArgProduction));
+        ArgProduction *arg_prod = alloca(num_to_produce * sizeof(ArgProduction));
 
         for (i = 0; i < num_to_produce; i++) {
             /* Work out the source of this arg in the capture. For the rationale
@@ -2645,8 +2645,6 @@ static void emit_args_ops(MVMThreadContext *tc, MVMCallStackDispatchRecord *reco
             op.load.idx = arg_prod[i].index;
             MVM_VECTOR_PUSH(cs->ops, op);
         }
-
-        MVM_free(arg_prod);
 
         /* Finally, the instruction to copy what we can from the args tail. */
         MVMDispProgramOp op;

--- a/src/jit/linear_scan.c
+++ b/src/jit/linear_scan.c
@@ -427,7 +427,7 @@ static void find_holes(MVMThreadContext *tc, RegisterAllocator *alc, MVMJitTileL
 
     MVMint32 is_calloced = 0;
     MVMBitmap *bitmaps;
-    if (total_bitmap_alloc > 3000) {
+    if (total_bitmap_alloc > MAX_ALLOCA_SIZE) {
         bitmaps = MVM_calloc(list->blocks_num + 1, sizeof(MVMBitmap) * bitmap_size);
         is_calloced = 1;
     }

--- a/src/jit/linear_scan.c
+++ b/src/jit/linear_scan.c
@@ -419,12 +419,22 @@ static void find_holes(MVMThreadContext *tc, RegisterAllocator *alc, MVMJitTileL
 
     MVMJitExprTree *tree = list->tree;
     MVMuint32 bitmap_size = (alc->values_num >> 5) + 1;
+    MVMuint32 total_bitmap_alloc = (list->blocks_num + 1) * (sizeof(MVMBitmap) * bitmap_size);
 
  /* convenience macros */
 #define _BITMAP(_a)   (bitmaps + (_a)*bitmap_size)
 #define _SUCC(_a, _z) (list->blocks[(_a)].succ[(_z)])
 
-    MVMBitmap *bitmaps = MVM_calloc(list->blocks_num + 1, sizeof(MVMBitmap) * bitmap_size);
+    MVMint32 is_calloced = 0;
+    MVMBitmap *bitmaps;
+    if (total_bitmap_alloc > 3000) {
+        bitmaps = MVM_calloc(list->blocks_num + 1, sizeof(MVMBitmap) * bitmap_size);
+        is_calloced = 1;
+    }
+    else {
+        bitmaps = alloca(total_bitmap_alloc);
+        memset(bitmaps, 0, total_bitmap_alloc);
+    }
     /* last bitmap is allocated to hold diff, which is how we know which live
      * ranges holes potentially need to be closed */
     MVMBitmap *diff    = _BITMAP(list->blocks_num);
@@ -490,7 +500,8 @@ static void find_holes(MVMThreadContext *tc, RegisterAllocator *alc, MVMJitTileL
             }
         }
     }
-    MVM_free(bitmaps);
+    if (is_calloced)
+        MVM_free(bitmaps);
 
 #undef _BITMAP
 #undef _SUCC

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2772,7 +2772,7 @@ static void emit_posix_callargs(MVMThreadContext *tc, MVMJitCompiler *compiler, 
     MVMint32 num_gpr = 0, num_fpr = 0, num_stack = 0, i;
     MVMJitCallArg in_gpr[6], in_fpr[8], *on_stack = NULL;
     if (num_args > 6)
-        on_stack = MVM_malloc(sizeof(MVMJitCallArg) * (num_args - 6));
+        on_stack = alloca(sizeof(MVMJitCallArg) * (num_args - 6));
     /* divide in gpr, fpr, stack values */
     for (i = 0; i < num_args; i++) {
         switch (args[i].type) {
@@ -2832,8 +2832,6 @@ static void emit_posix_callargs(MVMThreadContext *tc, MVMJitCompiler *compiler, 
         // I'm not sure this is correct, btw
         emit_stack_arg(tc, compiler, jg, 8, i*8);
     }
-    if (on_stack)
-        MVM_free(on_stack);
 }
 
 static void emit_win64_callargs(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg,

--- a/src/spesh/dead_bb_elimination.c
+++ b/src/spesh/dead_bb_elimination.c
@@ -29,7 +29,8 @@ static void cleanup_dead_bb_instructions(MVMThreadContext *tc, MVMSpeshGraph *g,
                                          MVMSpeshBB *dead_bb, MVMint32 cleanup_facts,
                                          MVMuint8 *deleted_inline) {
     MVMSpeshIns *ins = dead_bb->first_ins;
-    MVMint8 *frame_handlers_started = MVM_calloc(g->num_handlers, 1);
+    MVMint8 *frame_handlers_started = alloca(g->num_handlers);
+    memset(frame_handlers_started, 0, g->num_handlers);
     while (ins) {
         /* Look over any annotations on the instruction. */
         MVMSpeshAnn *ann = ins->annotations;
@@ -103,7 +104,6 @@ static void cleanup_dead_bb_instructions(MVMThreadContext *tc, MVMSpeshGraph *g,
     }
     dead_bb->first_ins = NULL;
     dead_bb->last_ins = NULL;
-    MVM_free(frame_handlers_started);
 }
 
 static void mark_bb_seen(MVMThreadContext *tc, MVMSpeshBB *bb, MVMint8 *seen) {
@@ -125,7 +125,8 @@ void MVM_spesh_eliminate_dead_bbs(MVMThreadContext *tc, MVMSpeshGraph *g, MVMint
     /* First pass: mark every basic block that is reachable from the
      * entrypoint. */
     MVMuint32 orig_bbs = g->num_bbs;
-    MVMint8  *seen = MVM_calloc(1, g->num_bbs);
+    MVMint8  *seen = alloca(g->num_bbs);
+    memset(seen, 0, g->num_bbs);
     mark_bb_seen(tc, g->entry, seen);
 
     /* Second pass: remove dead BBs from the graph. */
@@ -143,7 +144,6 @@ void MVM_spesh_eliminate_dead_bbs(MVMThreadContext *tc, MVMSpeshGraph *g, MVMint
             cur_bb = cur_bb->linear_next;
         }
     }
-    MVM_free(seen);
 
     /* If we deleted an inline, make sure we don't leave behind any
      * stray end annotations. */

--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -933,10 +933,10 @@ static void dfs(MVMSpeshBB **rpo, MVMint32 *insert_pos, MVMuint8 *seen, MVMSpesh
 }
 MVMSpeshBB ** MVM_spesh_graph_reverse_postorder(MVMThreadContext *tc, MVMSpeshGraph *g) {
     MVMSpeshBB **rpo  = MVM_calloc(g->num_bbs, sizeof(MVMSpeshBB *));
-    MVMuint8    *seen = MVM_calloc(g->num_bbs, 1);
+    MVMuint8    *seen = alloca(g->num_bbs);
+    memset(seen, 0, g->num_bbs);
     MVMint32     ins  = g->num_bbs - 1;
     dfs(rpo, &ins, seen, g->entry);
-    MVM_free(seen);
     if (ins != -1) {
         char *dump_msg = MVM_spesh_dump(tc, g);
         printf("%s", dump_msg);

--- a/src/spesh/pea.c
+++ b/src/spesh/pea.c
@@ -494,7 +494,8 @@ static void add_deopt_materializations_ins(MVMThreadContext *tc, MVMSpeshGraph *
  * and, perhaps, some guard eliminations. */
 static MVMuint32 analyze(MVMThreadContext *tc, MVMSpeshGraph *g, GraphState *gs) {
     MVMSpeshBB **rpo = MVM_spesh_graph_reverse_postorder(tc, g);
-    MVMuint8 *seen = MVM_calloc(g->num_bbs, 1);
+    MVMuint8 *seen = alloca(g->num_bbs);
+    memset(seen, 0, g->num_bbs);
     MVMuint32 found_replaceable = 0;
     MVMuint32 i;
     for (i = 0; i < g->num_bbs; i++) {
@@ -506,7 +507,6 @@ static MVMuint32 analyze(MVMThreadContext *tc, MVMSpeshGraph *g, GraphState *gs)
         for (j = 0; j < bb->num_pred; j++) {
             if (!seen[bb->pred[j]->rpo_idx]) {
                 pea_log("partial escape analysis not implemented for loops");
-                MVM_free(seen);
                 MVM_free(rpo);
                 return 0;
             }
@@ -708,7 +708,6 @@ static MVMuint32 analyze(MVMThreadContext *tc, MVMSpeshGraph *g, GraphState *gs)
         seen[bb->rpo_idx] = 1;
     }
     MVM_free(rpo);
-    MVM_free(seen);
     return found_replaceable;
 }
 

--- a/src/spesh/plan.c
+++ b/src/spesh/plan.c
@@ -98,7 +98,8 @@ static void plan_for_cs(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMStaticFrame
         /* It is. We'll try and produce some specializations, looping until
          * no tuples that remain give us anything significant. */
         MVMuint32 required_hits = (PERCENT_RELEVANT * (by_cs->hits + by_cs->osr_hits)) / 100;
-        MVMuint8 *tuples_used = MVM_calloc(by_cs->num_by_type, 1);
+        MVMuint8 *tuples_used = alloca(by_cs->num_by_type);
+        memset(tuples_used, 0, by_cs->num_by_type);
         MVMuint32 num_obj_args = 0, i;
         for (i = 0; i < by_cs->cs->flag_count; i++)
             if (by_cs->cs->arg_flags[i] & MVM_CALLSITE_ARG_OBJ)
@@ -220,9 +221,6 @@ static void plan_for_cs(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMStaticFrame
                 break;
             }
         }
-
-        /* Clean up allocated memory. */
-        MVM_free(tuples_used);
     }
 
     /* If we get here, and found no specializations to produce, we can add

--- a/src/strings/parse_num.c
+++ b/src/strings/parse_num.c
@@ -104,7 +104,7 @@ static double parse_int_frac_exp(MVMThreadContext *tc, MVMCodepointIter *ci, MVM
     int buf_size = 1 + MVM_string_graphs(tc, s);
     int is_malloced = 0;
     char *digits_buf;
-    if (buf_size > 3000) {
+    if (buf_size > MAX_ALLOCA_SIZE) {
        digits_buf = (char *)MVM_malloc(buf_size);
        is_malloced = 1;
     }

--- a/src/strings/parse_num.c
+++ b/src/strings/parse_num.c
@@ -101,7 +101,16 @@ static double parse_int_frac_exp(MVMThreadContext *tc, MVMCodepointIter *ci, MVM
     int frac_digits = 0;
     int digit;
     int ends_with_underscore = 0;
-    char *digits_buf = (char *)MVM_malloc(1 + MVM_string_graphs(tc, s));
+    int buf_size = 1 + MVM_string_graphs(tc, s);
+    int is_malloced = 0;
+    char *digits_buf;
+    if (buf_size > 3000) {
+       digits_buf = (char *)MVM_malloc(buf_size);
+       is_malloced = 1;
+    }
+    else {
+        digits_buf = alloca(buf_size);
+    }
     char *digits_buf_tail = digits_buf;
     double result;
 
@@ -172,7 +181,8 @@ static double parse_int_frac_exp(MVMThreadContext *tc, MVMCodepointIter *ci, MVM
 
     *digits_buf_tail = '\0';
     result = strtod(digits_buf, NULL);
-    MVM_free(digits_buf);
+    if (is_malloced)
+        MVM_free(digits_buf);
     return result;
 }
 


### PR DESCRIPTION
These were all pointed out by heaptrack as sources of temporary
allocations during a Rakudo compile of CORE.c.setting.

Before heaptrack reported 29,995,046 calls to allocation functions and
2,600,772 temporary allocations. After it reports 29,526,794 calls to
allocation functions and 2,442,004 temporary allocations.

Most of these probably don't impact performance all that much, but the
change to parse_int_frac_exp does make a small-but-noticeably-positive
difference when coercing a native str to a native num. `my str $a =
100000.rand.Str; my num $b; $b = $a for ^10_000_000; say now - INIT now;
say $b` reports ~2.17s before and ~2s after.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.