### PR TITLE
Deserialize empty hashes robustly

### DIFF
--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -187,16 +187,18 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
         MVM_oops(tc, "deserialize on MVMHash that is already initialized");
     }
     MVMint64 elems = MVM_serialization_read_int(tc, reader);
-    MVM_str_hash_build(tc, hashtable, sizeof(MVMHashEntry), elems);
-    MVMint64 i;
-    for (i = 0; i < elems; i++) {
-        MVMString *key = MVM_serialization_read_str(tc, reader);
-        if (!MVM_str_hash_key_is_valid(tc, key)) {
-            MVM_str_hash_key_throw_invalid(tc, key);
-        }
-        MVMObject *value = MVM_serialization_read_ref(tc, reader);
-        MVMHashEntry *entry = MVM_str_hash_insert_nocheck(tc, hashtable, key);
-        MVM_ASSIGN_REF(tc, &(root->header), entry->value, value);
+    if (elems) {
+        MVM_str_hash_build(tc, hashtable, sizeof(MVMHashEntry), elems);
+        MVMint64 i = 0;
+        do {
+            MVMString *key = MVM_serialization_read_str(tc, reader);
+            if (!MVM_str_hash_key_is_valid(tc, key)) {
+                MVM_str_hash_key_throw_invalid(tc, key);
+            }
+            MVMObject *value = MVM_serialization_read_ref(tc, reader);
+            MVMHashEntry *entry = MVM_str_hash_insert_nocheck(tc, hashtable, key);
+            MVM_ASSIGN_REF(tc, &(root->header), entry->value, value);
+        } while (++i < elems);
     }
 }
 

--- a/src/core/str_hash_table_funcs.h
+++ b/src/core/str_hash_table_funcs.h
@@ -24,8 +24,14 @@ MVM_STATIC_INLINE MVMuint32 MVM_str_hash_allocated_items(const struct MVMStrHash
     assert(!(control->cur_items == 0 && control->max_items == 0));
     return MVM_str_hash_official_size(control) + control->max_probe_distance_limit - 1;
 }
+/* Returns the number of buckets that the hash is using. This can be lower than
+ * the number of buckets allocated, as the last bucket that can be used is at
+ * max_probe_distance - 1, whereas buckets are allocated up to
+ * max_probe_distance_limit - 1. And if the hash is empty, it can't be using
+ * any buckets. As the name is meant to imply, this function is private. */
 MVM_STATIC_INLINE MVMuint32 MVM_str_hash_kompromat(const struct MVMStrHashTableControl *control) {
-    assert(!(control->cur_items == 0 && control->max_items == 0));
+    if (MVM_UNLIKELY(control->cur_items == 0))
+        return 0;
     return MVM_str_hash_official_size(control) + control->max_probe_distance - 1;
 }
 MVM_STATIC_INLINE MVMuint8 *MVM_str_hash_metadata(const struct MVMStrHashTableControl *control) {


### PR DESCRIPTION
Fixes a bug whereby we wrongly hit an assertion failure if attempting to iterate an empty hash that had been serialized/deserialized. This was recently discovered because it broke the build of `LibXML`. However, the bug has been present for months, so it is totally unclear how it was only just encountered. (Other than "assertions default to disabled", and the code path beyond the assertion would still give correct results)

Also optimise the hash memory allocation when deserializing an empty hash, and the code executed when serializing it.