### PR TITLE
Fix segfault with void native calls

### DIFF
--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -1132,6 +1132,7 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                     MVM_gc_mark_thread_unblocked(tc);
                     result = res_type;
                     update_rws(tc, free_rws, num_args, arg_types, args, interval_id);
+                    MVM_args_set_dispatch_result_obj(tc, tc->cur_frame, result);
                     break;
                 case MVM_NATIVECALL_ARG_CHAR: {
                     MVMint64 native_result = (signed char)dcCallChar(vm, entry_point);

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -1127,6 +1127,7 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                     MVM_gc_mark_thread_unblocked(tc);
                     result = res_type;
                     update_rws(tc, values, num_args, arg_types, args, interval_id);
+                    MVM_args_set_dispatch_result_obj(tc, tc->cur_frame, result);
                     break;
                 }
                 case MVM_NATIVECALL_ARG_CHAR:


### PR DESCRIPTION
This PR fixes two situations where calls to native functions without return values could lead to uninitialized registers getting read.