### PR TITLE
Jit iscont_u, missed in the recent uint work

### DIFF
--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -2495,6 +2495,12 @@
       (carg (tc) ptr)
       (carg $1 ptr)) int_sz))
 
+(template: iscont_u
+  (call (^func MVM_6model_container_iscont_u)
+    (arglist
+      (carg (tc) ptr)
+      (carg $1 ptr)) int_sz))
+
 (template: decont_s!
   (callv (^func &MVM_6model_container_decont_s)
     (arglist

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -359,6 +359,7 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_iscont_i: return MVM_6model_container_iscont_i;
     case MVM_OP_iscont_n: return MVM_6model_container_iscont_n;
     case MVM_OP_iscont_s: return MVM_6model_container_iscont_s;
+    case MVM_OP_iscont_u: return MVM_6model_container_iscont_u;
     case MVM_OP_isrwcont: return MVM_6model_container_iscont_rw;
     case MVM_OP_assign_i: return MVM_6model_container_assign_i;
     case MVM_OP_assign_n: return MVM_6model_container_assign_n;


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`. No longer causing bails in a random spesh log I was looking at.