### PR TITLE
Ignore untracked changes in the ryu submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,4 @@
 [submodule "3rdparty/ryu"]
 	path = 3rdparty/ryu
 	url = https://github.com/MoarVM/ryu
+	ignore = untracked


### PR DESCRIPTION
This stops the `modified:   3rdparty/ryu (untracked content)` message
from showing up in a `git status` in the MoarVM repo after it's built.
An alternative would be to add `ryu/ds2.o` to 3rdparty/ryu/.gitignore,
but that would require adding a commit to the submodule instead.