### PR TITLE
Fix handling of native unsigned integers

### DIFF
--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -469,8 +469,8 @@ static void native_ref_fetch_i(MVMThreadContext *tc, MVMObject *cont, MVMRegiste
 
 static void native_ref_fetch_u(MVMThreadContext *tc, MVMObject *cont, MVMRegister *res) {
     MVMNativeRefREPRData *repr_data = (MVMNativeRefREPRData *)STABLE(cont)->REPR_data;
-    if (repr_data->primitive_type != MVM_STORAGE_SPEC_BP_INT)
-        MVM_exception_throw_adhoc(tc, "This container does not reference a native integer");
+    if (repr_data->primitive_type != MVM_STORAGE_SPEC_BP_UINT64)
+        MVM_exception_throw_adhoc(tc, "This container does not reference a native unsigned integer");
     switch (repr_data->ref_kind) {
         case MVM_NATIVEREF_LEX:
             res->u64 = MVM_nativeref_read_lex_i(tc, cont); /* covers unsigned as well */
@@ -541,6 +541,7 @@ static void native_ref_fetch(MVMThreadContext *tc, MVMObject *cont, MVMRegister 
         hll = MVM_hll_current(tc);
     switch (repr_data->primitive_type) {
         case MVM_STORAGE_SPEC_BP_INT:
+        case MVM_STORAGE_SPEC_BP_UINT64:
             if (repr_data->is_unsigned) {
                 native_ref_fetch_u(tc, cont, &tmp);
                 res->o = MVM_repr_box_uint(tc, hll->int_box_type, tmp.u64);
@@ -587,7 +588,7 @@ static void native_ref_store_i(MVMThreadContext *tc, MVMObject *cont, MVMint64 v
 
 static void native_ref_store_u(MVMThreadContext *tc, MVMObject *cont, MVMuint64 value) {
     MVMNativeRefREPRData *repr_data = (MVMNativeRefREPRData *)STABLE(cont)->REPR_data;
-    if (repr_data->primitive_type != MVM_STORAGE_SPEC_BP_INT)
+    if (repr_data->primitive_type != MVM_STORAGE_SPEC_BP_UINT64)
         MVM_exception_throw_adhoc(tc, "This container does not reference a native integer");
     switch (repr_data->ref_kind) {
         case MVM_NATIVEREF_LEX:
@@ -654,6 +655,7 @@ static void native_ref_store_s(MVMThreadContext *tc, MVMObject *cont, MVMString 
 static void native_ref_store(MVMThreadContext *tc, MVMObject *cont, MVMObject *obj) {
     MVMNativeRefREPRData *repr_data = (MVMNativeRefREPRData *)STABLE(cont)->REPR_data;
     switch (repr_data->primitive_type) {
+        case MVM_STORAGE_SPEC_BP_UINT64:
         case MVM_STORAGE_SPEC_BP_INT:
             if (repr_data->is_unsigned)
                 native_ref_store_u(tc, cont, MVM_repr_get_uint(tc, obj));

--- a/src/6model/containers.h
+++ b/src/6model/containers.h
@@ -21,7 +21,7 @@ struct MVMContainerSpec {
 
     /* Native container stores. */
     void (*store_i) (MVMThreadContext *tc, MVMObject *cont, MVMint64 value);
-    void (*store_u) (MVMThreadContext *tc, MVMObject *cont, MVMint64 value);
+    void (*store_u) (MVMThreadContext *tc, MVMObject *cont, MVMuint64 value);
     void (*store_n) (MVMThreadContext *tc, MVMObject *cont, MVMnum64 value);
     void (*store_s) (MVMThreadContext *tc, MVMObject *cont, MVMString *value);
 

--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -166,6 +166,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMSTable *st,
                 MVMint32  type_id    = REPR(type)->ID;
                 if (spec->inlineable == MVM_STORAGE_SPEC_INLINED &&
                         (spec->boxed_primitive == MVM_STORAGE_SPEC_BP_INT ||
+                         spec->boxed_primitive == MVM_STORAGE_SPEC_BP_UINT64 ||
                          spec->boxed_primitive == MVM_STORAGE_SPEC_BP_NUM)) {
                     /* It's a boxed int or num; pretty easy. It'll just live in the
                      * body of the struct. Instead of masking in i here (which
@@ -525,6 +526,14 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 MVM_exception_throw_adhoc(tc, "CPPStruct: invalid native get of object attribute");
             break;
         }
+        case MVM_reg_uint64: {
+            if (attr_st)
+                result_reg->u64 = attr_st->REPR->box_funcs.get_uint(tc, attr_st, root,
+                    ((char *)body->cppstruct) + repr_data->struct_offsets[slot]);
+            else
+                MVM_exception_throw_adhoc(tc, "CPPStruct: invalid native get of object attribute");
+            break;
+        }
         case MVM_reg_num64: {
             if (attr_st)
                 result_reg->n64 = attr_st->REPR->box_funcs.get_num(tc, attr_st, root,
@@ -632,6 +641,14 @@ static void bind_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
             if (attr_st)
                 attr_st->REPR->box_funcs.set_int(tc, attr_st, root,
                     ((char *)body->cppstruct) + repr_data->struct_offsets[slot], value_reg.i64);
+            else
+                MVM_exception_throw_adhoc(tc, "CPPStruct: invalid native binding to object attribute");
+            break;
+        }
+        case MVM_reg_uint64: {
+            if (attr_st)
+                attr_st->REPR->box_funcs.set_uint(tc, attr_st, root,
+                    ((char *)body->cppstruct) + repr_data->struct_offsets[slot], value_reg.u64);
             else
                 MVM_exception_throw_adhoc(tc, "CPPStruct: invalid native binding to object attribute");
             break;

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -180,6 +180,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                 MVMint32  type_id    = REPR(type)->ID;
                 if (spec->inlineable == MVM_STORAGE_SPEC_INLINED &&
                         (spec->boxed_primitive == MVM_STORAGE_SPEC_BP_INT ||
+                         spec->boxed_primitive == MVM_STORAGE_SPEC_BP_UINT64 ||
                          spec->boxed_primitive == MVM_STORAGE_SPEC_BP_NUM)) {
                     /* It's a boxed int or num; pretty easy. It'll just live in the
                      * body of the struct. Instead of masking in i here (which
@@ -553,6 +554,14 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 MVM_exception_throw_adhoc(tc, "CStruct: invalid native get of object attribute");
             break;
         }
+        case MVM_reg_uint64: {
+            if (attr_st)
+                result_reg->u64 = attr_st->REPR->box_funcs.get_uint(tc, attr_st, root,
+                    ((char *)body->cstruct) + repr_data->struct_offsets[slot]);
+            else
+                MVM_exception_throw_adhoc(tc, "CStruct: invalid native get of object attribute");
+            break;
+        }
         case MVM_reg_num64: {
             if (attr_st)
                 result_reg->n64 = attr_st->REPR->box_funcs.get_num(tc, attr_st, root,
@@ -672,6 +681,14 @@ static void bind_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
             if (attr_st)
                 attr_st->REPR->box_funcs.set_int(tc, attr_st, root,
                     ((char *)body->cstruct) + repr_data->struct_offsets[slot], value_reg.i64);
+            else
+                MVM_exception_throw_adhoc(tc, "CStruct: invalid native binding to object attribute");
+            break;
+        }
+        case MVM_reg_uint64: {
+            if (attr_st)
+                attr_st->REPR->box_funcs.set_uint(tc, attr_st, root,
+                    ((char *)body->cstruct) + repr_data->struct_offsets[slot], value_reg.u64);
             else
                 MVM_exception_throw_adhoc(tc, "CStruct: invalid native binding to object attribute");
             break;

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -139,6 +139,7 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
                 MVMint32  type_id    = REPR(type)->ID;
                 if (spec->inlineable == MVM_STORAGE_SPEC_INLINED &&
                         (spec->boxed_primitive == MVM_STORAGE_SPEC_BP_INT ||
+                         spec->boxed_primitive == MVM_STORAGE_SPEC_BP_UINT64 ||
                          spec->boxed_primitive == MVM_STORAGE_SPEC_BP_NUM)) {
                     /* It's a boxed int or num; pretty easy. It'll just live in the
                      * body of the struct. Instead of masking in i here (which
@@ -485,6 +486,14 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 MVM_exception_throw_adhoc(tc, "CUnion: invalid native get of object attribute");
             break;
         }
+        case MVM_reg_uint64: {
+            if (attr_st)
+                result_reg->u64 = attr_st->REPR->box_funcs.get_uint(tc, attr_st, root,
+                    ((char *)body->cunion) + repr_data->struct_offsets[slot]);
+            else
+                MVM_exception_throw_adhoc(tc, "CUnion: invalid native get of object attribute");
+            break;
+        }
         case MVM_reg_num64: {
             if (attr_st)
                 result_reg->n64 = attr_st->REPR->box_funcs.get_num(tc, attr_st, root,
@@ -580,6 +589,14 @@ static void bind_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
             if (attr_st)
                 attr_st->REPR->box_funcs.set_int(tc, attr_st, root,
                     ((char *)body->cunion) + repr_data->struct_offsets[slot], value_reg.i64);
+            else
+                MVM_exception_throw_adhoc(tc, "CUnion: invalid native binding to object attribute");
+            break;
+        }
+        case MVM_reg_uint64: {
+            if (attr_st)
+                attr_st->REPR->box_funcs.set_uint(tc, attr_st, root,
+                    ((char *)body->cunion) + repr_data->struct_offsets[slot], value_reg.u64);
             else
                 MVM_exception_throw_adhoc(tc, "CUnion: invalid native binding to object attribute");
             break;

--- a/src/6model/reprs/MVMCapture.c
+++ b/src/6model/reprs/MVMCapture.c
@@ -178,6 +178,8 @@ static MVMint64 flag_to_spec(MVMint64 flag) {
     switch (flag & MVM_CALLSITE_ARG_TYPE_MASK) {
         case MVM_CALLSITE_ARG_INT:
             return MVM_STORAGE_SPEC_BP_INT;
+        case MVM_CALLSITE_ARG_UINT:
+            return MVM_STORAGE_SPEC_BP_UINT64;
         case MVM_CALLSITE_ARG_NUM:
             return MVM_STORAGE_SPEC_BP_NUM;
         case MVM_CALLSITE_ARG_STR:

--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -144,6 +144,41 @@ static void spec_to_repr_data(MVMThreadContext *tc, MVMMultiDimArrayREPRData *re
                 }
             }
             break;
+        case MVM_STORAGE_SPEC_BP_UINT64:
+            switch (spec->bits) {
+                case 64:
+                    repr_data->slot_type = MVM_ARRAY_U64;
+                    repr_data->elem_size = sizeof(MVMuint64);
+                    break;
+                case 32:
+                    repr_data->slot_type = MVM_ARRAY_U32;
+                    repr_data->elem_size = sizeof(MVMuint32);
+                    break;
+                case 16:
+                    repr_data->slot_type = MVM_ARRAY_U16;
+                    repr_data->elem_size = sizeof(MVMuint16);
+                    break;
+                case 8:
+                    repr_data->slot_type = MVM_ARRAY_U8;
+                    repr_data->elem_size = sizeof(MVMuint8);
+                    break;
+                case 4:
+                    repr_data->slot_type = MVM_ARRAY_U4;
+                    repr_data->elem_size = 0;
+                    break;
+                case 2:
+                    repr_data->slot_type = MVM_ARRAY_U2;
+                    repr_data->elem_size = 0;
+                    break;
+                case 1:
+                    repr_data->slot_type = MVM_ARRAY_U1;
+                    repr_data->elem_size = 0;
+                    break;
+                default:
+                    MVM_exception_throw_adhoc(tc,
+                        "MVMMultiDimArray: Unsupported uint size");
+            }
+            break;
         case MVM_STORAGE_SPEC_BP_NUM:
             switch (spec->bits) {
                 case 64:
@@ -524,28 +559,28 @@ static void at_pos_multidim(MVMThreadContext *tc, MVMSTable *st, MVMObject *root
                     MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected num register");
                 break;
             case MVM_ARRAY_U64:
-                if (kind == MVM_reg_int64)
-                    value->i64 = (MVMint64)body->slots.u64[flat_index];
+                if (kind == MVM_reg_uint64)
+                    value->u64 = body->slots.u64[flat_index];
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected uint register");
                 break;
             case MVM_ARRAY_U32:
-                if (kind == MVM_reg_int64)
-                    value->i64 = (MVMint64)body->slots.u32[flat_index];
+                if (kind == MVM_reg_uint64)
+                    value->u64 = (MVMuint64)body->slots.u32[flat_index];
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected uint register");
                 break;
             case MVM_ARRAY_U16:
-                if (kind == MVM_reg_int64)
-                    value->i64 = (MVMint64)body->slots.u16[flat_index];
+                if (kind == MVM_reg_uint64)
+                    value->u64 = (MVMuint64)body->slots.u16[flat_index];
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected uint register");
                 break;
             case MVM_ARRAY_U8:
-                if (kind == MVM_reg_int64)
-                    value->i64 = (MVMint64)body->slots.u8[flat_index];
+                if (kind == MVM_reg_uint64)
+                    value->u64 = (MVMuint64)body->slots.u8[flat_index];
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: atpos expected uint register");
                 break;
             default:
                 MVM_exception_throw_adhoc(tc, "MultiDimArray: Unhandled slot type");
@@ -617,28 +652,28 @@ static void bind_pos_multidim(MVMThreadContext *tc, MVMSTable *st, MVMObject *ro
                     MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected num register");
                 break;
             case MVM_ARRAY_U64:
-                if (kind == MVM_reg_int64)
-                    body->slots.u64[flat_index] = value.i64;
+                if (kind == MVM_reg_uint64)
+                    body->slots.u64[flat_index] = value.u64;
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected uint register");
                 break;
             case MVM_ARRAY_U32:
-                if (kind == MVM_reg_int64)
-                    body->slots.u32[flat_index] = (MVMuint32)value.i64;
+                if (kind == MVM_reg_uint64)
+                    body->slots.u32[flat_index] = (MVMuint32)value.u64;
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected uint register");
                 break;
             case MVM_ARRAY_U16:
-                if (kind == MVM_reg_int64)
-                    body->slots.u16[flat_index] = (MVMuint16)value.i64;
+                if (kind == MVM_reg_uint64)
+                    body->slots.u16[flat_index] = (MVMuint16)value.u64;
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected uint register");
                 break;
             case MVM_ARRAY_U8:
-                if (kind == MVM_reg_int64)
-                    body->slots.u8[flat_index] = (MVMuint8)value.i64;
+                if (kind == MVM_reg_uint64)
+                    body->slots.u8[flat_index] = (MVMuint8)value.u64;
                 else
-                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected int register");
+                    MVM_exception_throw_adhoc(tc, "MultiDimArray: bindpos expected uint register");
                 break;
             default:
                 MVM_exception_throw_adhoc(tc, "MultiDimArray: Unhandled slot type");

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -244,6 +244,23 @@ MVMObject * MVM_nativeref_lex_i(MVMThreadContext *tc, MVMuint16 outers, MVMuint1
     }
     MVM_exception_throw_adhoc(tc, "No int lexical reference type registered for current HLL");
 }
+MVMObject * MVM_nativeref_lex_u(MVMThreadContext *tc, MVMuint16 outers, MVMuint16 idx) {
+    MVMObject *ref_type;
+    MVM_frame_force_to_heap(tc, tc->cur_frame);
+    ref_type = MVM_hll_current(tc)->uint_lex_ref;
+    if (ref_type) {
+        MVMFrame  *f = get_lexical_outer(tc, outers);
+        MVMuint16 *lexical_types = f->spesh_cand && f->spesh_cand->body.lexical_types
+            ? f->spesh_cand->body.lexical_types
+            : f->static_info->body.lexical_types;
+        MVMuint16 type = lexical_types[idx];
+        if (type != MVM_reg_uint64 && type != MVM_reg_uint32 &&
+                type != MVM_reg_uint16 && type != MVM_reg_uint8)
+            MVM_exception_throw_adhoc(tc, "getlexref_u: lexical is not an uint");
+        return lex_ref(tc, ref_type, f, idx, type);
+    }
+    MVM_exception_throw_adhoc(tc, "No uint lexical reference type registered for current HLL");
+}
 MVMObject * MVM_nativeref_lex_n(MVMThreadContext *tc, MVMuint16 outers, MVMuint16 idx) {
     MVMObject *ref_type;
     MVM_frame_force_to_heap(tc, tc->cur_frame);

--- a/src/6model/reprs/NativeRef.h
+++ b/src/6model/reprs/NativeRef.h
@@ -50,6 +50,7 @@ const MVMREPROps * MVMNativeRef_initialize(MVMThreadContext *tc);
 /* Operations on a nativeref REPR. */
 void MVM_nativeref_ensure(MVMThreadContext *tc, MVMObject *val, MVMuint16 wantprim, MVMuint16 wantkind, char *guilty);
 MVMObject * MVM_nativeref_lex_i(MVMThreadContext *tc, MVMuint16 outers, MVMuint16 idx);
+MVMObject * MVM_nativeref_lex_u(MVMThreadContext *tc, MVMuint16 outers, MVMuint16 idx);
 MVMObject * MVM_nativeref_lex_n(MVMThreadContext *tc, MVMuint16 outers, MVMuint16 idx);
 MVMObject * MVM_nativeref_lex_s(MVMThreadContext *tc, MVMuint16 outers, MVMuint16 idx);
 MVMObject * MVM_nativeref_lex_name_i(MVMThreadContext *tc, MVMString *name);

--- a/src/6model/reprs/P6int.c
+++ b/src/6model/reprs/P6int.c
@@ -9,7 +9,7 @@ static const MVMREPROps P6int_this_repr;
 static void mk_storage_spec(MVMThreadContext *tc, MVMuint16 bits, MVMuint16 is_unsigned, MVMStorageSpec *spec) {
     /* create storage spec */
     spec->inlineable      = MVM_STORAGE_SPEC_INLINED;
-    spec->boxed_primitive = MVM_STORAGE_SPEC_BP_INT;
+    spec->boxed_primitive = is_unsigned ? MVM_STORAGE_SPEC_BP_UINT64 : MVM_STORAGE_SPEC_BP_INT;
     spec->can_box         = MVM_STORAGE_SPEC_CAN_BOX_INT;
     spec->bits            = bits;
     spec->is_unsigned     = is_unsigned;

--- a/src/6model/reprs/P6opaque.h
+++ b/src/6model/reprs/P6opaque.h
@@ -47,6 +47,9 @@ struct MVMP6opaqueREPRData {
     /* Slot to delegate to when we need to unbox to a native integer. */
     MVMint16 unbox_int_slot;
 
+    /* Slot to delegate to when we need to unbox to a native unsigned integer. */
+    MVMint16 unbox_uint_slot;
+
     /* Slot to delegate to when we need to unbox to a native number. */
     MVMint16 unbox_num_slot;
 

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -1082,7 +1082,7 @@ static MVMStorageSpec get_elem_storage_spec(MVMThreadContext *tc, MVMSTable *st)
         case MVM_ARRAY_U16:
         case MVM_ARRAY_U8:
             spec.inlineable      = MVM_STORAGE_SPEC_INLINED;
-            spec.boxed_primitive = MVM_STORAGE_SPEC_BP_INT;
+            spec.boxed_primitive = MVM_STORAGE_SPEC_BP_UINT64;
             spec.can_box         = MVM_STORAGE_SPEC_CAN_BOX_INT;
             spec.is_unsigned     = 1;
             break;
@@ -1127,6 +1127,7 @@ static AO_t * pos_as_atomic_multidim(MVMThreadContext *tc, MVMSTable *st, MVMObj
 /* Compose the representation. */
 static void spec_to_repr_data(MVMThreadContext *tc, MVMArrayREPRData *repr_data, const MVMStorageSpec *spec) {
     switch (spec->boxed_primitive) {
+        case MVM_STORAGE_SPEC_BP_UINT64:
         case MVM_STORAGE_SPEC_BP_INT:
             if (spec->is_unsigned) {
                 switch (spec->bits) {

--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -10,7 +10,7 @@
 
 /* Version of the serialization format that we are currently at and lowest
  * version we support. */
-#define CURRENT_VERSION 23
+#define CURRENT_VERSION 24
 #define MIN_VERSION     16
 
 /* Various sizes (in bytes). */

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -376,6 +376,10 @@ static MVMObject * decont_arg(MVMThreadContext *tc, MVMObject *arg) {
                             MVM_exception_throw_adhoc(tc, "Expected native int argument, but got num"); \
                         case MVM_CALLSITE_ARG_STR: \
                             MVM_exception_throw_adhoc(tc, "Expected native int argument, but got str"); \
+                        case MVM_CALLSITE_ARG_INT: \
+                        case MVM_CALLSITE_ARG_UINT: \
+                            /* Ignore signedness mismatch to facilitate rebootstrapping */ \
+                            break; \
                         default: \
                             MVM_exception_throw_adhoc(tc, "unreachable unbox 1"); \
                     } \
@@ -524,13 +528,13 @@ MVMArgInfo MVM_args_get_optional_pos_str(MVMThreadContext *tc, MVMArgProcContext
 MVMuint64 MVM_args_get_required_pos_uint(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
     MVMArgInfo result;
     args_get_pos(tc, ctx, pos, MVM_ARG_REQUIRED, result);
-    autounbox(tc, MVM_CALLSITE_ARG_INT, "unsigned integer", result);
+    autounbox(tc, MVM_CALLSITE_ARG_UINT, "unsigned integer", result);
     return result.arg.u64;
 }
 MVMArgInfo MVM_args_get_optional_pos_uint(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMuint32 pos) {
     MVMArgInfo result;
     args_get_pos(tc, ctx, pos, MVM_ARG_OPTIONAL, result);
-    autounbox(tc, MVM_CALLSITE_ARG_INT, "unsigned integer", result);
+    autounbox(tc, MVM_CALLSITE_ARG_UINT, "unsigned integer", result);
     return result;
 }
 
@@ -589,7 +593,7 @@ MVMArgInfo MVM_args_get_named_str(MVMThreadContext *tc, MVMArgProcContext *ctx, 
 MVMArgInfo MVM_args_get_named_uint(MVMThreadContext *tc, MVMArgProcContext *ctx, MVMString *name, MVMuint8 required) {
     MVMArgInfo result;
     args_get_named(tc, ctx, name, required);
-    autounbox(tc, MVM_CALLSITE_ARG_INT, "unsigned integer", result);
+    autounbox(tc, MVM_CALLSITE_ARG_UINT, "unsigned integer", result);
     return result;
 }
 void MVM_args_assert_nameds_used(MVMThreadContext *tc, MVMArgProcContext *ctx) {

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -199,6 +199,10 @@ MVMCallStackFlattening * MVM_args_perform_flattening(MVMThreadContext *tc, MVMCa
                             record->produced_cs.arg_flags[cur_new_arg] = MVM_CALLSITE_ARG_INT;
                             record->arg_info.source[cur_new_arg].i64 = MVM_repr_at_pos_i(tc, list, j);
                             break;
+                        case MVM_STORAGE_SPEC_BP_UINT64:
+                            record->produced_cs.arg_flags[cur_new_arg] = MVM_CALLSITE_ARG_UINT;
+                            record->arg_info.source[cur_new_arg].u64 = MVM_repr_at_pos_u(tc, list, j);
+                            break;
                         case MVM_STORAGE_SPEC_BP_NUM:
                             record->produced_cs.arg_flags[cur_new_arg] = MVM_CALLSITE_ARG_NUM;
                             record->arg_info.source[cur_new_arg].n64 = MVM_repr_at_pos_n(tc, list, j);

--- a/src/core/hll.c
+++ b/src/core/hll.c
@@ -141,7 +141,7 @@ MVMObject * MVM_hll_set_config(MVMThreadContext *tc, MVMString *name, MVMObject 
             check_config_key_reftype(tc, config_hash, "int_lex_ref", int_lex_ref,
                 config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_LEX);
             check_config_key_reftype(tc, config_hash, "uint_lex_ref", uint_lex_ref,
-                config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_LEX);
+                config, MVM_STORAGE_SPEC_BP_UINT64, MVM_NATIVEREF_LEX);
             check_config_key_reftype(tc, config_hash, "num_lex_ref", num_lex_ref,
                 config, MVM_STORAGE_SPEC_BP_NUM, MVM_NATIVEREF_LEX);
             check_config_key_reftype(tc, config_hash, "str_lex_ref", str_lex_ref,
@@ -149,7 +149,7 @@ MVMObject * MVM_hll_set_config(MVMThreadContext *tc, MVMString *name, MVMObject 
             check_config_key_reftype(tc, config_hash, "int_attr_ref", int_attr_ref,
                 config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_ATTRIBUTE);
             check_config_key_reftype(tc, config_hash, "uint_attr_ref", uint_attr_ref,
-                config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_ATTRIBUTE);
+                config, MVM_STORAGE_SPEC_BP_UINT64, MVM_NATIVEREF_ATTRIBUTE);
             check_config_key_reftype(tc, config_hash, "num_attr_ref", num_attr_ref,
                 config, MVM_STORAGE_SPEC_BP_NUM, MVM_NATIVEREF_ATTRIBUTE);
             check_config_key_reftype(tc, config_hash, "str_attr_ref", str_attr_ref,
@@ -157,7 +157,7 @@ MVMObject * MVM_hll_set_config(MVMThreadContext *tc, MVMString *name, MVMObject 
             check_config_key_reftype(tc, config_hash, "int_pos_ref", int_pos_ref,
                 config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_POSITIONAL);
             check_config_key_reftype(tc, config_hash, "uint_pos_ref", uint_pos_ref,
-                config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_POSITIONAL);
+                config, MVM_STORAGE_SPEC_BP_UINT64, MVM_NATIVEREF_POSITIONAL);
             check_config_key_reftype(tc, config_hash, "num_pos_ref", num_pos_ref,
                 config, MVM_STORAGE_SPEC_BP_NUM, MVM_NATIVEREF_POSITIONAL);
             check_config_key_reftype(tc, config_hash, "str_pos_ref", str_pos_ref,
@@ -165,7 +165,7 @@ MVMObject * MVM_hll_set_config(MVMThreadContext *tc, MVMString *name, MVMObject 
             check_config_key_reftype(tc, config_hash, "int_multidim_ref", int_multidim_ref,
                 config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_MULTIDIM);
             check_config_key_reftype(tc, config_hash, "uint_multidim_ref", uint_multidim_ref,
-                config, MVM_STORAGE_SPEC_BP_INT, MVM_NATIVEREF_MULTIDIM);
+                config, MVM_STORAGE_SPEC_BP_UINT64, MVM_NATIVEREF_MULTIDIM);
             check_config_key_reftype(tc, config_hash, "num_multidim_ref", num_multidim_ref,
                 config, MVM_STORAGE_SPEC_BP_NUM, MVM_NATIVEREF_MULTIDIM);
             check_config_key_reftype(tc, config_hash, "str_multidim_ref", str_multidim_ref,

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -4627,8 +4627,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(getlexref_u32):
             OP(getlexref_u16):
             OP(getlexref_u8):
-                /* XXX Cheat should have a _u here. */
-                GET_REG(cur_op, 0).o = MVM_nativeref_lex_i(tc,
+                GET_REG(cur_op, 0).o = MVM_nativeref_lex_u(tc,
                     GET_UI16(cur_op, 4), GET_UI16(cur_op, 2));
                 cur_op += 6;
                 goto NEXT;

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -307,19 +307,19 @@ static char callback_handler(DCCallback *cb, DCArgs *cb_args, DCValue *cb_result
                 num_roots++;
                 break;
             case MVM_NATIVECALL_ARG_UCHAR:
-                args[i - 1].i64 = dcbArgUChar(cb_args);
+                args[i - 1].u64 = dcbArgUChar(cb_args);
                 break;
             case MVM_NATIVECALL_ARG_USHORT:
-                args[i - 1].i64 = dcbArgUShort(cb_args);
+                args[i - 1].u64 = dcbArgUShort(cb_args);
                 break;
             case MVM_NATIVECALL_ARG_UINT:
-                args[i - 1].i64 = dcbArgUInt(cb_args);
+                args[i - 1].u64 = dcbArgUInt(cb_args);
                 break;
             case MVM_NATIVECALL_ARG_ULONG:
-                args[i - 1].i64 = dcbArgULong(cb_args);
+                args[i - 1].u64 = dcbArgULong(cb_args);
                 break;
             case MVM_NATIVECALL_ARG_ULONGLONG:
-                args[i - 1].i64 = dcbArgULongLong(cb_args);
+                args[i - 1].u64 = dcbArgULongLong(cb_args);
                 break;
             default:
                 MVM_telemetry_interval_stop(tc, interval_id, "nativecall callback handler failed");
@@ -580,19 +580,19 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                 break;
             }
             case MVM_NATIVECALL_ARG_UCHAR:
-                handle_arg("integer", cont_i, DCuchar, i64, dcArgChar, MVM_nativecall_unmarshal_uchar);
+                handle_arg("integer", cont_u, DCuchar, u64, dcArgChar, MVM_nativecall_unmarshal_uchar);
                 break;
             case MVM_NATIVECALL_ARG_USHORT:
-                handle_arg("integer", cont_i, DCushort, i64, dcArgShort, MVM_nativecall_unmarshal_ushort);
+                handle_arg("integer", cont_u, DCushort, u64, dcArgShort, MVM_nativecall_unmarshal_ushort);
                 break;
             case MVM_NATIVECALL_ARG_UINT:
-                handle_arg("integer", cont_i, DCuint, i64, dcArgInt, MVM_nativecall_unmarshal_uint);
+                handle_arg("integer", cont_u, DCuint, u64, dcArgInt, MVM_nativecall_unmarshal_uint);
                 break;
             case MVM_NATIVECALL_ARG_ULONG:
-                handle_arg("integer", cont_i, DCulong, i64, dcArgLong, MVM_nativecall_unmarshal_ulong);
+                handle_arg("integer", cont_u, DCulong, u64, dcArgLong, MVM_nativecall_unmarshal_ulong);
                 break;
             case MVM_NATIVECALL_ARG_ULONGLONG:
-                handle_arg("integer", cont_i, DCulonglong, i64, dcArgLongLong, MVM_nativecall_unmarshal_ulonglong);
+                handle_arg("integer", cont_u, DCulonglong, u64, dcArgLongLong, MVM_nativecall_unmarshal_ulonglong);
                 break;
             default:
                 MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke failed");
@@ -838,19 +838,19 @@ static void update_rws(MVMThreadContext *tc, void **free_rws, MVMint16 num_args,
                         MVM_6model_container_assign_n(tc, value, (MVMnum64)*(DCdouble *)free_rws[num_rws]);
                         break;
                     case MVM_NATIVECALL_ARG_UCHAR:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(DCuchar *)free_rws[num_rws]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(DCuchar *)free_rws[num_rws]);
                         break;
                     case MVM_NATIVECALL_ARG_USHORT:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(DCushort *)free_rws[num_rws]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(DCushort *)free_rws[num_rws]);
                         break;
                     case MVM_NATIVECALL_ARG_UINT:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(DCuint *)free_rws[num_rws]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(DCuint *)free_rws[num_rws]);
                         break;
                     case MVM_NATIVECALL_ARG_ULONG:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(DCulong *)free_rws[num_rws]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(DCulong *)free_rws[num_rws]);
                         break;
                     case MVM_NATIVECALL_ARG_ULONGLONG:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(DCulonglong *)free_rws[num_rws]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(DCulonglong *)free_rws[num_rws]);
                         break;
                     case MVM_NATIVECALL_ARG_CPOINTER:
                         REPR(value)->box_funcs.set_int(tc, STABLE(value), value, OBJECT_BODY(value),
@@ -994,19 +994,19 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                     break;
                 }
                 case MVM_NATIVECALL_ARG_UCHAR:
-                    handle_arg("integer", cont_i, DCuchar, i64, dcArgChar, MVM_nativecall_unmarshal_uchar);
+                    handle_arg("integer", cont_u, DCuchar, u64, dcArgChar, MVM_nativecall_unmarshal_uchar);
                     break;
                 case MVM_NATIVECALL_ARG_USHORT:
-                    handle_arg("integer", cont_i, DCushort, i64, dcArgShort, MVM_nativecall_unmarshal_ushort);
+                    handle_arg("integer", cont_u, DCushort, u64, dcArgShort, MVM_nativecall_unmarshal_ushort);
                     break;
                 case MVM_NATIVECALL_ARG_UINT:
-                    handle_arg("integer", cont_i, DCuint, i64, dcArgInt, MVM_nativecall_unmarshal_uint);
+                    handle_arg("integer", cont_u, DCuint, u64, dcArgInt, MVM_nativecall_unmarshal_uint);
                     break;
                 case MVM_NATIVECALL_ARG_ULONG:
-                    handle_arg("integer", cont_i, DCulong, i64, dcArgLong, MVM_nativecall_unmarshal_ulong);
+                    handle_arg("integer", cont_u, DCulong, u64, dcArgLong, MVM_nativecall_unmarshal_ulong);
                     break;
                 case MVM_NATIVECALL_ARG_ULONGLONG:
-                    handle_arg("integer", cont_i, DCulonglong, i64, dcArgLongLong, MVM_nativecall_unmarshal_ulonglong);
+                    handle_arg("integer", cont_u, DCulonglong, u64, dcArgLongLong, MVM_nativecall_unmarshal_ulonglong);
                     break;
                 default:
                     MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke failed");

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -298,19 +298,19 @@ static void callback_handler(ffi_cif *cif, void *cb_result, void **cb_args, void
                 num_roots++;
                 break;
             case MVM_NATIVECALL_ARG_UCHAR:
-                args[i - 1].i64 = *(unsigned char *)cb_args[i - 1];
+                args[i - 1].u64 = *(unsigned char *)cb_args[i - 1];
                 break;
             case MVM_NATIVECALL_ARG_USHORT:
-                args[i - 1].i64 = *(unsigned short *)cb_args[i - 1];
+                args[i - 1].u64 = *(unsigned short *)cb_args[i - 1];
                 break;
             case MVM_NATIVECALL_ARG_UINT:
-                args[i - 1].i64 = *(unsigned int *)cb_args[i - 1];
+                args[i - 1].u64 = *(unsigned int *)cb_args[i - 1];
                 break;
             case MVM_NATIVECALL_ARG_ULONG:
-                args[i - 1].i64 = *(unsigned long *)cb_args[i - 1];
+                args[i - 1].u64 = *(unsigned long *)cb_args[i - 1];
                 break;
             case MVM_NATIVECALL_ARG_ULONGLONG:
-                args[i - 1].i64 = *(unsigned long long *)cb_args[i - 1];
+                args[i - 1].u64 = *(unsigned long long *)cb_args[i - 1];
                 break;
             default:
                 MVM_telemetry_interval_stop(tc, interval_id, "nativecall callback handler failed");
@@ -595,19 +595,19 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                 *(void **)values[i] = unmarshal_callback(tc, (MVMCode *)value, body->arg_info[i]);
                 break;
             case MVM_NATIVECALL_ARG_UCHAR:
-                handle_arg("integer", cont_i, unsigned char, i64, MVM_nativecall_unmarshal_uchar);
+                handle_arg("integer", cont_u, unsigned char, u64, MVM_nativecall_unmarshal_uchar);
                 break;
             case MVM_NATIVECALL_ARG_USHORT:
-                handle_arg("integer", cont_i, unsigned short, i64, MVM_nativecall_unmarshal_ushort);
+                handle_arg("integer", cont_u, unsigned short, u64, MVM_nativecall_unmarshal_ushort);
                 break;
             case MVM_NATIVECALL_ARG_UINT:
-                handle_arg("integer", cont_i, unsigned int, i64, MVM_nativecall_unmarshal_uint);
+                handle_arg("integer", cont_u, unsigned int, u64, MVM_nativecall_unmarshal_uint);
                 break;
             case MVM_NATIVECALL_ARG_ULONG:
-                handle_arg("integer", cont_i, unsigned long, i64, MVM_nativecall_unmarshal_ulong);
+                handle_arg("integer", cont_u, unsigned long, u64, MVM_nativecall_unmarshal_ulong);
                 break;
             case MVM_NATIVECALL_ARG_ULONGLONG:
-                handle_arg("integer", cont_i, unsigned long long, i64, MVM_nativecall_unmarshal_ulonglong);
+                handle_arg("integer", cont_u, unsigned long long, u64, MVM_nativecall_unmarshal_ulonglong);
                 break;
             default:
                 MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke failed");
@@ -747,19 +747,19 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                     MVM_6model_container_assign_n(tc, value, (MVMnum64)*(double *)*(void **)values[i]);
                     break;
                 case MVM_NATIVECALL_ARG_UCHAR:
-                    MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned char *)*(void **)values[i]);
+                    MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned char *)*(void **)values[i]);
                     break;
                 case MVM_NATIVECALL_ARG_USHORT:
-                    MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned short *)*(void **)values[i]);
+                    MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned short *)*(void **)values[i]);
                     break;
                 case MVM_NATIVECALL_ARG_UINT:
-                    MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned int *)*(void **)values[i]);
+                    MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned int *)*(void **)values[i]);
                     break;
                 case MVM_NATIVECALL_ARG_ULONG:
-                    MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned long *)*(void **)values[i]);
+                    MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned long *)*(void **)values[i]);
                     break;
                 case MVM_NATIVECALL_ARG_ULONGLONG:
-                    MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned long long *)*(void **)values[i]);
+                    MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned long long *)*(void **)values[i]);
                     break;
                 case MVM_NATIVECALL_ARG_CPOINTER:
                     REPR(value)->box_funcs.set_int(tc, STABLE(value), value, OBJECT_BODY(value),
@@ -813,19 +813,19 @@ static void update_rws(MVMThreadContext *tc, void **values, MVMint16 num_args, M
                         MVM_6model_container_assign_n(tc, value, (MVMnum64)*(double *)*(void **)values[i]);
                         break;
                     case MVM_NATIVECALL_ARG_UCHAR:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned char *)*(void **)values[i]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned char *)*(void **)values[i]);
                         break;
                     case MVM_NATIVECALL_ARG_USHORT:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned short *)*(void **)values[i]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned short *)*(void **)values[i]);
                         break;
                     case MVM_NATIVECALL_ARG_UINT:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned int *)*(void **)values[i]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned int *)*(void **)values[i]);
                         break;
                     case MVM_NATIVECALL_ARG_ULONG:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned long *)*(void **)values[i]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned long *)*(void **)values[i]);
                         break;
                     case MVM_NATIVECALL_ARG_ULONGLONG:
-                        MVM_6model_container_assign_i(tc, value, (MVMint64)*(unsigned long long *)*(void **)values[i]);
+                        MVM_6model_container_assign_u(tc, value, (MVMint64)*(unsigned long long *)*(void **)values[i]);
                         break;
                     case MVM_NATIVECALL_ARG_CPOINTER:
                         REPR(value)->box_funcs.set_int(tc, STABLE(value), value, OBJECT_BODY(value),
@@ -965,19 +965,19 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                     *(void **)values[i] = unmarshal_callback(tc, (MVMCode *)value, body->arg_info[i]);
                     break;
                 case MVM_NATIVECALL_ARG_UCHAR:
-                    handle_arg("integer", cont_i, unsigned char, i64, MVM_nativecall_unmarshal_uchar);
+                    handle_arg("integer", cont_u, unsigned char, u64, MVM_nativecall_unmarshal_uchar);
                     break;
                 case MVM_NATIVECALL_ARG_USHORT:
-                    handle_arg("integer", cont_i, unsigned short, i64, MVM_nativecall_unmarshal_ushort);
+                    handle_arg("integer", cont_u, unsigned short, u64, MVM_nativecall_unmarshal_ushort);
                     break;
                 case MVM_NATIVECALL_ARG_UINT:
-                    handle_arg("integer", cont_i, unsigned int, i64, MVM_nativecall_unmarshal_uint);
+                    handle_arg("integer", cont_u, unsigned int, u64, MVM_nativecall_unmarshal_uint);
                     break;
                 case MVM_NATIVECALL_ARG_ULONG:
-                    handle_arg("integer", cont_i, unsigned long, i64, MVM_nativecall_unmarshal_ulong);
+                    handle_arg("integer", cont_u, unsigned long, u64, MVM_nativecall_unmarshal_ulong);
                     break;
                 case MVM_NATIVECALL_ARG_ULONGLONG:
-                    handle_arg("integer", cont_i, unsigned long long, i64, MVM_nativecall_unmarshal_ulonglong);
+                    handle_arg("integer", cont_u, unsigned long long, u64, MVM_nativecall_unmarshal_ulonglong);
                     break;
                 default:
                     MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke failed");

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -373,7 +373,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_getsignals: return MVM_io_get_signals;
     case MVM_OP_sleep: return MVM_platform_sleep;
     case MVM_OP_getlexref_i32: case MVM_OP_getlexref_i16: case MVM_OP_getlexref_i8: case MVM_OP_getlexref_i: return MVM_nativeref_lex_i;
-    case MVM_OP_getlexref_u32: case MVM_OP_getlexref_u16: case MVM_OP_getlexref_u8: case MVM_OP_getlexref_u: return MVM_nativeref_lex_i;
+    case MVM_OP_getlexref_u32: case MVM_OP_getlexref_u16: case MVM_OP_getlexref_u8: case MVM_OP_getlexref_u: return MVM_nativeref_lex_u;
     case MVM_OP_getlexref_n32: case MVM_OP_getlexref_n: return MVM_nativeref_lex_n;
     case MVM_OP_getlexref_s: return MVM_nativeref_lex_s;
     case MVM_OP_getattrref_i: return MVM_nativeref_attr_i;

--- a/src/spesh/args.c
+++ b/src/spesh/args.c
@@ -478,7 +478,7 @@ void MVM_spesh_args(MVMThreadContext *tc, MVMSpeshGraph *g, MVMCallsite *cs,
                 case MVM_OP_param_op_u:
                     if (arg_type != MVM_CALLSITE_ARG_UINT)
                         if (arg_type != MVM_CALLSITE_ARG_OBJ ||
-                                !cmp_prim_spec(tc, type_tuple, i, MVM_STORAGE_SPEC_BP_INT)) {
+                                !cmp_prim_spec(tc, type_tuple, i, MVM_STORAGE_SPEC_BP_UINT64)) {
                             MVM_spesh_graph_add_comment(tc, g, pos_ins[i],
                                     "bailed argument spesh: expected arg flag %ld to be int or box an int; type at position was %s", i, type_tuple && type_tuple[i].type ? MVM_6model_get_debug_name(tc, type_tuple[i].type) : "null type tuple");
                             goto cleanup;


### PR DESCRIPTION
This is the final round of unsigned fixes that gets us into a stable situation again. It switches over to treating unsigneds as such by giving them their own objprimspec (10). This requires appropriate changes in NQP and Rakudo contained in similarily named branches in their respective repos.