### PR TITLE
Remove callsite flat named flag

### DIFF
--- a/lib/MAST/Nodes.nqp
+++ b/lib/MAST/Nodes.nqp
@@ -396,7 +396,6 @@ module Arg {
     our $literal := 16;
     our $named := 32;
     our $flat  := 64;
-    our $flatnamed := 128;
 }
 
 # Labels (used directly in the instruction stream indicates where the

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -912,23 +912,6 @@ static MVMCallsite ** deserialize_callsites(MVMThreadContext *tc, MVMCompUnit *c
                     positionals++;
                 }
             }
-            else if (callsites[i]->arg_flags[j] & MVM_CALLSITE_ARG_FLAT_NAMED) {
-                if (!(callsites[i]->arg_flags[j] & MVM_CALLSITE_ARG_OBJ)) {
-                    MVMuint32 k;
-                    for (k = 0; k <= i; k++) {
-                        if (!callsites[i]->is_interned) {
-                            MVM_free(callsites[i]->arg_flags);
-                            MVM_free_null(callsites[i]);
-                        }
-                    }
-                    MVM_fixed_size_free(tc, tc->instance->fsa,
-                        sizeof(MVMCallsite *) * rs->expected_callsites,
-                        callsites);
-                    MVM_exception_throw_adhoc(tc, "Flattened named args must be objects");
-                }
-                has_flattening = 1;
-                nameds_slots++;
-            }
             else if (callsites[i]->arg_flags[j] & MVM_CALLSITE_ARG_NAMED) {
                 nameds_slots += 2;
                 nameds_non_flattening++;

--- a/src/core/bytecodedump.c
+++ b/src/core/bytecodedump.c
@@ -430,19 +430,21 @@ char * MVM_bytecode_dump(MVMThreadContext *tc, MVMCompUnit *cu) {
             MVMCallsiteEntry csitee = callsite->arg_flags[i++];
             a("    Arg %u :", i);
             if (csitee & MVM_CALLSITE_ARG_NAMED) {
-                if (callsite->arg_names) {
-                    char *arg_name = MVM_string_utf8_encode_C_string(tc,
-                        callsite->arg_names[nameds_count++]);
-                    a(" named(%s)", arg_name);
-                    MVM_free(arg_name);
+                if (csitee & MVM_CALLSITE_ARG_FLAT) {
+                    a(" flatnamed");
                 }
                 else {
-                    a(" named");
+                    if (callsite->arg_names) {
+                        char *arg_name = MVM_string_utf8_encode_C_string(tc,
+                            callsite->arg_names[nameds_count++]);
+                        a(" named(%s)", arg_name);
+                        MVM_free(arg_name);
+                    }
+                    else {
+                        a(" named");
+                    }
+                    j++;
                 }
-                j++;
-            }
-            else if (csitee & MVM_CALLSITE_ARG_FLAT_NAMED) {
-                a(" flatnamed");
             }
             else if (csitee & MVM_CALLSITE_ARG_FLAT) {
                 a(" flat");

--- a/src/core/callsite.h
+++ b/src/core/callsite.h
@@ -132,7 +132,7 @@ MVM_STATIC_INLINE MVMuint16 MVM_callsite_num_nameds(MVMThreadContext *tc, const 
     MVMuint16 i = cs->num_pos;
     MVMuint16 nameds = 0;
     while (i < cs->flag_count) {
-        if (!(cs->arg_flags[i] & MVM_CALLSITE_ARG_FLAT_NAMED))
+        if (!(cs->arg_flags[i] & (MVM_CALLSITE_ARG_FLAT_NAMED | MVM_CALLSITE_ARG_FLAT)))
             nameds++;
         i++;
     }

--- a/src/core/callsite.h
+++ b/src/core/callsite.h
@@ -22,9 +22,6 @@ typedef enum {
 
     /* Argument is flattened. What this means is up to the target. */
     MVM_CALLSITE_ARG_FLAT = 64,
-
-    /* Argument is flattened and named. */
-    MVM_CALLSITE_ARG_FLAT_NAMED = 128
 } MVMCallsiteFlags;
 
 /* Callsites that are used within the VM. */
@@ -132,7 +129,7 @@ MVM_STATIC_INLINE MVMuint16 MVM_callsite_num_nameds(MVMThreadContext *tc, const 
     MVMuint16 i = cs->num_pos;
     MVMuint16 nameds = 0;
     while (i < cs->flag_count) {
-        if (!(cs->arg_flags[i] & (MVM_CALLSITE_ARG_FLAT_NAMED | MVM_CALLSITE_ARG_FLAT)))
+        if (!(cs->arg_flags[i] & MVM_CALLSITE_ARG_FLAT))
             nameds++;
         i++;
     }

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -2388,8 +2388,7 @@ static MVMint32 request_object_metadata(MVMThreadContext *dtc, cmp_ctx_t *ctx, r
                 + !!(entry & MVM_CALLSITE_ARG_NUM)
                 + !!(entry & MVM_CALLSITE_ARG_STR)
                 + !!(entry & MVM_CALLSITE_ARG_NAMED)
-                + !!(entry & MVM_CALLSITE_ARG_FLAT)
-                + !!(entry & MVM_CALLSITE_ARG_FLAT_NAMED);
+                + !!(entry & MVM_CALLSITE_ARG_FLAT);
             cmp_write_array(ctx, entry_count ? entry_count : 0);
             if (entry & MVM_CALLSITE_ARG_OBJ)
                 cmp_write_str(ctx, "obj", 3);
@@ -2399,12 +2398,14 @@ static MVMint32 request_object_metadata(MVMThreadContext *dtc, cmp_ctx_t *ctx, r
                 cmp_write_str(ctx, "num", 3);
             if (entry & MVM_CALLSITE_ARG_STR)
                 cmp_write_str(ctx, "str", 3);
-            if (entry & MVM_CALLSITE_ARG_NAMED)
-                cmp_write_str(ctx, "named", 5);
-            if (entry & MVM_CALLSITE_ARG_FLAT)
-                cmp_write_str(ctx, "flat", 4);
-            if (entry & MVM_CALLSITE_ARG_FLAT_NAMED)
-                cmp_write_str(ctx, "flat&named", 10);
+            if (entry & MVM_CALLSITE_ARG_FLAT) {
+                if (entry & MVM_CALLSITE_ARG_NAMED)
+                    cmp_write_str(ctx, "flat&named", 10);
+                else
+                    cmp_write_str(ctx, "flat", 4);
+            }
+            else if (entry & MVM_CALLSITE_ARG_NAMED)
+                    cmp_write_str(ctx, "named", 5);
             if (!entry_count)
                 cmp_write_str(ctx, "nothing", 7);
         }


### PR DESCRIPTION
The flag is superseeded by the combination of MVM_CALLSITE_ARG_FLAT and
MVM_CALLSITE_ARG_NAMED. Freeing it up, so we have a flag available for
unsigned integers.