### PR TITLE
update-submodules.pl should handle linked worktrees created by git-worktree

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -77,7 +77,9 @@ for my $target (@target_dirs) {
 }
 
 # Download / Update submodules
-my $code = system($^X, 'tools/update-submodules.pl', Cwd::cwd(), @args);
+my @update_args = defined $args{'git-cache-dir'}
+    ? ('--git-cache-dir', $args{'git-cache-dir'}) : ();
+my $code = system($^X, 'tools/update-submodules.pl', @update_args);
 exit 1 if $code >> 8 != 0;
 
 # fiddle with flags

--- a/tools/update-submodules.pl
+++ b/tools/update-submodules.pl
@@ -11,7 +11,21 @@ use File::Spec;
 my $repo = shift @ARGV;
 chdir $repo;
 
-exit 0 if !-d '.git';
+if (-d ".git" || (exists $ENV{GIT_DIR} && -d $ENV{GIT_DIR})) {
+    # We assume a conventional git directory
+}
+elsif (-f '.git') {
+    # Also handle linked worktrees created by git-worktree:
+    # the hash of the initial commit in MoarVM
+    my $commit = '51481efadbf5bbebfc20767c07056bd2dfc2fabc';
+    my $out = exec_with_output(qw(git rev-parse --verify --quiet), "$commit^{commit}");
+    chomp $out;
+    exit 0
+        unless $out eq $commit;
+}
+else {
+    exit 0;
+}
 
 my $git_cache_dir;
 Getopt::Long::Configure("pass_through");

--- a/tools/update-submodules.pl
+++ b/tools/update-submodules.pl
@@ -5,11 +5,13 @@ use 5.8.4;
 use strict;
 use warnings;
 use Getopt::Long;
+use Pod::Usage;
 use Cwd;
 use File::Spec;
 
-my $repo = shift @ARGV;
-chdir $repo;
+my ($back, $git_cache_dir);
+GetOptions('git-cache-dir=s' => \$git_cache_dir)
+    or pod2usage(1);
 
 if (-d ".git" || (exists $ENV{GIT_DIR} && -d $ENV{GIT_DIR})) {
     # We assume a conventional git directory
@@ -26,10 +28,6 @@ elsif (-f '.git') {
 else {
     exit 0;
 }
-
-my $git_cache_dir;
-Getopt::Long::Configure("pass_through");
-Getopt::Long::GetOptions('git-cache-dir=s' => \$git_cache_dir);
 
 print 'Updating submodules .................................... ';
 
@@ -52,17 +50,17 @@ my $git_new_enough = eval "v$1 ge v2.32.0";
 exec_and_check('git', 'submodule', 'sync', '--quiet', 'Submodule sync failed for an unknown reason.');
 exec_and_check('git', 'submodule', '--quiet', 'init', 'Submodule init failed for an unknown reason.');
 
-if ($git_cache_dir) {
+if (defined $git_cache_dir) {
     my $out = exec_with_output('git', 'submodule', 'status');
     if ($? >> 8 != 0) {
-        print "\n===SORRY=== ERROR: Submodule status failed for an unknown reason.\n";
-        print "The error message was: $out\n";
+        print STDERR "\n===SORRY=== ERROR: Submodule status failed for an unknown reason.\n";
+        print STDERR "The output message was: $out\n";
         exit 1;
     }
     for my $smodline (split(/^/m, $out)) {
         chomp $smodline;
         if ($smodline !~ /^.[0-9a-f]+ ([^ ]+)(?:$| )/) {
-            print "\n===SORRY=== ERROR: "
+            print STDERR "\n===SORRY=== ERROR: "
               . "Submodule status output looks unexpected: '$smodline'";
             exit 1;
         }
@@ -72,17 +70,19 @@ if ($git_cache_dir) {
         my $url = exec_with_output('git', 'config', "submodule.$smodpath.url");
         chomp $url;
         if (!$url) {
-            print "Couldn't retrieve submodule URL for submodule $smodname\n";
-            exit 1;
+            die "Couldn't retrieve submodule URL for submodule $smodname";
         }
         if (!-e $modrefdir) {
             exec_and_check('git', 'clone', '--quiet', '--bare', $url, $modrefdir, "Git clone of $url failed.");
         }
         else {
-            my $back = Cwd::cwd();
-            chdir $modrefdir;
+            $back = Cwd::cwd()
+                unless defined $back;
+            chdir $modrefdir
+                or die "chdir $modrefdir failed: $!";
             exec_and_check('git', 'fetch', '--quiet', '--all', "Git fetch in $modrefdir failed.");
-            chdir $back;
+            chdir $back
+                or die "chdir $back failed: $!";
         }
         exec_and_check('git', 'submodule', '--quiet', 'update', '--reference', $modrefdir, $smodpath, 'Git submodule update failed.');
     }
@@ -118,8 +118,8 @@ sub exec_and_check {
     my @command = @_;
     my $out = exec_with_output(@command);
     if ($? >> 8 != 0) {
-        print "\n===SORRY=== ERROR: $msg\n";
-        print "The program's output was: $out\n";
+        print STDERR "\n===SORRY=== ERROR: $msg\n";
+        print STDERR "The program's output was: $out\n";
         exit 1;
     }
 }

--- a/tools/update-submodules.pl
+++ b/tools/update-submodules.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 # Copyright (C) 2009-2019 The Perl Foundation
 
-use 5.10.1;
+use 5.8.4;
 use strict;
 use warnings;
 use Getopt::Long;
@@ -104,12 +104,12 @@ print "OK\n";
 
 sub exec_with_output {
     my @command = @_;
-    open(my $handle, '-|', @command);
-    my $out;
-    while(<$handle>) {
-        $out .= $_;
-    }
-    close $handle;
+    open(my $handle, '-|', @command)
+        or die "piped open @command failed: $!";
+    local $/;
+    my $out = <$handle>;
+    close $handle
+        or die "piped close @command failed: $!";
     return $out;
 }
 


### PR DESCRIPTION
`git worktree` allows multiple working trees attached to the same repository, which is useful if one wants to have multiple development projects checked out in parallel on the same machine. A side effect of its implementation is that in a "linked working tree" `.git` is a *file*, not a directory. `git` commands handle this just fine, but tools that assume that they can test for a git checkout by simply looking for a directory `.git` will fail.

Teach `tools/update-submodules.pl` that `.git` can be a file too.
