### PR TITLE
Add mimalloc submodule, and default to mimalloc where possible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,7 @@
 	path = 3rdparty/ryu
 	url = https://github.com/MoarVM/ryu
 	ignore = untracked
+[submodule "3rdparty/mimalloc"]
+	path = 3rdparty/mimalloc
+	url = https://github.com/microsoft/mimalloc.git
+	ignore = untracked

--- a/Configure.pl
+++ b/Configure.pl
@@ -548,6 +548,7 @@ build::probe::substandard_trig(\%config, \%defaults);
 build::probe::has_isinf_and_isnan(\%config, \%defaults);
 build::probe::unaligned_access(\%config, \%defaults);
 build::probe::ptr_size(\%config, \%defaults);
+build::probe::stdatomic(\%config, \%defaults);
 
 my $archname = $Config{archname};
 if ($args{'jit'}) {

--- a/Configure.pl
+++ b/Configure.pl
@@ -556,6 +556,10 @@ if (!defined $config{use_mimalloc}) {
         print "Defaulting to mimalloc because you have <stdatomic.h>\n";
         $config{use_mimalloc} = 1;
     }
+    elsif ($config{cc} eq 'cl') {
+        print "Defaulting to mimalloc because you are using MSVC\n";
+        $config{use_mimalloc} = 1;
+    }
     else {
         print "Defaulting to libc malloc because <stdatomic.h> was not found.\n";
         $config{use_mimalloc} = 0;
@@ -1116,11 +1120,11 @@ is specified the default is to optimize.
 
 Control whether we build with mimalloc or use the C library's malloc.
 
-mimalloc requires working C11 C<< <stdatomic> >>. We probe for this, and
-if found we default is to use mimalloc. If not found we default to the
-C library's malloc. Specify C<--no-mimalloc> to force use of the C library's
-malloc always. Specify C<--no-mimalloc> to force use of mimalloc, even if
-the probing thinks that it won't build.
+mimalloc requires either MSVC or working C11 C<< <stdatomic> >>. We probe for
+this, and if found or using MSVC we default to use mimalloc. Otherwise we
+default to the C library's malloc. Specify C<--no-mimalloc> to force use of the
+C library's malloc always. Specify C<--mimalloc> to force use of mimalloc, even
+if the probing thinks that it won't build.
 
 =item --os <os>
 

--- a/Configure.pl
+++ b/Configure.pl
@@ -48,12 +48,11 @@ GetOptions(\%args, qw(
     build=s host=s big-endian jit! enable-jit
     prefix=s bindir=s libdir=s mastdir=s
     relocatable make-install asan ubsan tsan
-    valgrind telemeh dtrace show-autovect git-cache-dir=s
+    valgrind telemeh! dtrace show-autovect git-cache-dir=s
     show-autovect-failed:s),
 
     'no-optimize|nooptimize' => sub { $args{optimize} = 0 },
     'no-debug|nodebug' => sub { $args{debug} = 0 },
-    'no-telemeh|notelemeh' => sub { $args{telemeh} = 0 }
 ) or die "See --help for further information\n";
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -30,3 +30,4 @@ Unofficial summary of the intended application of the Artistic License 2.0:
 - sha1       Public Domain
 - tinymt     MIT
 - freebsd    MIT
+- mimalloc   MIT

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,6 +135,18 @@ stages:
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=moar'
            MOAR_OPTIONS: '--cc=clang --debug=3'
+         MVM_gcc_malloc:
+           IMAGE_NAME: 'ubuntu-20.04'
+           RAKUDO_OPTIONS: ''
+           NQP_OPTIONS: '--backends=moar'
+           MOAR_OPTIONS: '--cc=gcc --debug=3 --no-mimalloc'
+           CHECK_LEAKS: 'yes'
+         MVM_clang_malloc:
+           IMAGE_NAME: 'ubuntu-20.04'
+           RAKUDO_OPTIONS: ''
+           NQP_OPTIONS: '--backends=moar'
+           MOAR_OPTIONS: '--cc=clang --debug=3 --no-mimalloc'
+           CHECK_LEAKS: 'yes'
 
       pool:
         vmImage: $(IMAGE_NAME)

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -40,6 +40,7 @@ PKGCONFIGDIR = @prefix@/share/pkgconfig
 CFLAGS    = @cflags@ @ccdef@MVM_TRACING=$(TRACING) @ccdef@MVM_CGOTO=$(CGOTO)
 CINCLUDES = @moar_cincludes@ \
             @ccinc@@shaincludedir@ \
+            @mimalloc_include@ \
             @ccincsystem@3rdparty/tinymt \
             @ccincsystem@3rdparty/ryu \
             @ccincsystem@3rdparty/dynasm \
@@ -253,6 +254,7 @@ OBJECTS2 = src/6model/reprs/MVMDLLSym@obj@ \
           src/platform/memmem32@obj@ \
           3rdparty/freebsd/memmem@obj@ \
           3rdparty/ryu/ryu/d2s@obj@ \
+          @mimalloc_object@ \
           src/platform/malloc_trim@obj@ \
           src/moar@obj@ \
           @platform@ \

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -105,6 +105,10 @@
 #define MVM_HAS_SIGNBIT
 #endif
 
+#if @use_mimalloc@
+#define MVM_USE_MIMALLOC
+#endif
+
 /* Should we translate \n to \r\n on output? */
 #define MVM_TRANSLATE_NEWLINE_OUTPUT @translate_newline_output@
 

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -293,7 +293,7 @@ my %TC_MINGW32 = (
 
     libdir                   => '@bindir@',
     ccshared                 => '',
-    ldshared                 => '-shared -Wl,--out-implib,lib$(notdir $@).a',
+    ldshared                 => '-shared -Wl,--out-implib,lib$(notdir $@).a -lbcrypt',
     moarshared_norelocatable => '',
     moarshared_relocatable   => '',
     ldrpath                  => '',
@@ -479,7 +479,7 @@ our %COMPILERS = (
 my %OS_WIN32 = (
     exe      => '.exe',
     defs     => [ qw( WIN32 AO_ASSUME_WINDOWS98 ) ],
-    syslibs  => [ qw( shell32 ws2_32 mswsock rpcrt4 advapi32 psapi iphlpapi userenv user32 ) ],
+    syslibs  => [ qw( shell32 ws2_32 mswsock rpcrt4 advapi32 psapi iphlpapi userenv user32 bcrypt ) ],
     platform => '$(PLATFORM_WIN32)',
 
     translate_newline_output => 1,

--- a/src/6model/bootstrap.c
+++ b/src/6model/bootstrap.c
@@ -339,7 +339,7 @@ static void add_meta_object(MVMThreadContext *tc, MVMObject *type_obj, char *nam
         /* Set name. */
         name_str = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, name);
         MVM_ASSIGN_REF(tc, &(meta_obj->header), ((MVMKnowHOWREPR *)meta_obj)->body.name, name_str);
-        type_obj->st->debug_name = strdup(name);
+        type_obj->st->debug_name = MVM_strdup(name);
     });
 }
 

--- a/src/core/alloc.h
+++ b/src/core/alloc.h
@@ -1,5 +1,9 @@
 MVM_STATIC_INLINE void * MVM_malloc(size_t size) {
+#ifdef MVM_USE_MIMALLOC
+    void *ptr = mi_malloc(size);
+#else
     void *ptr = malloc(size);
+#endif
 
     if (!ptr)
         MVM_panic_allocation_failed(size);
@@ -8,7 +12,11 @@ MVM_STATIC_INLINE void * MVM_malloc(size_t size) {
 }
 
 MVM_STATIC_INLINE void * MVM_calloc(size_t num, size_t size) {
+#ifdef MVM_USE_MIMALLOC
+    void *ptr = mi_calloc(num, size);
+#else
     void *ptr = calloc(num, size);
+#endif
 
     if (!ptr)
         MVM_panic_allocation_failed(num * size);
@@ -17,7 +25,11 @@ MVM_STATIC_INLINE void * MVM_calloc(size_t num, size_t size) {
 }
 
 MVM_STATIC_INLINE void * MVM_realloc(void *p, size_t size) {
+#ifdef MVM_USE_MIMALLOC
+    void *ptr = mi_realloc(p, size);
+#else
     void *ptr = realloc(p, size);
+#endif
 
     if (!ptr && size > 0)
         MVM_panic_allocation_failed(size);
@@ -26,7 +38,11 @@ MVM_STATIC_INLINE void * MVM_realloc(void *p, size_t size) {
 }
 
 MVM_STATIC_INLINE void * MVM_recalloc(void *p, size_t old_size, size_t size) {
+#ifdef MVM_USE_MIMALLOC
+    void *ptr = mi_realloc(p, size);
+#else
     void *ptr = realloc(p, size);
+#endif
 
     if (size > 0) {
         if (!ptr)
@@ -40,7 +56,11 @@ MVM_STATIC_INLINE void * MVM_recalloc(void *p, size_t old_size, size_t size) {
 }
 
 MVM_STATIC_INLINE void MVM_free(void *p) {
+#ifdef MVM_USE_MIMALLOC
+    mi_free(p);
+#else
     free(p);
+#endif
 }
 
 #define MVM_free_null(addr) do { \

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -197,14 +197,14 @@ static void dump_program(MVMThreadContext *tc, MVMDispProgram *dp) {
                 char *c_str = MVM_string_utf8_encode_C_string(tc,
                        op->resume.disp->id);
                 fprintf(stderr, "    Resume topmost dispatch if it is %s\n", c_str);
-                free(c_str);
+                MVM_free(c_str);
                 break;
             }
             case MVMDispOpcodeResumeCaller: {
                 char *c_str = MVM_string_utf8_encode_C_string(tc,
                        op->resume.disp->id);
                 fprintf(stderr, "    Resume caller dispatch if it is %s\n", c_str);
-                free(c_str);
+                MVM_free(c_str);
                 break;
             }
             case MVMDispOpcodeGuardResumeInitCallsite:

--- a/src/moar.c
+++ b/src/moar.c
@@ -54,13 +54,13 @@ static FILE *fopen_perhaps_with_pid(char *env_var, char *path, const char *mode)
         if (found_percents > 1) {
             result = MVM_platform_fopen(path, mode);
         } else {
-            char *fixed_path = malloc(path_length + 16);
+            char *fixed_path = MVM_malloc(path_length + 16);
             MVMint64 pid = MVM_proc_getpid(NULL);
             /* We make the brave assumption that
              * pids only go up to 16 characters. */
             snprintf(fixed_path, path_length + 16, path, pid);
             result = MVM_platform_fopen(fixed_path, mode);
-            free(fixed_path);
+            MVM_free(fixed_path);
         }
     } else {
         result = MVM_platform_fopen(path, mode);

--- a/src/moar.h
+++ b/src/moar.h
@@ -24,8 +24,16 @@
 /* platform-specific setjmp override */
 #include <platform/setjmp.h>
 
+#ifdef MVM_USE_MIMALLOC
+/* mimalloc needs to come early so other libs use it */
+#include <mimalloc.h>
+
+#define MVM_strdup mi_strdup
+#define MVM_strndup mi_strndup
+#else
 #define MVM_strdup strdup
 #define MVM_strndup strndup
+#endif
 
 /* libuv
  * must precede atomic_ops.h so we get the ordering of Winapi headers right

--- a/src/moar.h
+++ b/src/moar.h
@@ -24,6 +24,9 @@
 /* platform-specific setjmp override */
 #include <platform/setjmp.h>
 
+#define MVM_strdup strdup
+#define MVM_strndup strndup
+
 /* libuv
  * must precede atomic_ops.h so we get the ordering of Winapi headers right
  */

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -121,7 +121,7 @@ static MVMuint64 get_string_index(MVMThreadContext *tc, MVMHeapSnapshotState *ss
         &(col->alloc_strings_free), sizeof(char));
     col->strings_free[col->num_strings_free] = str_mode != STR_MODE_CONST;
     col->num_strings_free++;
-    col->strings[col->num_strings] = str_mode == STR_MODE_DUP ? strdup(str) : str;
+    col->strings[col->num_strings] = str_mode == STR_MODE_DUP ? MVM_strdup(str) : str;
     return col->num_strings++;
 }
 

--- a/src/profiler/telemeh.c
+++ b/src/profiler/telemeh.c
@@ -203,7 +203,7 @@ MVM_PUBLIC void MVM_telemetry_interval_annotate_dynamic(uintptr_t subject, int i
     record->u.annotation_dynamic.intervalID = intervalID;
 
     /* Dynamic description arbitrarily limited for performance reasons. */
-    record->u.annotation_dynamic.description = strndup(description, 1024);
+    record->u.annotation_dynamic.description = MVM_strndup(description, 1024);
 }
 
 void calibrateTSC(FILE *outfile)

--- a/src/profiler/telemeh.c
+++ b/src/profiler/telemeh.c
@@ -261,7 +261,7 @@ void serializeTelemetryBufferRange(FILE *outfile, unsigned int serializationStar
                 break;
             case DynamicString:
                 fprintf(outfile,  "%15s ???  \"%s\" (%d)\n", " ", record->u.annotation_dynamic.description, record->u.annotation_dynamic.intervalID);
-                free(record->u.annotation_dynamic.description);
+                MVM_free(record->u.annotation_dynamic.description);
                 break;
         }
     }

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -5,7 +5,7 @@ VERSION=$1
 {
     echo MANIFEST
     git ls-files | perl -ne "print unless /^3rdparty\/\w+$/"
-    for submod in 3rdparty/libatomicops/ 3rdparty/dyncall/ 3rdparty/libuv/ 3rdparty/dynasm/ 3rdparty/libtommath/ 3rdparty/cmp/ 3rdparty/ryu/; do
+    for submod in 3rdparty/libatomicops/ 3rdparty/dyncall/ 3rdparty/libuv/ 3rdparty/dynasm/ 3rdparty/libtommath/ 3rdparty/cmp/ 3rdparty/ryu/ 3rdparty/mimalloc; do
         cd $submod
         git ls-files | perl -pe "s{^}{$submod}"
         cd ../..;


### PR DESCRIPTION
Permit building with mimalloc instead of libc malloc

Implement this by statically include mimalloc as a single source. Default to using mimalloc if `Configure.pl's` probe detects that the compiler provides C11 atomics, otherwise continue to use the C library's malloc as before. Add `--no-mimalloc` and `--mimalloc` options to override the automatic behaviour.

Add CI tests for `--no-mimalloc`. The CI systems have compilers that support atomics, so they now default to mimalloc.

See #1623 for motivation and #1634 for the previous iteration