### PR TITLE
Correctly free memory allocated by libuv

### DIFF
--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -423,7 +423,7 @@ MVMString * MVM_file_readlink(MVMThreadContext *tc, MVMString *path) {
 
     MVM_free(path_s);
     result = MVM_string_utf8_c8_decode(tc, tc->instance->VMString, req.ptr, strlen(req.ptr));
-    MVM_free(req.ptr);
+    uv_fs_req_cleanup(&req);
 
     return result;
 }


### PR DESCRIPTION
Use the correct libuv function to do it. According to
http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_req_cleanup "Cleanup request.
Must be called after a request is finished to deallocate any memory libuv
might have allocated."