### PR TITLE
Support using C11 atomics as an alternative libatomic_ops

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,11 @@ stages:
            RAKUDO_OPTIONS: '--relocatable'
            NQP_OPTIONS: '--backends=moar --relocatable'
            MOAR_OPTIONS: '--relocatable'
+         Mac_MVM_C11_atomics:
+           IMAGE_NAME: 'macOS-10.15'
+           RAKUDO_OPTIONS: ''
+           NQP_OPTIONS: '--backends=moar'
+           MOAR_OPTIONS: '--c11-atomics'
 
          Lin_MVM:
            IMAGE_NAME: 'ubuntu-20.04'
@@ -146,6 +151,18 @@ stages:
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=moar'
            MOAR_OPTIONS: '--cc=clang --debug=3 --no-mimalloc'
+           CHECK_LEAKS: 'yes'
+         MVM_gcc_c11_atomics:
+           IMAGE_NAME: 'ubuntu-20.04'
+           RAKUDO_OPTIONS: ''
+           NQP_OPTIONS: '--backends=moar'
+           MOAR_OPTIONS: '--cc=gcc --debug=3 --c11-atomics'
+           CHECK_LEAKS: 'yes'
+         MVM_clang_c11_atomics:
+           IMAGE_NAME: 'ubuntu-20.04'
+           RAKUDO_OPTIONS: ''
+           NQP_OPTIONS: '--backends=moar'
+           MOAR_OPTIONS: '--cc=clang --debug=3 --c11-atomics'
            CHECK_LEAKS: 'yes'
 
       pool:

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -109,6 +109,10 @@
 #define MVM_USE_MIMALLOC
 #endif
 
+#if @use_c11_atomics@
+#define MVM_USE_C11_ATOMICS
+#endif
+
 /* Should we translate \n to \r\n on output? */
 #define MVM_TRANSLATE_NEWLINE_OUTPUT @translate_newline_output@
 

--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -1057,7 +1057,7 @@ static AO_t * native_ref_as_atomic_i(MVMThreadContext *tc, MVMObject *cont) {
 
 MVMint64 MVM_6model_container_cas_i(MVMThreadContext *tc, MVMObject *cont,
                                     MVMint64 expected, MVMint64 value) {
-    return (MVMint64)MVM_cas(native_ref_as_atomic_i(tc, cont), (AO_t)expected, (AO_t)value);
+    return (MVMint64)MVM_cas(native_ref_as_atomic_i(tc, cont), AO_CAST(expected), AO_CAST(value));
 }
 
 MVMint64 MVM_6model_container_atomic_load_i(MVMThreadContext *tc, MVMObject *cont) {
@@ -1077,5 +1077,5 @@ MVMint64 MVM_6model_container_atomic_dec(MVMThreadContext *tc, MVMObject *cont) 
 }
 
 MVMint64 MVM_6model_container_atomic_add(MVMThreadContext *tc, MVMObject *cont, MVMint64 value) {
-    return (MVMint64)MVM_add(native_ref_as_atomic_i(tc, cont), (AO_t)value);
+    return (MVMint64)MVM_add(native_ref_as_atomic_i(tc, cont), AO_CAST(value));
 }

--- a/src/6model/containers.h
+++ b/src/6model/containers.h
@@ -57,8 +57,8 @@ struct MVMContainerSpec {
      * operation, and atomic store operation. */
     void (*cas) (MVMThreadContext *tc, MVMObject *cont, MVMObject *expected,
         MVMObject *value, MVMRegister *result);
-    MVMObject * (*atomic_load) (MVMThreadContext *tc, MVMObject *cont);
-    void (*atomic_store) (MVMThreadContext *tc, MVMObject *cont, MVMObject *value);
+    MVMObject * (*load_atomic) (MVMThreadContext *tc, MVMObject *cont);
+    void (*store_atomic) (MVMThreadContext *tc, MVMObject *cont, MVMObject *value);
 
     /* Set this to a non-zero value if a fetch promises to never invoke any
      * code. This means the VM knows it can safely decontainerize in places

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -6223,7 +6223,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             }
             OP(sp_atomicload_o): {
                 MVMObject *target = GET_REG(cur_op, 2).o;
-                GET_REG(cur_op, 0).o = target->st->container_spec->atomic_load(tc, target);
+                GET_REG(cur_op, 0).o = target->st->container_spec->load_atomic(tc, target);
                 cur_op += 4;
                 goto NEXT;
             }
@@ -6231,7 +6231,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMObject *target = GET_REG(cur_op, 0).o;
                 MVMObject *value = GET_REG(cur_op, 2).o;
                 cur_op += 4;
-                target->st->container_spec->atomic_store(tc, target, value);
+                target->st->container_spec->store_atomic(tc, target, value);
                 goto NEXT;
             }
             OP(sp_add_I): {

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -278,7 +278,7 @@ MVMint32 MVM_thread_cleanup_threads_list(MVMThreadContext *tc, MVMThread **head)
     *head = NULL;
     while (this) {
         next = this->body.next;
-        switch (this->body.stage) {
+        switch (AO_READ(this->body.stage)) {
             case MVM_thread_stage_starting:
             case MVM_thread_stage_waiting:
             case MVM_thread_stage_started:

--- a/src/gc/orchestrate.c
+++ b/src/gc/orchestrate.c
@@ -29,7 +29,7 @@ static MVMuint32 signal_one_thread(MVMThreadContext *tc, MVMThreadContext *to_si
     unsigned int had_suspend_request = 0;
     while (1) {
         AO_t current = MVM_load(&to_signal->gc_status);
-        switch (current) {
+        switch (AO_READ(current)) {
             case MVMGCStatus_NONE:
                 /* Try to set it from running to interrupted - the common case. */
                 if (MVM_cas(&to_signal->gc_status, MVMGCStatus_NONE,

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2214,7 +2214,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov ARG2, aword WORK[target];
         | mov FUNCTION, OBJECT:ARG2->st;
         | mov FUNCTION, STABLE:FUNCTION->container_spec;
-        | mov FUNCTION, CONTAINERSPEC:FUNCTION->atomic_load;
+        | mov FUNCTION, CONTAINERSPEC:FUNCTION->load_atomic;
         | call FUNCTION;
         | mov WORK[result], RV
         break;
@@ -2227,7 +2227,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov ARG3, aword WORK[value];
         | mov FUNCTION, OBJECT:ARG2->st;
         | mov FUNCTION, STABLE:FUNCTION->container_spec;
-        | mov FUNCTION, CONTAINERSPEC:FUNCTION->atomic_store;
+        | mov FUNCTION, CONTAINERSPEC:FUNCTION->store_atomic;
         | call FUNCTION;
         break;
     }

--- a/src/moar.h
+++ b/src/moar.h
@@ -40,11 +40,28 @@
  */
 #include <uv.h>
 
+#ifdef MVM_USE_C11_ATOMICS
+#include <stdatomic.h>
+typedef atomic_uintptr_t AO_t;
+#ifdef __clang__
+/* clang and gcc disagree on rvalue semantics of atomic types
+ * clang refuses to implicitly assign the value of an atomic variable to the
+ * regular non-atomic type. Hence we need this: */
+#define AO_READ(v) atomic_load_explicit(&(v), memory_order_relaxed)
+
+#else
+#define AO_READ(v) (v)
+#endif
+/* clang also refuses to cast as (AO_t)(v), but doing this works for gcc and
+ * clang (and hopefully other compilers, when we get there) */
+#define AO_CAST(v) (uintptr_t)(v)
+#else
 /* libatomic_ops */
 #define AO_REQUIRE_CAS
 #include <atomic_ops.h>
 #define AO_READ(v) (v)
 #define AO_CAST(v) (AO_t)(v)
+#endif
 
 /* libffi or dynload/dyncall/dyncallback */
 #ifdef HAVE_LIBFFI
@@ -289,6 +306,51 @@ MVM_PUBLIC int MVM_exepath(char* buffer, size_t* size);
 MVM_PUBLIC int MVM_set_std_handles_to_nul(void);
 #endif
 
+#ifdef MVM_USE_C11_ATOMICS
+
+#define MVM_incr(addr) atomic_fetch_add((volatile AO_t *)(addr), 1)
+#define MVM_decr(addr) atomic_fetch_sub((volatile AO_t *)(addr), 1)
+#define MVM_add(addr, add) atomic_fetch_add((volatile AO_t *)(addr), (add))
+
+/* Returns non-zero for success. Use for both AO_t numbers and pointers. */
+MVM_STATIC_INLINE int
+MVM_trycas_AO(volatile AO_t *addr, uintptr_t old, const uintptr_t new) {
+    return atomic_compare_exchange_strong(addr, &old, new);
+}
+#define MVM_trycas(addr, old, new) MVM_trycas_AO((volatile AO_t *)(addr), AO_CAST(old), AO_CAST(new))
+
+
+/* Returns the old value dereferenced at addr.
+ * Strictly, as libatomic_ops documents it:
+ *      Atomically compare *addr to old_val, and replace *addr by new_val
+ *      if the first comparison succeeds; returns the original value of *addr;
+ *       cannot fail spuriously.
+ */
+MVM_STATIC_INLINE uintptr_t
+MVM_cas(volatile AO_t *addr, uintptr_t old, const uintptr_t new) {
+    /* If *addr == old then { does exchange, returns true }
+     * else { writes old value to &old, returns false }
+     * Hence if exchange happens, we return the old value because C11 doesn't
+     * overwrite &old. If exchange doesn't happen, C11 does overwrite. */
+    atomic_compare_exchange_strong(addr, &old, new);
+    return old;
+}
+
+/* Returns the old pointer value dereferenced at addr. Provided for a tiny bit of type safety. */
+#define MVM_casptr(addr, old, new) ((void *)MVM_cas((AO_t *)(addr), (uintptr_t)(old), (uintptr_t)(new)))
+
+/* Full memory barrier. */
+#define MVM_barrier() atomic_thread_fence(memory_order_seq_cst)
+
+/* Need to use these to assign to or read from any memory locations on
+ * which the other atomic operation macros are used... */
+#define MVM_store(addr, new) atomic_store((volatile AO_t *)(addr), AO_CAST(new))
+#define MVM_load(addr) atomic_load((volatile AO_t *)(addr))
+
+#else
+
+/* libatomic_ops */
+
 /* Seems that both 32 and 64 bit sparc need this crutch */
 #if defined(__s390__) || defined(__sparc__)
 AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t new_val);
@@ -317,3 +379,5 @@ AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val, AO_t
  * which the other atomic operation macros are used... */
 #define MVM_store(addr, new) AO_store_full((volatile AO_t *)(addr), (AO_t)(new))
 #define MVM_load(addr) AO_load_full((volatile AO_t *)(addr))
+
+#endif

--- a/src/moar.h
+++ b/src/moar.h
@@ -43,6 +43,8 @@
 /* libatomic_ops */
 #define AO_REQUIRE_CAS
 #include <atomic_ops.h>
+#define AO_READ(v) (v)
+#define AO_CAST(v) (AO_t)(v)
 
 /* libffi or dynload/dyncall/dyncallback */
 #ifdef HAVE_LIBFFI

--- a/src/profiler/configuration.c
+++ b/src/profiler/configuration.c
@@ -988,7 +988,7 @@ finish_main_loop:
     stats_slot = stats_position_for_value(NULL, entrypoint, result);
 
     if (stats_slot != -1) {
-        MVM_store(&prog->last_return_time[stats_slot], (AO_t)MVM_proc_time(tc));
+        MVM_store(&prog->last_return_time[stats_slot], AO_CAST(MVM_proc_time(tc)));
         MVM_incr(&prog->return_counts[stats_slot]);
     }
 

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1825,7 +1825,7 @@ static void optimize_container_atomic(MVMThreadContext *tc, MVMSpeshGraph *g,
                 ins->info = MVM_op_get_op(MVM_OP_sp_cas_o);
                 break;
             case MVM_OP_atomicstore_o:
-                if (!cs->atomic_store)
+                if (!cs->store_atomic)
                     return;
                 ins->info = MVM_op_get_op(MVM_OP_sp_atomicstore_o);
                 break;


### PR DESCRIPTION
Add a new `Configure.pl` flag `--c11-atomics` that uses C11's `<stdatomic.h>` for MoarVM's atomic operations instead of the bundled library libatomic_ops.

If using C11 atomics then completely disable building libatomic_ops.

This permits MoarVM to build on architectures which libatomic_ops does not support, as long as they have a current C compiler which implements this optional C11 feature.

With this I can build MoarVM, NQP and Rakudo on the Loongson-3A5000 hardware on the [GCC compiler farm](https://cfarm.tetaneutral.net/machines/list/). This is a new architecture not supported by libatomic_ops, but with a C compiler supporting C11 atomics.

I *think* that I have this correct, but I'm "translating" from the libatomic_ops APIs and descriptions to what I think are the appropriate C11 APIs and options. I can also (still) build on x86_64, and aarch64. The former is extremely forgiving, but I believe the latter's memory model provides a bit sterner test of correctness. Sadly I don't have access to a DEC Alpha.

Specifically, please check that

1) My choice of `atomic_uintptr_t` is appropriate to replace `AO_t`
2) I have correctly translated the APIs, particularly `MVM_cas`
3) C11 `memory_order_seq_cst` (generally) and `memory_order_relaxed` (in `src/jit/compile.c`) are the correct "translations" of libatomic_ops `_full` and "nothing".


This branch is based on `mimalloc-optional`, not `master`