### PR TITLE
Add missing `static` qualifiers to various private functions

### DIFF
--- a/src/6model/reprs/MVMSpeshCandidate.c
+++ b/src/6model/reprs/MVMSpeshCandidate.c
@@ -60,7 +60,7 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 }
 
 /* Called by the VM in order to free memory associated with this object. */
-void gc_free(MVMThreadContext *tc, MVMObject *obj) {
+static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMSpeshCandidate *candidate = (MVMSpeshCandidate *)obj;
     MVM_free(candidate->body.type_tuple);
     MVM_free(candidate->body.bytecode);

--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -756,9 +756,9 @@ static MVMStorageSpec get_elem_storage_spec(MVMThreadContext *tc, MVMSTable *st)
     return spec;
 }
 
-AO_t * pos_as_atomic_multidim(MVMThreadContext *tc, MVMSTable *st,
-                              MVMObject *root, void *data,
-                              MVMint64 num_indices, MVMint64 *indices) {
+static AO_t * pos_as_atomic_multidim(MVMThreadContext *tc, MVMSTable *st,
+                                     MVMObject *root, void *data,
+                                     MVMint64 num_indices, MVMint64 *indices) {
     MVMMultiDimArrayREPRData *repr_data = (MVMMultiDimArrayREPRData *)st->REPR_data;
     if (num_indices == repr_data->num_dimensions) {
         MVMMultiDimArrayBody *body = (MVMMultiDimArrayBody *)data;

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -915,7 +915,7 @@ static void write_buf(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void
     memcpy(body->slots.u8 + (start + offset) * repr_data->elem_size, from, count);
 }
 
-MVMint64 read_buf(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 offset, MVMuint64 count) {
+static MVMint64 read_buf(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 offset, MVMuint64 count) {
     MVMArrayREPRData *repr_data = (MVMArrayREPRData *)st->REPR_data;
     MVMArrayBody     *body      = (MVMArrayBody *)data;
     MVMint64 start = body->start;

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -553,8 +553,8 @@ static void write_code_ref(MVMThreadContext *tc, MVMSerializationWriter *writer,
     MVMint32  idx     = (MVMint32)MVM_sc_find_code_idx(tc, sc, code);
     write_locate_sc_and_index(tc, writer, sc_id, idx);
 }
-MVM_NO_RETURN void throw_closure_serialization_error(MVMThreadContext *tc, MVMCode *closure, const char *message) MVM_NO_RETURN_ATTRIBUTE;
-MVM_NO_RETURN void throw_closure_serialization_error(MVMThreadContext *tc, MVMCode *closure, const char *message) {
+static MVM_NO_RETURN void throw_closure_serialization_error(MVMThreadContext *tc, MVMCode *closure, const char *message) MVM_NO_RETURN_ATTRIBUTE;
+static MVM_NO_RETURN void throw_closure_serialization_error(MVMThreadContext *tc, MVMCode *closure, const char *message) {
     MVMString *file;
     MVMint32 line;
     MVMROOT(tc, closure, {

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -633,7 +633,7 @@ static MVMObject * decont_result(MVMThreadContext *tc, MVMObject *result) {
         return result;
     }
 }
-void save_for_exit_handler(MVMThreadContext *tc, MVMObject *result) {
+static void save_for_exit_handler(MVMThreadContext *tc, MVMObject *result) {
     MVMFrameExtra *e = MVM_frame_extra(tc, tc->cur_frame);
     e->exit_handler_result = result;
 }

--- a/src/core/callsite.c
+++ b/src/core/callsite.c
@@ -141,7 +141,7 @@ void MVM_callsite_destroy(MVMCallsite *cs) {
 }
 
 /* Copies the named args of one callsite into another. */
-void copy_nameds(MVMThreadContext *tc, MVMCallsite *to, const MVMCallsite *from) {
+static void copy_nameds(MVMThreadContext *tc, MVMCallsite *to, const MVMCallsite *from) {
     if (from->arg_names) {
         MVMuint32 num_names = MVM_callsite_num_nameds(tc, from);
         size_t memory_area = num_names * sizeof(MVMString *);

--- a/src/core/callstack.c
+++ b/src/core/callstack.c
@@ -53,7 +53,7 @@ static void next_oversize_region(MVMThreadContext *tc, size_t size) {
 }
 
 /* Gets the name of the callstack record type. */
-char * record_name(MVMuint8 kind) {
+static char * record_name(MVMuint8 kind) {
     switch (kind) {
         case MVM_CALLSTACK_RECORD_START: return "start";
         case MVM_CALLSTACK_RECORD_START_REGION: return "start region";
@@ -97,7 +97,7 @@ static MVMCallStackRecord * allocate_record(MVMThreadContext *tc, MVMuint8 kind,
 static MVMuint32 to_8_bytes(MVMuint32 num) {
     return (num + 8 - 1) & -8;
 }
-size_t record_size(MVMCallStackRecord *record) {
+static size_t record_size(MVMCallStackRecord *record) {
     switch (MVM_callstack_kind_ignoring_deopt(record)) {
         case MVM_CALLSTACK_RECORD_START:
             return sizeof(MVMCallStackStart);

--- a/src/core/fixkey_hash_table.c
+++ b/src/core/fixkey_hash_table.c
@@ -2,8 +2,8 @@
 
 #define FIXKEY_INITIAL_SIZE_LOG2 3
 
-void hash_demolish_internal(MVMThreadContext *tc,
-                            struct MVMFixKeyHashTableControl *control) {
+static void hash_demolish_internal(MVMThreadContext *tc,
+                                   struct MVMFixKeyHashTableControl *control) {
     size_t allocated_items = MVM_fixkey_hash_allocated_items(control);
     size_t entries_size = sizeof(MVMString ***) * allocated_items;
     size_t metadata_size = MVM_hash_round_size_up(allocated_items + 1);

--- a/src/core/hll.c
+++ b/src/core/hll.c
@@ -99,7 +99,7 @@ MVMHLLConfig *MVM_hll_get_config_for(MVMThreadContext *tc, MVMString *name) {
     MVMObject *val = MVM_repr_at_key_o((tc), (hash), key); \
     if (!MVM_is_null(tc, val)) (config)->member = MVM_repr_get_str(tc, val); \
 } while (0)
-void set_max_inline_size(MVMThreadContext *tc, MVMObject *config_hash, MVMHLLConfig *config) {
+static void set_max_inline_size(MVMThreadContext *tc, MVMObject *config_hash, MVMHLLConfig *config) {
     MVMROOT(tc, config_hash, {
         MVMString *key = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "max_inline_size");
         MVMObject *size = MVM_repr_at_key_o(tc, config_hash, key);

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -139,7 +139,7 @@ static void request_all_threads_suspend(MVMThreadContext *dtc, cmp_ctx_t *ctx, r
 static MVMuint64 allocate_handle(MVMThreadContext *dtc, MVMObject *target);
 
 /* Breakpoint stuff */
-void normalize_filename(char *name) {
+static void normalize_filename(char *name) {
     /* On Windows, we sometimes see forward slashes, sometimes backslashes.
      * Normalize them to forward slash so we can reliably hit breakpoints. */
     char *cur_bs = strchr(name, '\\');
@@ -369,7 +369,7 @@ MVM_PUBLIC MVMint32 MVM_debugserver_breakpoint_check(MVMThreadContext *tc, MVMui
 
 #define REQUIRE(field, message) do { if (!(data->fields_set & (field))) { data->parse_fail = 1; data->parse_fail_message = (message); return 0; }; accepted = accepted | (field); } while (0)
 
-MVMuint8 check_requirements(MVMThreadContext *tc, request_data *data) {
+static MVMuint8 check_requirements(MVMThreadContext *tc, request_data *data) {
     fields_set accepted = FS_id | FS_type;
 
     MVMuint8 allow_optional = 0;
@@ -1000,7 +1000,7 @@ static void send_is_execution_suspended_info(MVMThreadContext *dtc, cmp_ctx_t *c
     cmp_write_bool(ctx, result);
 }
 
-MVMuint8 setup_step(MVMThreadContext *dtc, cmp_ctx_t *ctx, request_data *argument, MVMDebugSteppingMode mode, MVMThread *thread) {
+static MVMuint8 setup_step(MVMThreadContext *dtc, cmp_ctx_t *ctx, request_data *argument, MVMDebugSteppingMode mode, MVMThread *thread) {
     MVMThread *to_do = thread ? thread : find_thread_by_id(dtc->instance, argument->thread_id);
     MVMThreadContext *tc;
 
@@ -2793,7 +2793,7 @@ static bool is_valid_num(cmp_object_t *obj, MVMnum64 *result) {
 #define CHECK(operation, message) do { if(!(operation)) { data->parse_fail = 1; data->parse_fail_message = (message); if (tc->instance->debugserver->debugspam_protocol) fprintf(stderr, "CMP error: %s; %s\n", cmp_strerror(ctx), message); return 0; } } while(0)
 #define FIELD_FOUND(field, duplicated_message) do { if(data->fields_set & (field)) { data->parse_fail = 1; data->parse_fail_message = duplicated_message;  return 0; }; field_to_set = (field); } while (0)
 
-MVMint8 skip_all_read_data(cmp_ctx_t *ctx, MVMuint32 size) {
+static MVMint8 skip_all_read_data(cmp_ctx_t *ctx, MVMuint32 size) {
     char dump[1024];
 
     while (size > 1024) {
@@ -2808,7 +2808,7 @@ MVMint8 skip_all_read_data(cmp_ctx_t *ctx, MVMuint32 size) {
     return 1;
 }
 
-MVMint8 skip_whole_object(MVMThreadContext *tc, cmp_ctx_t *ctx, request_data *data) {
+static MVMint8 skip_whole_object(MVMThreadContext *tc, cmp_ctx_t *ctx, request_data *data) {
     cmp_object_t obj;
     MVMuint32 obj_size = 0;
     MVMuint32 index;
@@ -2883,7 +2883,7 @@ MVMint8 skip_whole_object(MVMThreadContext *tc, cmp_ctx_t *ctx, request_data *da
     return 1;
 }
 
-MVMint32 parse_message_map(MVMThreadContext *tc, cmp_ctx_t *ctx, request_data *data) {
+static MVMint32 parse_message_map(MVMThreadContext *tc, cmp_ctx_t *ctx, request_data *data) {
     MVMuint32 map_size = 0;
     MVMuint32 i;
     cmp_object_t obj;

--- a/src/disp/inline_cache.c
+++ b/src/disp/inline_cache.c
@@ -2,7 +2,7 @@
 
 #define DUMP_FULL_CACHES 0
 
-MVMuint32 try_update_cache_entry(MVMThreadContext *tc, MVMDispInlineCacheEntry **target,
+static MVMuint32 try_update_cache_entry(MVMThreadContext *tc, MVMDispInlineCacheEntry **target,
         MVMDispInlineCacheEntry *from, MVMDispInlineCacheEntry *to);
 
 /**
@@ -603,7 +603,7 @@ void MVM_disp_inline_cache_setup(MVMThreadContext *tc, MVMStaticFrame *sf) {
 }
 
 /* Cleans up a cache entry. */
-void cleanup_entry(MVMThreadContext *tc, MVMDispInlineCacheEntry *entry, MVMuint8 destroy_dps) {
+static void cleanup_entry(MVMThreadContext *tc, MVMDispInlineCacheEntry *entry, MVMuint8 destroy_dps) {
     if (!entry)
         return;
     else if (entry->run_getlexstatic == getlexstatic_initial) {

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -1697,7 +1697,7 @@ static void ensure_resume_ok(MVMThreadContext *tc, MVMCallStackDispatchRecord *r
 }
 
 /* Form a capture from the resume initialization arguments. */
-MVMObject * resume_init_capture(MVMThreadContext *tc, MVMDispResumptionData *resume_data,
+static MVMObject * resume_init_capture(MVMThreadContext *tc, MVMDispResumptionData *resume_data,
         MVMDispProgramRecordingResumption *rec_resumption) {
     MVMDispProgramResumption *resumption = resume_data->resumption;
     MVMCallsite *callsite = resumption->init_callsite;
@@ -1721,7 +1721,7 @@ MVMObject * resume_init_capture(MVMThreadContext *tc, MVMDispResumptionData *res
 
 /* Set up another level of dispatch resumption in the resumptions list. Used
  * for both the initial resume and falling back on the next resumption. */
-void push_resumption(MVMThreadContext *tc, MVMCallStackDispatchRecord *record,
+static void push_resumption(MVMThreadContext *tc, MVMCallStackDispatchRecord *record,
         MVMDispResumptionData *resume_data) {
     MVMDispProgramRecordingResumption rec_resumption;
     rec_resumption.initial_resume_capture.transformation = MVMDispProgramRecordingResumeInitial;
@@ -1739,7 +1739,7 @@ void push_resumption(MVMThreadContext *tc, MVMCallStackDispatchRecord *record,
 }
 
 /* Record the initial resumption of a dispatch. */
-void record_resume(MVMThreadContext *tc, MVMObject *capture, MVMDispResumptionData *resume_data,
+static void record_resume(MVMThreadContext *tc, MVMObject *capture, MVMDispResumptionData *resume_data,
         MVMDispProgramRecordingResumeKind resume_kind) {
     /* Make sure we're in a dispatcher and that we didn't already call resume. */
     MVMCallStackDispatchRecord *record = MVM_callstack_find_topmost_dispatch_recording(tc);
@@ -3796,7 +3796,7 @@ void MVM_disp_program_destroy(MVMThreadContext *tc, MVMDispProgram *dp) {
 }
 
 /* Free the memory associated with a dispatch program recording. */
-void destroy_recording_capture(MVMThreadContext *tc, MVMDispProgramRecordingCapture *cap) {
+static void destroy_recording_capture(MVMThreadContext *tc, MVMDispProgramRecordingCapture *cap) {
     MVMuint32 i;
     for (i = 0; i < MVM_VECTOR_ELEMS(cap->captures); i++)
         destroy_recording_capture(tc, &(cap->captures[i]));

--- a/src/disp/registry.c
+++ b/src/disp/registry.c
@@ -1,7 +1,7 @@
 #include "moar.h"
 
 /* Allocates a dispatcher table. */
-MVMDispRegistryTable * allocate_table(MVMThreadContext *tc, MVMuint32 num_entries) {
+static MVMDispRegistryTable * allocate_table(MVMThreadContext *tc, MVMuint32 num_entries) {
     MVMDispRegistryTable *table = MVM_fixed_size_alloc_zeroed(tc, tc->instance->fsa,
             sizeof(MVMDispRegistryTable));
     table->num_dispatchers = 0;

--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -440,7 +440,7 @@ static void deferred_close_perform(MVMThreadContext *tc, uv_loop_t *loop, MVMObj
     }
 }
 
-MVMObject * get_async_task_handle(MVMThreadContext *tc, MVMOSHandle *h) {
+static MVMObject * get_async_task_handle(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOAsyncProcessData *handle_data = (MVMIOAsyncProcessData *)h->body.data;
     return handle_data->async_task;
 }

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -74,7 +74,7 @@ static void read_one_packet(MVMThreadContext *tc, MVMIOSyncSocketData *data) {
     }
 }
 
-MVMint64 socket_read_bytes(MVMThreadContext *tc, MVMOSHandle *h, char **buf, MVMuint64 bytes) {
+static MVMint64 socket_read_bytes(MVMThreadContext *tc, MVMOSHandle *h, char **buf, MVMuint64 bytes) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
     char *use_last_packet = NULL;
     MVMuint16 use_last_packet_start = 0, use_last_packet_end = 0;
@@ -169,21 +169,21 @@ MVMint64 socket_read_bytes(MVMThreadContext *tc, MVMOSHandle *h, char **buf, MVM
 }
 
 /* Checks if EOF has been reached on the incoming data. */
-MVMint64 socket_eof(MVMThreadContext *tc, MVMOSHandle *h) {
+static MVMint64 socket_eof(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
     return data->eof;
 }
 
-void socket_flush(MVMThreadContext *tc, MVMOSHandle *h, MVMint32 sync) {
+static void socket_flush(MVMThreadContext *tc, MVMOSHandle *h, MVMint32 sync) {
     /* A no-op for sockets; we don't buffer. */
 }
 
-void socket_truncate(MVMThreadContext *tc, MVMOSHandle *h, MVMint64 bytes) {
+static void socket_truncate(MVMThreadContext *tc, MVMOSHandle *h, MVMint64 bytes) {
     MVM_exception_throw_adhoc(tc, "Cannot truncate a socket");
 }
 
 /* Writes the specified bytes to the stream. */
-MVMint64 socket_write_bytes(MVMThreadContext *tc, MVMOSHandle *h, char *buf, MVMuint64 bytes) {
+static MVMint64 socket_write_bytes(MVMThreadContext *tc, MVMOSHandle *h, char *buf, MVMuint64 bytes) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
     MVMint64 sent = 0;
     unsigned int interval_id;
@@ -460,7 +460,7 @@ static void socket_bind(MVMThreadContext *tc, MVMOSHandle *h, MVMString *host, M
     }
 }
 
-MVMint64 socket_getport(MVMThreadContext *tc, MVMOSHandle *h) {
+static MVMint64 socket_getport(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOSyncSocketData *data = (MVMIOSyncSocketData *)h->body.data;
 
     struct sockaddr_storage name;

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -708,7 +708,7 @@ MVMObject *MVM_bigint_shl(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
 }
 /* Checks if a MVMP6bigintBody is negative. Handles cases where it is stored as
  * a small int as well as cases when it is stored as a bigint */
-int BIGINT_IS_NEGATIVE (MVMP6bigintBody *ba) {
+static int BIGINT_IS_NEGATIVE (MVMP6bigintBody *ba) {
     mp_int *mp_a = ba->u.bigint;
     if (MVM_BIGINT_IS_BIG(ba)) {
         return mp_a->sign == MP_NEG;

--- a/src/profiler/configuration.c
+++ b/src/profiler/configuration.c
@@ -476,7 +476,7 @@ static void error_concreteness(MVMThreadContext *tc, MVMObject *object, MVMuint1
             MVM_repr_get_by_id(tc, reprid)->name, purpose, MVM_6model_get_debug_name(tc, object), REPR(object)->name);
 }
 
-MVMint16 stats_position_for_value(MVMThreadContext *tc, MVMuint8 entrypoint, MVMuint64 return_value) {
+static MVMint16 stats_position_for_value(MVMThreadContext *tc, MVMuint8 entrypoint, MVMuint64 return_value) {
     switch (entrypoint) {
         case MVM_PROGRAM_ENTRYPOINT_PROFILER_STATIC:
             if (return_value == MVM_CONFPROG_SF_RESULT_TO_BE_DETERMINED

--- a/src/profiler/heapsnapshot.c
+++ b/src/profiler/heapsnapshot.c
@@ -835,7 +835,7 @@ MVMuint32 get_new_toc_entry(MVMThreadContext *tc, MVMHeapDumpTableOfContents *to
     return i;
 }
 
-void serialize_attribute_stream(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, char *name, char *start, size_t offset, size_t elem_size, size_t count, FILE* fh) {
+static void serialize_attribute_stream(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, char *name, char *start, size_t offset, size_t elem_size, size_t count, FILE* fh) {
     char *pointer = (char *)start;
 
     ZSTD_CStream *cstream;
@@ -1371,7 +1371,7 @@ void snapshot_to_filehandle_ver3(MVMThreadContext *tc, MVMHeapSnapshotCollection
 }
 #endif /* heapsnapshot version 3 */
 
-void static_frames_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
+static void static_frames_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
     MVMuint64 i;
     MVMHeapDumpIndex *index = col->index;
     FILE *fh = col->fh;
@@ -1420,7 +1420,7 @@ void static_frames_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotColle
 }
 
 
-void string_heap_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
+static void string_heap_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
     MVMuint64 i;
     MVMHeapDumpIndex *index = col->index;
     FILE *fh = col->fh;
@@ -1479,7 +1479,7 @@ void string_heap_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollect
  * so that the parser can confidently skip to the exact middle of
  * the references table and parse it with two threads in parallel.
  */
-void references_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, MVMHeapDumpIndexSnapshotEntry *entry) {
+static void references_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, MVMHeapDumpIndexSnapshotEntry *entry) {
     MVMuint64 i;
     MVMuint64 halfway;
     FILE *fh = col->fh;
@@ -1574,7 +1574,7 @@ void references_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollecti
  * We also write a partial table after every snapshot so that if the process
  * crashes we still have a usable file.
  */
-void types_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
+static void types_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
     MVMuint64 i;
     MVMHeapDumpIndex *index = col->index;
     FILE *fh = col->fh;
@@ -1620,7 +1620,7 @@ void types_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *c
  * This sizes table has three entries for each entry. The first one is the
  * size of the collectables table.
  */
-void collectables_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, MVMHeapDumpIndexSnapshotEntry *entry) {
+static void collectables_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col, MVMHeapDumpIndexSnapshotEntry *entry) {
     MVMuint64 i;
     FILE *fh = col->fh;
     MVMHeapSnapshot *s = col->snapshot;
@@ -1679,7 +1679,7 @@ void collectables_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollec
 }
 
 
-void snapshot_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
+static void snapshot_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
     MVMHeapDumpIndex *index = col->index;
     MVMuint64 i = col->snapshot_idx;
     MVMHeapDumpIndexSnapshotEntry *entry;
@@ -1705,7 +1705,7 @@ void snapshot_to_filehandle_ver2(MVMThreadContext *tc, MVMHeapSnapshotCollection
 
     /*entry->incremental_data = index->stringheap_size + index->types_size + index->staticframes_size;*/
 }
-void index_to_filehandle(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
+static void index_to_filehandle(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
     MVMHeapDumpIndex *index = col->index;
     FILE *fh = col->fh;
 
@@ -1818,7 +1818,7 @@ static void snapmeta_to_filehandle_ver3(MVMThreadContext *tc, MVMHeapSnapshotCol
 }
 #endif
 
-void finish_collection_to_filehandle(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
+static void finish_collection_to_filehandle(MVMThreadContext *tc, MVMHeapSnapshotCollection *col) {
     /*col->strings_written = 0;*/
     /*col->types_written = 0;*/
     /*col->static_frames_written = 0;*/

--- a/src/profiler/log.c
+++ b/src/profiler/log.c
@@ -336,7 +336,7 @@ void MVM_profile_log_thread_created(MVMThreadContext *tc, MVMThreadContext *chil
 }
 
 /* Logs one allocation, potentially scalar replaced. */
-void log_one_allocation(MVMThreadContext *tc, MVMObject *obj, MVMProfileCallNode *pcn, MVMuint8 replaced) {
+static void log_one_allocation(MVMThreadContext *tc, MVMObject *obj, MVMProfileCallNode *pcn, MVMuint8 replaced) {
     MVMObject *what = STABLE(obj)->WHAT;
     MVMuint32 i;
     MVMuint8 allocation_target;

--- a/src/profiler/telemeh.c
+++ b/src/profiler/telemeh.c
@@ -114,7 +114,7 @@ static unsigned int lastSerializedIndex = 0;
 static unsigned long long beginningEpoch = 0;
 static unsigned int telemetry_active = 0;
 
-struct TelemetryRecord *newRecord()
+static struct TelemetryRecord *newRecord()
 {
     AO_t newBufferIndex, recordIndex;
     struct TelemetryRecord *record;
@@ -206,7 +206,7 @@ MVM_PUBLIC void MVM_telemetry_interval_annotate_dynamic(uintptr_t subject, int i
     record->u.annotation_dynamic.description = MVM_strndup(description, 1024);
 }
 
-void calibrateTSC(FILE *outfile)
+static void calibrateTSC(FILE *outfile)
 {
     unsigned long long startTsc, endTsc;
     uint64_t startTime, endTime;
@@ -232,7 +232,7 @@ void calibrateTSC(FILE *outfile)
 static uv_thread_t backgroundSerializationThread;
 static volatile int continueBackgroundSerialization = 1;
 
-void serializeTelemetryBufferRange(FILE *outfile, unsigned int serializationStart, unsigned int serializationEnd)
+static void serializeTelemetryBufferRange(FILE *outfile, unsigned int serializationStart, unsigned int serializationEnd)
 {
     unsigned int i;
     for(i = serializationStart; i < serializationEnd; i++) {
@@ -267,7 +267,7 @@ void serializeTelemetryBufferRange(FILE *outfile, unsigned int serializationStar
     }
 }
 
-void serializeTelemetryBuffer(FILE *outfile)
+static void serializeTelemetryBuffer(FILE *outfile)
 {
     unsigned int serializationEnd = recordBufferIndex;
     unsigned int serializationStart = lastSerializedIndex;
@@ -282,7 +282,7 @@ void serializeTelemetryBuffer(FILE *outfile)
     lastSerializedIndex = serializationEnd;
 }
 
-void backgroundSerialization(void *outfile)
+static void backgroundSerialization(void *outfile)
 {
     while(continueBackgroundSerialization) {
         MVM_sleep(500);

--- a/src/spesh/dump.c
+++ b/src/spesh/dump.c
@@ -742,8 +742,8 @@ char * MVM_spesh_dump(MVMThreadContext *tc, MVMSpeshGraph *g) {
 }
 
 /* Dumps a spesh stats type typle. */
-void dump_stats_type_tuple(MVMThreadContext *tc, DumpStr *ds, MVMCallsite *cs,
-                           MVMSpeshStatsType *type_tuple, char *prefix) {
+static void dump_stats_type_tuple(MVMThreadContext *tc, DumpStr *ds, MVMCallsite *cs,
+                                  MVMSpeshStatsType *type_tuple, char *prefix) {
     MVMuint32 j;
     for (j = 0; j < cs->flag_count; j++) {
         MVMObject *type = type_tuple[j].type;
@@ -764,7 +764,7 @@ void dump_stats_type_tuple(MVMThreadContext *tc, DumpStr *ds, MVMCallsite *cs,
 }
 
 /* Dumps the statistics associated with a particular callsite object. */
-void dump_stats_by_callsite(MVMThreadContext *tc, DumpStr *ds, MVMSpeshStatsByCallsite *css) {
+static void dump_stats_by_callsite(MVMThreadContext *tc, DumpStr *ds, MVMSpeshStatsByCallsite *css) {
     MVMuint32 i, j, k;
 
     if (css->cs)

--- a/src/spesh/frame_walker.c
+++ b/src/spesh/frame_walker.c
@@ -114,7 +114,7 @@ static void go_to_first_inline(MVMThreadContext *tc, MVMSpeshFrameWalker *fw, MV
 }
 
 /* Moves one caller frame deeper, accounting for inlines. */
-MVMuint32 move_one_caller(MVMThreadContext *tc, MVMSpeshFrameWalker *fw) {
+static MVMuint32 move_one_caller(MVMThreadContext *tc, MVMSpeshFrameWalker *fw) {
     MVMFrame *caller;
 
      /* Is there an inline to try and visit? If there is one, then

--- a/src/spesh/graph.c
+++ b/src/spesh/graph.c
@@ -1156,7 +1156,7 @@ static SSAVarInfo * initialize_ssa_var_info(MVMThreadContext *tc, MVMSpeshGraph 
     return var_info;
 }
 
-MVMOpInfo *get_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMuint32 nrargs) {
+MVMOpInfo *MVM_spesh_graph_get_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMuint32 nrargs) {
     MVMOpInfo *result = NULL;
 
     /* Check number of args to phi isn't huge. */
@@ -1198,7 +1198,7 @@ MVMOpInfo *get_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMuint32 nrargs) {
 /* Inserts SSA phi functions at the required places in the graph. */
 void MVM_spesh_graph_place_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb, MVMint32 n, MVMuint16 var) {
     MVMint32     i;
-    MVMOpInfo   *phi_op  = get_phi(tc, g, n + 1);
+    MVMOpInfo   *phi_op  = MVM_spesh_graph_get_phi(tc, g, n + 1);
     MVMSpeshIns *ins     = MVM_spesh_alloc(tc, g, sizeof(MVMSpeshIns));
     ins->info            = phi_op;
     ins->operands        = MVM_spesh_alloc(tc, g, phi_op->num_operands * sizeof(MVMSpeshOperand));

--- a/src/spesh/graph.h
+++ b/src/spesh/graph.h
@@ -298,7 +298,7 @@ void MVM_spesh_graph_mark(MVMThreadContext *tc, MVMSpeshGraph *g, MVMGCWorklist 
 void MVM_spesh_graph_describe(MVMThreadContext *tc, MVMSpeshGraph *g, MVMHeapSnapshotState *snapshot);
 void MVM_spesh_graph_destroy(MVMThreadContext *tc, MVMSpeshGraph *g);
 MVM_PUBLIC void * MVM_spesh_alloc(MVMThreadContext *tc, MVMSpeshGraph *g, size_t bytes);
-MVMOpInfo *get_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMuint32 nrargs);
+MVMOpInfo *MVM_spesh_graph_get_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMuint32 nrargs);
 void MVM_spesh_graph_place_phi(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb, MVMint32 n, MVMuint16 var);
 
 MVM_PUBLIC void MVM_spesh_graph_add_comment(MVMThreadContext *tc, MVMSpeshGraph *g,

--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -1297,7 +1297,7 @@ static void rewrite_returns(MVMThreadContext *tc, MVMSpeshGraph *inliner,
                 MVMuint32 num_rets = final_last_result_version - initial_last_result_version;
                 MVMuint32 i;
                 MVMSpeshIns *phi = MVM_spesh_alloc(tc, inliner, sizeof(MVMSpeshIns));
-                phi->info = get_phi(tc, inliner, num_rets + 1);
+                phi->info = MVM_spesh_graph_get_phi(tc, inliner, num_rets + 1);
                 phi->operands = MVM_spesh_alloc(tc, inliner, (1 + num_rets) * sizeof(MVMSpeshOperand));
                 phi->operands[0] = runbytecode_ins->operands[0];
                 MVM_spesh_get_facts(tc, inliner, phi->operands[0])->writer = phi;

--- a/src/spesh/log.c
+++ b/src/spesh/log.c
@@ -23,7 +23,7 @@ MVMSpeshLog * MVM_spesh_log_create(MVMThreadContext *tc, MVMThread *target_threa
 
 /* Increments the used count and - if it hits the limit - sends the log off
  * to the worker thread and NULLs it out. */
-void send_log(MVMThreadContext *tc, MVMSpeshLog *sl) {
+static void send_log(MVMThreadContext *tc, MVMSpeshLog *sl) {
     if (tc->instance->spesh_blocking) {
         uv_mutex_t *block_mutex;
         uv_cond_t *block_condvar;
@@ -52,7 +52,7 @@ void send_log(MVMThreadContext *tc, MVMSpeshLog *sl) {
         tc->spesh_log = NULL;
     }
 }
-void commit_entry(MVMThreadContext *tc, MVMSpeshLog *sl) {
+static void commit_entry(MVMThreadContext *tc, MVMSpeshLog *sl) {
     sl->body.used++;
     if (sl->body.used == sl->body.limit)
         send_log(tc, sl);
@@ -91,7 +91,7 @@ static void log_param_type(MVMThreadContext *tc, MVMint32 cid, MVMuint16 arg_idx
     entry->param.arg_idx = arg_idx;
     commit_entry(tc, sl);
 }
-void log_parameter(MVMThreadContext *tc, MVMint32 cid, MVMuint16 arg_idx, MVMObject *param) {
+static void log_parameter(MVMThreadContext *tc, MVMint32 cid, MVMuint16 arg_idx, MVMObject *param) {
     MVMContainerSpec const *cs = STABLE(param)->container_spec;
     MVMROOT(tc, param, {
         log_param_type(tc, cid, arg_idx, param, MVM_SPESH_LOG_PARAMETER,

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1936,7 +1936,7 @@ static int eliminate_phi_dead_reads(MVMThreadContext *tc, MVMSpeshGraph *g, MVMS
         operand++;
     }
     if (num_operands != ins->info->num_operands)
-        ins->info = get_phi(tc, g, num_operands);
+        ins->info = MVM_spesh_graph_get_phi(tc, g, num_operands);
     if (num_operands <= 1) {
         MVM_spesh_manipulate_delete_ins(tc, g, bb, ins);
         return 0;

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1163,7 +1163,7 @@ static void optimize_getlex_per_invocant(MVMThreadContext *tc, MVMSpeshGraph *g,
 
 /* Find the dispatch cache bytecode offset of the given instruction. Returns 0
  * if not found. */
-MVMuint32 find_cache_offset(MVMThreadContext *tc, MVMSpeshIns *ins) {
+static MVMuint32 find_cache_offset(MVMThreadContext *tc, MVMSpeshIns *ins) {
     MVMSpeshAnn *ann = ins->annotations;
     while (ann) {
         if (ann->type == MVM_SPESH_ANN_CACHED)
@@ -1177,7 +1177,7 @@ MVMuint32 find_cache_offset(MVMThreadContext *tc, MVMSpeshIns *ins) {
  * of operations culminating in the runbytecode instruction. It may be on the
  * runbytecode itself, if no guards were stacked up before it, but may also be
  * earlier (but always in the same basic block). */
-MVMint32 find_predeopt_index(MVMThreadContext *tc, MVMSpeshIns *ins) {
+static MVMint32 find_predeopt_index(MVMThreadContext *tc, MVMSpeshIns *ins) {
     while (ins) {
         MVMSpeshAnn *ann = ins->annotations;
         while (ann) {
@@ -1198,7 +1198,7 @@ MVMint32 find_predeopt_index(MVMThreadContext *tc, MVMSpeshIns *ins) {
 
 /* Given an instruction, finds the deopt target on it. Panics if there is not
  * one there. */
-void find_deopt_target_and_index(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns *ins,
+static void find_deopt_target_and_index(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshIns *ins,
         MVMuint32 *deopt_target_out, MVMuint32 *deopt_index_out) {
     MVMSpeshAnn *deopt_ann = ins->annotations;
     while (deopt_ann) {
@@ -1264,7 +1264,7 @@ static MVMSpeshStatsType * find_invokee_type_tuple(MVMThreadContext *tc,
 
 /* Sees if any static frames were logged for the dispatch at this location,
  * and if so checks if there was a stable one. */
-MVMStaticFrame * find_runbytecode_static_frame(MVMThreadContext *tc, MVMSpeshPlanned *p,
+static MVMStaticFrame * find_runbytecode_static_frame(MVMThreadContext *tc, MVMSpeshPlanned *p,
         MVMSpeshIns *ins, MVMuint32 cache_offset) {
     MVMuint32 i;
     MVMStaticFrame *best_result = NULL;
@@ -1434,7 +1434,7 @@ static void check_and_tweak_arg_guards(MVMThreadContext *tc, MVMSpeshGraph *g,
 
 /* Ties to optimize a runbytecode instruction by either pre-selecting a spesh
  * candidate or, if possible, inlining it. */
-void optimize_runbytecode(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
+static void optimize_runbytecode(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpeshBB *bb,
         MVMSpeshIns *ins, MVMSpeshPlanned *p) {
     /* Make sure we can find the dispatch bytecode offset (used for both
      * looking up in the spesh log) and the pre-deopt index (for use with

--- a/src/spesh/osr.c
+++ b/src/spesh/osr.c
@@ -19,7 +19,7 @@ static MVMint32 get_osr_deopt_index(MVMThreadContext *tc, MVMSpeshCandidate *can
 }
 
 /* Does the jump into the optimized code. */
-void perform_osr(MVMThreadContext *tc, MVMSpeshCandidate *specialized) {
+static void perform_osr(MVMThreadContext *tc, MVMSpeshCandidate *specialized) {
     /* Ensure there is space for the work area. */
     if (specialized->body.work_size > tc->cur_frame->allocd_work ||
             specialized->body.env_size > tc->cur_frame->allocd_env) {

--- a/src/spesh/pea.c
+++ b/src/spesh/pea.c
@@ -111,7 +111,7 @@ typedef struct {
 /* Turns a flattened-in STable into a register type to allocate, if possible.
  * Should it not be possible, returns a negative value. If passed NULL (which
  * indicates a reference type), then returns MVM_reg_obj. */
-MVMint32 flattened_type_to_register_kind(MVMThreadContext *tc, MVMSTable *st) {
+static MVMint32 flattened_type_to_register_kind(MVMThreadContext *tc, MVMSTable *st) {
     if (st) {
         const MVMStorageSpec *ss = st->REPR->get_storage_spec(tc, st);
         switch (ss->boxed_primitive) {

--- a/src/spesh/plan.c
+++ b/src/spesh/plan.c
@@ -1,7 +1,7 @@
 #include "moar.h"
 
 /* Checks if we have any existing specialization of this. */
-MVMint32 have_existing_specialization(MVMThreadContext *tc, MVMStaticFrame *sf,
+static MVMint32 have_existing_specialization(MVMThreadContext *tc, MVMStaticFrame *sf,
         MVMCallsite *cs, MVMSpeshStatsType *type_tuple) {
     MVMStaticFrameSpesh *sfs = sf->body.spesh;
     MVMuint32 i;
@@ -27,10 +27,10 @@ MVMint32 have_existing_specialization(MVMThreadContext *tc, MVMStaticFrame *sf,
 /* Adds a planned specialization, provided it doesn't already exist (this may
  * happen due to further data suggesting it being logged while it was being
  * produced). */
-void add_planned(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMSpeshPlannedKind kind,
-                 MVMStaticFrame *sf, MVMSpeshStatsByCallsite *cs_stats,
-                 MVMSpeshStatsType *type_tuple, MVMSpeshStatsByType **type_stats,
-                 MVMuint32 num_type_stats) {
+static void add_planned(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMSpeshPlannedKind kind,
+                        MVMStaticFrame *sf, MVMSpeshStatsByCallsite *cs_stats,
+                        MVMSpeshStatsType *type_tuple, MVMSpeshStatsByType **type_stats,
+                        MVMuint32 num_type_stats) {
     MVMSpeshPlanned *p;
     if (sf->body.bytecode_size > MVM_SPESH_MAX_BYTECODE_SIZE ||
         have_existing_specialization(tc, sf, cs_stats->cs, type_tuple)) {
@@ -233,7 +233,7 @@ static void plan_for_cs(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMStaticFrame
 
 /* Considers the statistics of a given static frame and plans specializtions
  * to produce for it. */
-void plan_for_sf(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMStaticFrame *sf,
+static void plan_for_sf(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMStaticFrame *sf,
         MVMuint64 *in_certain_specialization, MVMuint64 *in_observed_specialization, MVMuint64 *in_osr_specialization) {
     MVMSpeshStats *ss = sf->body.spesh->body.spesh_stats;
     MVMuint32 threshold = MVM_spesh_threshold(tc, sf);
@@ -253,7 +253,7 @@ void plan_for_sf(MVMThreadContext *tc, MVMSpeshPlan *plan, MVMStaticFrame *sf,
  * but sometimes it's misleading, and we end up with a planned specialization
  * of a callee having a lower maximum than the caller. Boost the depth of any
  * callees in such a situation. */
-void twiddle_stack_depths(MVMThreadContext *tc, MVMSpeshPlanned *planned, MVMuint32 num_planned) {
+static void twiddle_stack_depths(MVMThreadContext *tc, MVMSpeshPlanned *planned, MVMuint32 num_planned) {
     MVMuint32 i;
     if (num_planned < 2)
         return;
@@ -282,7 +282,7 @@ void twiddle_stack_depths(MVMThreadContext *tc, MVMSpeshPlanned *planned, MVMuin
 }
 
 /* Sorts the plan in descending order of maximum call depth. */
-void sort_plan(MVMThreadContext *tc, MVMSpeshPlanned *planned, MVMuint32 n) {
+static void sort_plan(MVMThreadContext *tc, MVMSpeshPlanned *planned, MVMuint32 n) {
     if (n >= 2) {
         MVMSpeshPlanned pivot = planned[n / 2];
         MVMuint32 i, j;

--- a/src/spesh/stats.c
+++ b/src/spesh/stats.c
@@ -1,7 +1,7 @@
 #include "moar.h"
 
 /* Gets the statistics for a static frame, creating them if needed. */
-MVMSpeshStats * stats_for(MVMThreadContext *tc, MVMStaticFrame *sf) {
+static MVMSpeshStats * stats_for(MVMThreadContext *tc, MVMStaticFrame *sf) {
     MVMStaticFrameSpesh *spesh = sf->body.spesh;
     if (!spesh->body.spesh_stats)
         spesh->body.spesh_stats = MVM_calloc(1, sizeof(MVMSpeshStats));
@@ -9,7 +9,7 @@ MVMSpeshStats * stats_for(MVMThreadContext *tc, MVMStaticFrame *sf) {
 }
 
 /* Gets the stats by callsite, adding it if it's missing. */
-MVMuint32 by_callsite_idx(MVMThreadContext *tc, MVMSpeshStats *ss, MVMCallsite *cs) {
+static MVMuint32 by_callsite_idx(MVMThreadContext *tc, MVMSpeshStats *ss, MVMCallsite *cs) {
     /* See if we already have it. */
     MVMuint32 found;
     MVMuint32 n = ss->num_by_callsite;
@@ -29,8 +29,8 @@ MVMuint32 by_callsite_idx(MVMThreadContext *tc, MVMSpeshStats *ss, MVMCallsite *
 
 /* Checks if a type tuple is incomplete (no types logged for some passed
  * objects, or no decont type logged for a container type). */
-MVMint32 incomplete_type_tuple(MVMThreadContext *tc, MVMCallsite *cs,
-                               MVMSpeshStatsType *arg_types) {
+static MVMint32 incomplete_type_tuple(MVMThreadContext *tc, MVMCallsite *cs,
+                                      MVMSpeshStatsType *arg_types) {
     MVMuint32 i;
     for (i = 0; i < cs->flag_count; i++) {
         if (cs->arg_flags[i] & MVM_CALLSITE_ARG_OBJ) {
@@ -46,7 +46,7 @@ MVMint32 incomplete_type_tuple(MVMThreadContext *tc, MVMCallsite *cs,
 }
 
 /* Returns true if the callsite has no object arguments, false otherwise. */
-MVMint32 cs_without_object_args(MVMThreadContext *tc, MVMCallsite *cs) {
+static MVMint32 cs_without_object_args(MVMThreadContext *tc, MVMCallsite *cs) {
     MVMuint32 i;
     for (i = 0; i < cs->flag_count; i++)
         if (cs->arg_flags[i] & MVM_CALLSITE_ARG_OBJ)
@@ -56,8 +56,8 @@ MVMint32 cs_without_object_args(MVMThreadContext *tc, MVMCallsite *cs) {
 
 /* Gets the stats by type, adding it if it's missing. Frees arg_types. Returns
  * the index in the by type array, or -1 if unresolved. */
-MVMint32 by_type(MVMThreadContext *tc, MVMSpeshStats *ss, MVMuint32 callsite_idx,
-                  MVMSpeshStatsType *arg_types) {
+static MVMint32 by_type(MVMThreadContext *tc, MVMSpeshStats *ss, MVMuint32 callsite_idx,
+                        MVMSpeshStatsType *arg_types) {
     /* Resolve type by callsite level info. If this is the no-callsite
      * specialization there is nothing further to do. */
     MVMSpeshStatsByCallsite *css = &(ss->by_callsite[callsite_idx]);
@@ -113,8 +113,8 @@ MVMint32 by_type(MVMThreadContext *tc, MVMSpeshStats *ss, MVMuint32 callsite_idx
 }
 
 /* Get the stats by offset entry, adding it if it's missing. */
-MVMSpeshStatsByOffset * by_offset(MVMThreadContext *tc, MVMSpeshStatsByType *tss,
-                                  MVMuint32 bytecode_offset) {
+static MVMSpeshStatsByOffset * by_offset(MVMThreadContext *tc, MVMSpeshStatsByType *tss,
+                                         MVMuint32 bytecode_offset) {
     /* See if we already have it. */
     MVMuint32 found;
     MVMuint32 n = tss->num_by_offset;
@@ -133,8 +133,8 @@ MVMSpeshStatsByOffset * by_offset(MVMThreadContext *tc, MVMSpeshStatsByType *tss
 }
 
 /* Adds/increments the count of a certain type seen at the given offset. */
-void add_type_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
-                        MVMStaticFrame *sf, MVMObject *type, MVMuint8 concrete) {
+static void add_type_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
+                               MVMStaticFrame *sf, MVMObject *type, MVMuint8 concrete) {
     /* If we have it already, increment the count. */
     MVMuint32 found;
     MVMuint32 n = oss->num_types;
@@ -156,9 +156,9 @@ void add_type_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
 
 /* Adds/increments the count of a certain invocation target seen at the given
  * offset. */
-void add_invoke_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
-                          MVMStaticFrame *sf, MVMStaticFrame *target_sf,
-                          MVMint16 caller_is_outer) {
+static void add_invoke_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
+                                 MVMStaticFrame *sf, MVMStaticFrame *target_sf,
+                                 MVMint16 caller_is_outer) {
     /* If we have it already, increment the count. */
     MVMuint32 found;
     MVMuint32 n = oss->num_invokes;
@@ -182,8 +182,8 @@ void add_invoke_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
 }
 
 /* Adds/increments the count of a dispatch result seen at the given offset. */
-void add_dispatch_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
-                            MVMuint32 result_index) {
+static void add_dispatch_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
+                                   MVMuint32 result_index) {
     /* If we have it already, increment the count. */
     MVMuint32 found;
     MVMuint32 n = oss->num_dispatch_results;
@@ -204,8 +204,8 @@ void add_dispatch_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
 }
 
 /* Adds/increments the count of a type tuple seen at the given offset. */
-void add_type_tuple_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
-                              MVMStaticFrame *sf, MVMSpeshSimCallType *info) {
+static void add_type_tuple_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
+                                     MVMStaticFrame *sf, MVMSpeshSimCallType *info) {
     /* Compute type tuple size. */
     size_t tt_size = info->cs->flag_count * sizeof(MVMSpeshStatsType);
 
@@ -242,7 +242,7 @@ void add_type_tuple_at_offset(MVMThreadContext *tc, MVMSpeshStatsByOffset *oss,
 }
 
 /* Initializes the stack simulation. */
-void sim_stack_init(MVMThreadContext *tc, MVMSpeshSimStack *sims) {
+static void sim_stack_init(MVMThreadContext *tc, MVMSpeshSimStack *sims) {
     sims->used = 0;
     sims->limit = 32;
     sims->frames = MVM_malloc(sims->limit * sizeof(MVMSpeshSimStackFrame));
@@ -250,8 +250,8 @@ void sim_stack_init(MVMThreadContext *tc, MVMSpeshSimStack *sims) {
 }
 
 /* Pushes an entry onto the stack frame model. */
-void sim_stack_push(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMStaticFrame *sf,
-                    MVMSpeshStats *ss, MVMuint32 cid, MVMuint32 callsite_idx) {
+static void sim_stack_push(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMStaticFrame *sf,
+                           MVMSpeshStats *ss, MVMuint32 cid, MVMuint32 callsite_idx) {
     MVMSpeshSimStackFrame *frame;
     MVMCallsite *cs;
     if (sims->used == sims->limit) {
@@ -279,9 +279,9 @@ void sim_stack_push(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMStaticFrame
 
 /* Adds an entry to a sim frame's callsite type info list, for later
  * inclusion in the callsite stats. */
-void add_sim_call_type_info(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf,
-                            MVMuint32 bytecode_offset, MVMCallsite *cs,
-                            MVMSpeshStatsType *arg_types) {
+static void add_sim_call_type_info(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf,
+                                   MVMuint32 bytecode_offset, MVMCallsite *cs,
+                                   MVMSpeshStatsType *arg_types) {
     MVMSpeshSimCallType *info;
     if (simf->call_type_info_used == simf->call_type_info_limit) {
         simf->call_type_info_limit += 32;
@@ -295,9 +295,9 @@ void add_sim_call_type_info(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf,
 }
 
 /* Incorporate information collected into a sim stack frame. */
-void incorporate_stats(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf,
-                       MVMuint32 frame_depth, MVMSpeshSimStackFrame *caller,
-                       MVMObject *sf_updated) {
+static void incorporate_stats(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf,
+                              MVMuint32 frame_depth, MVMSpeshSimStackFrame *caller,
+                              MVMObject *sf_updated) {
     MVMSpeshStatsByType *tss;
     MVMint32 first_type_hit = 0;
 
@@ -388,7 +388,7 @@ void incorporate_stats(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf,
 }
 
 /* Pops the top frame from the sim stack. */
-void sim_stack_pop(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMObject *sf_updated) {
+static void sim_stack_pop(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMObject *sf_updated) {
     MVMSpeshSimStackFrame *simf;
     MVMuint32 frame_depth;
 
@@ -410,8 +410,8 @@ void sim_stack_pop(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMObject *sf_u
  * not on the top, searches to see if it's further down. If it is, then pops
  * off the top to reach it. If it's not found at all, returns NULL and does
  * nothing to the simulation stack. */
-MVMSpeshSimStackFrame * sim_stack_find(MVMThreadContext *tc, MVMSpeshSimStack *sims,
-                                       MVMuint32 cid, MVMObject *sf_updated) {
+static MVMSpeshSimStackFrame * sim_stack_find(MVMThreadContext *tc, MVMSpeshSimStack *sims,
+                                              MVMuint32 cid, MVMObject *sf_updated) {
     MVMuint32 found_at = sims->used;
     while (found_at != 0) {
         found_at--;
@@ -427,14 +427,14 @@ MVMSpeshSimStackFrame * sim_stack_find(MVMThreadContext *tc, MVMSpeshSimStack *s
 }
 
 /* Pops all the frames in the stack simulation and frees the frames storage. */
-void sim_stack_teardown(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMObject *sf_updated) {
+static void sim_stack_teardown(MVMThreadContext *tc, MVMSpeshSimStack *sims, MVMObject *sf_updated) {
     while (sims->used)
         sim_stack_pop(tc, sims, sf_updated);
     MVM_free(sims->frames);
 }
 
 /* Gets the parameter type slot from a simulation frame. */
-MVMSpeshStatsType * param_type(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf, MVMSpeshLogEntry *e) {
+static MVMSpeshStatsType * param_type(MVMThreadContext *tc, MVMSpeshSimStackFrame *simf, MVMSpeshLogEntry *e) {
     if (simf->arg_types) {
         MVMuint16 idx = e->param.arg_idx;
         MVMCallsite *cs = simf->ss->by_callsite[simf->callsite_idx].cs;

--- a/src/strings/gb18030.c
+++ b/src/strings/gb18030.c
@@ -22,7 +22,7 @@ const MVMint32 gb18030_two_byte_upper_bound[126] = {
 254,254,254,254,254,254,254,254,254,254,254,254,254,254,254,254,254,254,254,160,
 160,160,160,160,160,159};
 
-MVMint32 gb18030_valid_check_len2(MVMint32 c_1, MVMint32 c_2) {
+static MVMint32 gb18030_valid_check_len2(MVMint32 c_1, MVMint32 c_2) {
     /* This function serves like a 'first stage check' of c_1 and c_2.
        It eliminates most of the invalid combinations of c_1 and c_2, 
        but for code simplicity and to avoid lots of if-else here,
@@ -33,7 +33,7 @@ MVMint32 gb18030_valid_check_len2(MVMint32 c_1, MVMint32 c_2) {
     return gb18030_two_byte_lower_bound[c_1] <= c_2 && c_2 <= gb18030_two_byte_upper_bound[c_1];
 }
 
-MVMint32 gb18030_valid_check_len4(MVMint32 c_1, MVMint32 c_2, MVMint32 c_3, MVMint32 c_4) {
+static MVMint32 gb18030_valid_check_len4(MVMint32 c_1, MVMint32 c_2, MVMint32 c_3, MVMint32 c_4) {
     if ((0x81 <= c_1 && c_1 <= 0x83) || (c_1 == 0x84 && c_2 == 0x30)) {
         return (0x30 <= c_2 && c_2 <= 0x39) && (0x81 <= c_3 && c_3 <= 0xfe) && (0x30 <= c_4 && c_4 <= 0x39);
     } else if (c_1 == 0x84 && c_2 == 0x31) {
@@ -42,7 +42,7 @@ MVMint32 gb18030_valid_check_len4(MVMint32 c_1, MVMint32 c_2, MVMint32 c_3, MVMi
     return 0;
 }
 
-MVMint32 gb18030_valid_check_len4_first2(MVMint32 c_1, MVMint32 c_2) {
+static MVMint32 gb18030_valid_check_len4_first2(MVMint32 c_1, MVMint32 c_2) {
     return (((0x81 <= c_1 && c_1 <= 0x83) || (c_1 == 0x84 && c_2 == 0x30)) && (0x30 <= c_2 && c_2 <= 0x39))	|| (c_1 == 0x84 && c_2 == 0x31);
 }
 

--- a/src/strings/gb18030_codeindex.h
+++ b/src/strings/gb18030_codeindex.h
@@ -1,6 +1,6 @@
 #define GB18030_NULL 0
 
-const MVMint32 gb18030_index_to_cp_len2_record[126][191]=
+static const MVMint32 gb18030_index_to_cp_len2_record[126][191]=
 {{19970,19972,19973,19974,19983,19986,19991,19999,20000,20001,20003,20006,20009,
 20014,20015,20017,20019,20021,20023,20028,20032,20033,20034,20036,20038,20042,
 20049,20053,20055,20058,20059,20066,20067,20068,20069,20071,20072,20074,20075,
@@ -1781,11 +1781,11 @@ const MVMint32 gb18030_index_to_cp_len2_record[126][191]=
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 0,0,0,0,0,0,0,0}};
 
-const MVMint32 gb18030_len4_record_shift[32]={0,-1546,-2806,-4066,-5326,-6586,
+static const MVMint32 gb18030_len4_record_shift[32]={0,-1546,-2806,-4066,-5326,-6586,
 1,2,3,4,5,6,7,8,9,10,-41987,-43247,-44507,-45767,-47027,-48287,-49547,-50807,
 -52067,-53327,11,-59963,-61223,-62483,12,13};
 
-const MVMint32 gb18030_index_to_cp_len4_record[14][1260]={
+static const MVMint32 gb18030_index_to_cp_len4_record[14][1260]={
 {128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,
 147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,165,166,
 169,170,171,172,173,174,175,178,179,180,181,182,184,185,186,187,188,189,190,
@@ -3053,7 +3053,7 @@ const MVMint32 gb18030_index_to_cp_len4_record[14][1260]={
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}};
 
-const MVMuint32 gb18030_cp_to_index_record[61339]={
+static const MVMuint32 gb18030_cp_to_index_record[61339]={
 0x0,0x1,0x2,0x3,0x4,0x5,0x6,0x7,0x8,0x9,0xa,0xb,0xc,0xd,0xe,0xf,0x10,0x11,
 0x12,0x13,0x14,0x15,0x16,0x17,0x18,0x19,0x1a,0x1b,0x1c,0x1d,0x1e,0x1f,
 0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27,0x28,0x29,0x2a,0x2b,0x2c,0x2d,
@@ -10872,14 +10872,14 @@ const MVMuint32 gb18030_cp_to_index_record[61339]={
 0x8431a336,0x8431a337,0x8431a338,0x8431a339,0x8431a430,0x8431a431,0x8431a432,
 0x8431a433,0x8431a434,0x8431a435,0x8431a436,0x8431a437,0x8431a438,0x8431a439};
 
-MVMGrapheme32 gb18030_index_to_cp_len2(MVMuint8 byte1, MVMuint8 byte2) {
+static MVMGrapheme32 gb18030_index_to_cp_len2(MVMuint8 byte1, MVMuint8 byte2) {
     if (0x81 <= byte1 && byte1 <= 0xfe && 0x40 <= byte2 && byte2 <= 0xfe)
         return gb18030_index_to_cp_len2_record[byte1-0x81][byte2-0x40];
     else
         return 0;
 }
 
-MVMGrapheme32 gb18030_index_to_cp_len4(MVMuint8 byte1, MVMuint8 byte2, MVMuint8 byte3, MVMuint8 byte4) {
+static MVMGrapheme32 gb18030_index_to_cp_len4(MVMuint8 byte1, MVMuint8 byte2, MVMuint8 byte3, MVMuint8 byte4) {
     MVMint32 pos_1, pos_2;
     byte1 -= 0x81;
     byte2 -= 0x30;
@@ -10898,7 +10898,7 @@ MVMGrapheme32 gb18030_index_to_cp_len4(MVMuint8 byte1, MVMuint8 byte2, MVMuint8 
         return 0;
 }
 
-MVMint64 gb18030_cp_to_index(MVMGrapheme32 codepoint) {
+static MVMint64 gb18030_cp_to_index(MVMGrapheme32 codepoint) {
     MVMint64 result = 0;
     if (0 <= codepoint && codepoint <= 55295) {
         result = (MVMint64) gb18030_cp_to_index_record[codepoint];

--- a/src/strings/gb2312.c
+++ b/src/strings/gb2312.c
@@ -59,8 +59,8 @@ MVMString * MVM_string_gb2312_decode(MVMThreadContext *tc, const MVMObject *resu
 #define GB2312_DECODE_CODEPOINT_EXCEPTION -4
 #define GB2312_DECODE_CHINESE_CODEPOINT -5
 
-int gb2312_decode_handler(MVMThreadContext *tc, MVMint32 last_was_first_byte, 
-                          MVMuint16 codepoint, MVMuint16 last_codepoint, MVMGrapheme32 *out) {
+static int gb2312_decode_handler(MVMThreadContext *tc, MVMint32 last_was_first_byte,
+                                 MVMuint16 codepoint, MVMuint16 last_codepoint, MVMGrapheme32 *out) {
     MVMGrapheme32 graph;
     if (codepoint <= 127) {
         if (last_was_first_byte) {

--- a/src/strings/gb2312_codeindex.h
+++ b/src/strings/gb2312_codeindex.h
@@ -1778,7 +1778,7 @@ static MVMint32 gb2312_cp_to_index_record[24380]=
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,41449,41450,0,41982,
 0,41892,0};
 
-MVMGrapheme32 gb2312_index_to_cp(MVMuint16 codepoint) {
+static MVMGrapheme32 gb2312_index_to_cp(MVMuint16 codepoint) {
     int zone = codepoint / 256 - 161;
     int point = codepoint % 256 - 161;
     if (0 <= zone && zone < 87 && 0 <= point && point < 94) {
@@ -1788,7 +1788,7 @@ MVMGrapheme32 gb2312_index_to_cp(MVMuint16 codepoint) {
     }
 }
 
-MVMint32 gb2312_cp_to_index(MVMGrapheme32 codepoint) {
+static MVMint32 gb2312_cp_to_index(MVMGrapheme32 codepoint) {
     MVMint32 result = 0;
     if (0 <= codepoint && codepoint <= 1105) {
         result = gb2312_cp_to_index_record[codepoint];

--- a/src/strings/nfg.c
+++ b/src/strings/nfg.c
@@ -18,7 +18,7 @@ static MVMint32 find_child_node_idx(MVMThreadContext *tc, const MVMNFGTrieNode *
 }
 
 /* Does a lookup in the trie for a synthetic for the specified codepoints. */
-MVMNFGTrieNode * find_child_node(MVMThreadContext *tc, const MVMNFGTrieNode *node, MVMCodepoint cp) {
+static MVMNFGTrieNode * find_child_node(MVMThreadContext *tc, const MVMNFGTrieNode *node, MVMCodepoint cp) {
     MVMint32 idx = find_child_node_idx(tc, node, cp);
     return idx >= 0 ? node->next_codes[idx].node : NULL;
 }

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -1931,7 +1931,7 @@ MVMObject * MVM_string_split(MVMThreadContext *tc, MVMString *separator, MVMStri
     return result;
 }
 /* Used in the MVM_string_join function. Moved here to simplify the code */
-void copy_to_32bit (MVMThreadContext *tc, MVMString *source,
+static void copy_to_32bit (MVMThreadContext *tc, MVMString *source,
     MVMString *dest, MVMint64 *position, MVMGraphemeIter *gi) {
     /* Add source. */
     switch (source->body.storage_type) {

--- a/src/strings/unicode_ops.c
+++ b/src/strings/unicode_ops.c
@@ -307,7 +307,7 @@ static void collation_push_MVM_values (MVMThreadContext *tc, MVMCodepoint cp, co
  * Essentially the return value lets you know if it ended up pushing collation values for the last codepoint
  * in the sequence or if it only pushed collation values for fallback_cp
 */
-MVMint64 collation_add_keys_from_node (MVMThreadContext *tc, sub_node *last_node, collation_stack *stack, MVMCodepointIter *ci, char *name, MVMCodepoint fallback_cp, sub_node *first_node) {
+static int collation_add_keys_from_node (MVMThreadContext *tc, sub_node *last_node, collation_stack *stack, MVMCodepointIter *ci, char *name, MVMCodepoint fallback_cp, sub_node *first_node) {
     MVMint64 j;
     MVMint64 rtrn = 0;
     sub_node *choosen_node = NULL;
@@ -334,7 +334,7 @@ MVMint64 collation_add_keys_from_node (MVMThreadContext *tc, sub_node *last_node
     collation_push_MVM_values(tc, fallback_cp, stack, ci, name);
     return rtrn;
 }
-MVMint64 find_next_node (MVMThreadContext *tc, sub_node node, MVMCodepoint next_cp) {
+static MVMint64 find_next_node (MVMThreadContext *tc, sub_node node, MVMCodepoint next_cp) {
     MVMint64 next_min, next_max;
     MVMint64 i;
     /* There is nowhere else to go */
@@ -351,7 +351,7 @@ MVMint64 find_next_node (MVMThreadContext *tc, sub_node node, MVMCodepoint next_
     }
     return -1;
 }
-MVMint64 get_main_node (MVMThreadContext *tc, int cp, int range_min, int range_max) {
+static MVMint64 get_main_node (MVMThreadContext *tc, int cp, int range_min, int range_max) {
     MVMint64 i;
     MVMint64 rtrn = -1;
     /* Decrement range_min because binary search defaults to 1..* not 0..* */
@@ -452,7 +452,7 @@ static MVMint64 collation_push_cp (MVMThreadContext *tc, collation_stack *stack,
     }
     return num_cps_processed;
 }
-MVMint64 grab_from_stack(MVMThreadContext *tc, MVMCodepointIter *ci, collation_stack *stack, char *name) {
+static int grab_from_stack(MVMThreadContext *tc, MVMCodepointIter *ci, collation_stack *stack, char *name) {
     if (!MVM_string_ci_has_more(tc, ci))
         return 0;
     collation_push_cp(tc, stack, ci, NULL, 0, name);
@@ -947,7 +947,7 @@ void MVM_unicode_init(MVMThreadContext *tc) {
     }
     tc->instance->unicode_property_values_hashes = hash_array;
 }
-MVMint32 unicode_cname_to_property_value_code(MVMThreadContext *tc, MVMint64 property_code, const char *cname, MVMuint64 cname_length) {
+static MVMint32 unicode_cname_to_property_value_code(MVMThreadContext *tc, MVMint64 property_code, const char *cname, MVMuint64 cname_length) {
     char *out_str = NULL;
                                    /* number + dash + property_value + NULL */
     MVMuint64 out_str_length = length_of_num(property_code) + 1 + cname_length + 1;


### PR DESCRIPTION
I noticed that `record_size` was a missing `static` in `src/core/callstack.c`, and then wondered if there were any other similar oversights.

Hence I ran this to detect functions that aren't `static` but have names that suggest that they should be:

`for file in `find src -name \*.o`; do nm $file | grep ' T '  | grep -v ' T MVM' && echo ${file%.o}.c; done | tac`

and it found quite a few.

Size of `libmoar.so` on x86_64 drops by about 12K (ie from 9.4M to 9.4M), and I *think* that just under 7K of that is due to a reduction in size of the code segment. The code segment likely *should* get a bit smaller - the compiler optimser might decide to inline some of the smaller functions, and that can even be a size win where the function's preamble and postable or the calling convention's setup and return have larger code than the function body itself.