### PR TITLE
Fix out of bounds read of PHI facts in spesh

### DIFF
--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -1165,8 +1165,8 @@ MVMOpInfo *get_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMuint32 nrargs) {
 
     /* Up to 64 args, almost every number is represented, but after that
      * we have a sparse array through which we must search. */
-    if (nrargs - 2 < MVMPhiNodeCacheSparseBegin) {
-        result = &g->phi_infos[nrargs - 2];
+    if (nrargs - 1 < MVMPhiNodeCacheSparseBegin) {
+        result = &g->phi_infos[nrargs - 1];
     } else {
         MVMint32 cache_idx;
 


### PR DESCRIPTION
During spesh optimization, we remove reads of registers with dead writers from
PHI nodes. It could happen that the PHI node ended up with no registers to read
at all. However the following analysis code assumed that we'd always have at
least 1 register to read from, resulting in an array read out of bounds error
and a variety of failure modes.

Fix by removing a PHI instruction completely after removing the last read
operand. Note that since deleting an instruction also cleans up the usage chain,
we still have to generate a new instruction info with the correct number of
operands before being able to delete the PHI instruction.