### PR TITLE
Use libc allocator functions for NativeCall

### DIFF
--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -111,7 +111,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
     if (!repr_data)
         MVM_exception_throw_adhoc(tc, "CArray type must be composed before use");
 
-    body->storage = MVM_calloc(4, repr_data->elem_size);
+    body->storage = calloc(4, repr_data->elem_size);
     body->managed = 1;
 
     /* Don't need child_objs for numerics. */
@@ -132,7 +132,7 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
 
     if (src_body->managed) {
         MVMint32 alsize = src_body->allocated * repr_data->elem_size;
-        dest_body->storage = MVM_malloc(alsize);
+        dest_body->storage = malloc(alsize);
         memcpy(dest_body->storage, src_body->storage, alsize);
     }
     else {
@@ -156,7 +156,7 @@ static void gc_cleanup(MVMThreadContext *tc, MVMSTable *st, void *data) {
                 MVM_free( ((void **)body->storage)[i] );
             }
         }
-        MVM_free(body->storage);
+        free(body->storage);
     }
     if (body->child_objs)
         MVM_free(body->child_objs);
@@ -225,7 +225,7 @@ static void expand(MVMThreadContext *tc, MVMCArrayREPRData *repr_data, MVMCArray
         const size_t old_size = body->allocated * repr_data->elem_size;
         const size_t new_size = next_size * repr_data->elem_size;
 
-        body->storage = MVM_recalloc(body->storage, old_size, new_size);
+        body->storage = recalloc(body->storage, old_size, new_size);
     }
 
     is_complex = (repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_CARRAY

--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -225,7 +225,8 @@ static void expand(MVMThreadContext *tc, MVMCArrayREPRData *repr_data, MVMCArray
         const size_t old_size = body->allocated * repr_data->elem_size;
         const size_t new_size = next_size * repr_data->elem_size;
 
-        body->storage = recalloc(body->storage, old_size, new_size);
+        body->storage = realloc(body->storage, new_size);
+        memset((char *)body->storage + old_size, 0, new_size - old_size);
     }
 
     is_complex = (repr_data->elem_kind == MVM_CARRAY_ELEM_KIND_CARRAY

--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -404,7 +404,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
 
     /* Allocate object body. */
     MVMCPPStructBody *body = (MVMCPPStructBody *)data;
-    body->cppstruct = MVM_calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
+    body->cppstruct = calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
 
     /* Allocate child obj array. */
     if (repr_data->num_child_objs > 0)
@@ -416,7 +416,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
         MVMint32 i;
         for (i = 0; repr_data->initialize_slots[i] >= 0; i++) {
             MVMint32  offset = repr_data->struct_offsets[repr_data->initialize_slots[i]];
-            MVMSTable *st     = repr_data->flattened_stables[repr_data->initialize_slots[i]];
+            MVMSTable *st    = repr_data->flattened_stables[repr_data->initialize_slots[i]];
             st->REPR->initialize(tc, st, root, (char *)body->cppstruct + offset);
         }
     }
@@ -757,7 +757,7 @@ static void gc_cleanup(MVMThreadContext *tc, MVMSTable *st, void *data) {
     /* XXX For some reason, this causes crashes at the moment. Need to
      * work out why. */
     /*if (body->cppstruct)
-        MVM_free(body->cppstruct);*/
+        free(body->cppstruct);*/
 }
 
 /* Called by the VM in order to free memory associated with this object. */

--- a/src/6model/reprs/CStr.c
+++ b/src/6model/reprs/CStr.c
@@ -78,9 +78,10 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
 
     char *mvm_allocated_cstr  = MVM_string_utf8_encode_C_string(tc, orig);
 #ifdef MVM_USE_MIMALLOC
-    char *libc_allocated_cstr = malloc(strlen(mvm_allocated_cstr) + 1);
     /* Safe because MVM_string_utf8_encode_C_string is guaranteed to return a null-terminated string */
-    strcpy(libc_allocated_cstr, mvm_allocated_cstr);
+    size_t cstr_len = strlen(mvm_allocated_cstr) + 1;
+    char *libc_allocated_cstr = malloc(cstr_len);
+    memcpy(libc_allocated_cstr, mvm_allocated_cstr, cstr_len);
     MVM_free(mvm_allocated_cstr);
 
     body->cstr = libc_allocated_cstr;

--- a/src/6model/reprs/CStr.c
+++ b/src/6model/reprs/CStr.c
@@ -64,7 +64,7 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMCStr *cstr = (MVMCStr *)obj;
     if (obj && cstr->body.cstr)
-        MVM_free(cstr->body.cstr);
+        free(cstr->body.cstr);
 }
 
 static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
@@ -75,7 +75,18 @@ static void deserialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, vo
     MVMString *orig = MVM_serialization_read_str(tc, reader);
     MVMCStrBody *body = (MVMCStrBody *)data;
     MVM_ASSIGN_REF(tc, &(root->header), body->orig, orig);
-    body->cstr = MVM_string_utf8_encode_C_string(tc, orig);
+
+    char *mvm_allocated_cstr  = MVM_string_utf8_encode_C_string(tc, orig);
+#ifdef MVM_USE_MIMALLOC
+    char *libc_allocated_cstr = malloc(strlen(mvm_allocated_cstr) + 1);
+    /* Safe because MVM_string_utf8_encode_C_string is guaranteed to return a null-terminated string */
+    strcpy(libc_allocated_cstr, mvm_allocated_cstr);
+    MVM_free(mvm_allocated_cstr);
+
+    body->cstr = libc_allocated_cstr;
+#else
+    body->cstr = mvm_allocated_cstr;
+#endif
 }
 
 static void serialize(MVMThreadContext *tc, MVMSTable *st, void *data, MVMSerializationWriter *writer) {

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -422,7 +422,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
 
     /* Allocate object body. */
     MVMCStructBody *body = (MVMCStructBody *)data;
-    body->cstruct = MVM_calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
+    body->cstruct = calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
 
     /* Allocate child obj array. */
     if (repr_data->num_child_objs > 0)
@@ -797,7 +797,7 @@ static void gc_cleanup(MVMThreadContext *tc, MVMSTable *st, void *data) {
     /* XXX For some reason, this causes crashes at the moment. Need to
      * work out why. */
     /*if (body->cstruct)
-        MVM_free(body->cstruct);*/
+        free(body->cstruct);*/
 }
 
 /* Called by the VM in order to free memory associated with this object. */
@@ -820,7 +820,7 @@ static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data)
     MVMCStructREPRData *repr_data = (MVMCStructREPRData *)st->REPR_data;
     MVMuint64 result = 0;
 
-    /* The allocated (or just-poisted-at) memory block */
+    /* The allocated (or just-pointed-at) memory block */
     /* TODO make sure when structs properly track "ownership" to
      *      not add this for "child" structs */
     result += repr_data->struct_size;

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -360,7 +360,7 @@ static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, voi
 
     /* Allocate object body. */
     MVMCUnionBody *body = (MVMCUnionBody *)data;
-    body->cunion = MVM_calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
+    body->cunion = calloc(1, repr_data->struct_size > 0 ? repr_data->struct_size : 1);
 
     /* Allocate child obj array. */
     if (repr_data->num_child_objs > 0)
@@ -705,7 +705,7 @@ static void gc_cleanup(MVMThreadContext *tc, MVMSTable *st, void *data) {
     /* XXX For some reason, this causes crashes at the moment. Need to
      * work out why. */
     /*if (body->cunion)
-        MVM_free(body->cunion);*/
+        free(body->cunion);*/
 }
 
 /* Called by the VM in order to free memory associated with this object. */

--- a/src/core/alloc.h
+++ b/src/core/alloc.h
@@ -37,23 +37,6 @@ MVM_STATIC_INLINE void * MVM_realloc(void *p, size_t size) {
     return ptr;
 }
 
-/* This doesn't use any mimalloc functions because it's for use in NativeCall
- * code, where modules may be freeing or allocating memory and wouldn't be 
- * using mimalloc. */
-MVM_STATIC_INLINE void * recalloc(void *p, size_t old_size, size_t size) {
-    void *ptr = realloc(p, size);
-
-    if (size > 0) {
-        if (!ptr)
-            MVM_panic_allocation_failed(size);
-
-        if (size > old_size)
-            memset((char *)ptr + old_size, 0, size - old_size);
-    }
-
-    return ptr;
-}
-
 MVM_STATIC_INLINE void * MVM_recalloc(void *p, size_t old_size, size_t size) {
 #ifdef MVM_USE_MIMALLOC
     void *ptr = mi_realloc(p, size);

--- a/src/core/alloc.h
+++ b/src/core/alloc.h
@@ -37,6 +37,23 @@ MVM_STATIC_INLINE void * MVM_realloc(void *p, size_t size) {
     return ptr;
 }
 
+/* This doesn't use any mimalloc functions because it's for use in NativeCall
+ * code, where modules may be freeing or allocating memory and wouldn't be 
+ * using mimalloc. */
+MVM_STATIC_INLINE void * recalloc(void *p, size_t old_size, size_t size) {
+    void *ptr = realloc(p, size);
+
+    if (size > 0) {
+        if (!ptr)
+            MVM_panic_allocation_failed(size);
+
+        if (size > old_size)
+            memset((char *)ptr + old_size, 0, size - old_size);
+    }
+
+    return ptr;
+}
+
 MVM_STATIC_INLINE void * MVM_recalloc(void *p, size_t old_size, size_t size) {
 #ifdef MVM_USE_MIMALLOC
     void *ptr = mi_realloc(p, size);

--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -299,6 +299,13 @@ char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, M
                 str = MVM_string_utf8_encode_C_string(tc, value_str);
         }
 
+#ifdef MVM_USE_MIMALLOC
+        size_t str_len = strlen(str) + 1;
+        char *libc_str = malloc(str_len);
+        memcpy(libc_str, str, str_len);
+        MVM_free(str);
+#endif
+
         /* Set whether to free it or not. */
         if (free) {
             if (REPR(value)->ID == MVM_REPR_ID_MVMCStr)
@@ -309,7 +316,11 @@ char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, M
                 *free = 0;
         }
 
+#ifdef MVM_USE_MIMALLOC
+        return libc_str;
+#else
         return str;
+#endif
     }
     else {
         return NULL;

--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -290,16 +290,7 @@ char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, M
         char *str;
         switch (type & MVM_NATIVECALL_ARG_TYPE_MASK) {
             case MVM_NATIVECALL_ARG_ASCIISTR:
-                str = MVM_string_ascii_encode_any(tc, value_str);
-#ifdef MVM_USE_MIMALLOC
-                {
-                    size_t str_len = strlen(str) + 1;
-                    char *libc_str = malloc(str_len);
-                    memcpy(libc_str, str, str_len);
-                    MVM_free(str);
-                    str = libc_str;
-                }
-#endif
+                str = MVM_string_ascii_encode_malloc(tc, value_str);
                 break;
             case MVM_NATIVECALL_ARG_UTF16STR:
                 str = MVM_string_utf16_encode(tc, value_str, 0);

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -800,7 +800,11 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
     /* Free any memory that we need to. */
     if (free_strs)
         for (i = 0; i < num_strs; i++)
+#ifdef MVM_USE_MIMALLOC
+            free(free_strs[i]);
+#else
             MVM_free(free_strs[i]);
+#endif
 
     /* Finally, free call VM. */
     dcFree(vm);

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -777,7 +777,11 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
     /* Free any memory that we need to. */
     if (free_strs)
         for (i = 0; i < num_strs; i++)
+#ifdef MVM_USE_MIMALLOC
+            free(free_strs[i]);
+#else
             MVM_free(free_strs[i]);
+#endif
 
     MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke");
 

--- a/src/strings/ascii.h
+++ b/src/strings/ascii.h
@@ -4,3 +4,4 @@ MVM_PUBLIC MVMuint32 MVM_string_ascii_decodestream(MVMThreadContext *tc, MVMDeco
 MVM_PUBLIC char * MVM_string_ascii_encode_substr(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length, MVMString *replacement, MVMint32 translate_newlines);
 MVM_PUBLIC char * MVM_string_ascii_encode(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size, MVMint32 translate_newlines);
 char * MVM_string_ascii_encode_any(MVMThreadContext *tc, MVMString *str);
+char * MVM_string_ascii_encode_malloc(MVMThreadContext *tc, MVMString *str);

--- a/src/strings/utf8.h
+++ b/src/strings/utf8.h
@@ -5,5 +5,6 @@ MVM_PUBLIC char * MVM_string_utf8_encode_substr(MVMThreadContext *tc,
         MVMString *str, MVMuint64 *output_size, MVMint64 start, MVMint64 length, MVMString *replacement, MVMint32 translate_newlines);
 MVM_PUBLIC char * MVM_string_utf8_encode(MVMThreadContext *tc, MVMString *str, MVMuint64 *output_size, MVMint32 translate_newlines);
 MVM_PUBLIC char * MVM_string_utf8_encode_C_string(MVMThreadContext *tc, MVMString *str);
+MVM_PUBLIC char * MVM_string_utf8_encode_C_string_malloc(MVMThreadContext *tc, MVMString *str);
 char * MVM_string_utf8_maybe_encode_C_string(MVMThreadContext *tc, MVMString *str);
 void MVM_string_utf8_throw_encoding_exception (MVMThreadContext *tc, MVMCodepoint cp);


### PR DESCRIPTION
Because the memory could be passed to a module and freed there, we can't
use the `MVM_*` functions because those could be using a different
allocator (e.g., mimalloc as is the new default build configuration). In
cases where we can't specifiy the function to use, we instead explicitly
allocate another chunk of memory with libc functions, copy what we
originally got into it, then free the original version.