### PR TITLE
Fix possible access to fromspace when autoboxing return values

### DIFF
--- a/src/core/args.c
+++ b/src/core/args.c
@@ -711,9 +711,12 @@ void MVM_args_set_result_int(MVMThreadContext *tc, MVMint64 result, MVMint32 fra
             case MVM_RETURN_NUM:
                 target->return_value->n64 = (MVMnum64)result;
                 break;
-            case MVM_RETURN_OBJ:
-                autobox_int(tc, target, result, (frameless ? tc->cur_frame : tc->cur_frame->caller)->return_value->o);
+            case MVM_RETURN_OBJ: {
+                /* dereference target first to avoid GC issue */
+                MVMRegister *return_value = (frameless ? tc->cur_frame : tc->cur_frame->caller)->return_value;
+                autobox_int(tc, target, result, return_value->o);
                 break;
+            }
             case MVM_RETURN_ALLOMORPH:
                 target->return_type = MVM_RETURN_INT;
                 target->return_value->i64 = result;
@@ -734,9 +737,11 @@ void MVM_args_set_dispatch_result_int(MVMThreadContext *tc, MVMFrame *target, MV
         case MVM_RETURN_NUM:
             target->return_value->n64 = (MVMnum64)result;
             break;
-        case MVM_RETURN_OBJ:
-            autobox_int(tc, target, result, target->return_value->o);
+        case MVM_RETURN_OBJ: {
+            MVMRegister *return_value = target->return_value; /* dereference target first to avoid GC issue */
+            autobox_int(tc, target, result, return_value->o);
             break;
+        }
         default:
             MVM_exception_throw_adhoc(tc, "Result return coercion from int NYI; expects type %u", target->return_type);
     }
@@ -767,9 +772,12 @@ void MVM_args_set_result_num(MVMThreadContext *tc, MVMnum64 result, MVMint32 fra
             case MVM_RETURN_INT:
                 target->return_value->i64 = (MVMint64)result;
                 break;
-            case MVM_RETURN_OBJ:
-                autobox(tc, target, result, num_box_type, 0, set_num, (frameless ? tc->cur_frame : tc->cur_frame->caller)->return_value->o);
+            case MVM_RETURN_OBJ: {
+                /* dereference target first to avoid GC issue */
+                MVMRegister *return_value = (frameless ? tc->cur_frame : tc->cur_frame->caller)->return_value;
+                autobox(tc, target, result, num_box_type, 0, set_num, return_value->o);
                 break;
+            }
             case MVM_RETURN_ALLOMORPH:
                 target->return_type = MVM_RETURN_NUM;
                 target->return_value->n64 = result;
@@ -790,9 +798,11 @@ void MVM_args_set_dispatch_result_num(MVMThreadContext *tc, MVMFrame *target, MV
         case MVM_RETURN_INT:
             target->return_value->i64 = (MVMint64)result;
             break;
-        case MVM_RETURN_OBJ:
-            autobox(tc, target, result, num_box_type, 0, set_num, target->return_value->o);
+        case MVM_RETURN_OBJ: {
+            MVMRegister *return_value = target->return_value; /* dereference target first to avoid GC issue */
+            autobox(tc, target, result, num_box_type, 0, set_num, return_value->o);
             break;
+        }
         default:
             MVM_exception_throw_adhoc(tc, "Result return coercion from num NYI; expects type %u", target->return_type);
     }
@@ -824,9 +834,12 @@ void MVM_args_set_result_str(MVMThreadContext *tc, MVMString *result, MVMint32 f
             case MVM_RETURN_STR:
                 target->return_value->s = result;
                 break;
-            case MVM_RETURN_OBJ:
-                autobox(tc, target, result, str_box_type, 1, set_str, (frameless ? tc->cur_frame : tc->cur_frame->caller)->return_value->o);
+            case MVM_RETURN_OBJ: {
+                /* dereference target first to avoid GC issue */
+                MVMRegister *return_value = (frameless ? tc->cur_frame : tc->cur_frame->caller)->return_value;
+                autobox(tc, target, result, str_box_type, 1, set_str, return_value->o);
                 break;
+            }
             case MVM_RETURN_ALLOMORPH:
                 target->return_type = MVM_RETURN_STR;
                 target->return_value->s = result;
@@ -847,9 +860,11 @@ void MVM_args_set_dispatch_result_str(MVMThreadContext *tc, MVMFrame *target, MV
         case MVM_RETURN_STR:
             target->return_value->s = result;
             break;
-        case MVM_RETURN_OBJ:
-            autobox(tc, target, result, str_box_type, 1, set_str, target->return_value->o);
+        case MVM_RETURN_OBJ: {
+            MVMRegister *return_value = target->return_value; /* dereference target first to avoid GC issue */
+            autobox(tc, target, result, str_box_type, 1, set_str, return_value->o);
             break;
+        }
         default:
             MVM_exception_throw_adhoc(tc, "Result return coercion from str NYI; expects type %u", target->return_type);
     }


### PR DESCRIPTION
If the target frame (e.g. tc->cur_frame) is a heap frame that lives in the
nursery, the return value is a native value (e.g. return_i or a native call),
the caller expects an object and boxing happens to trigger a GC run, the
target frame could be moved before we dereference the target pointer to get
the return_value register. This would lead to a segfault with GC_DEBUG 3.

Fix by dereferencing target first instead of having the autobox(_int) macros
doing it after boxing.

Fixes GH #1621