### PR TITLE
Fix segfault in nqp::hllboolfor

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -5084,11 +5084,17 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(hllboolfor): {
-                MVMString   *hll     = GET_REG(cur_op, 4).s;
-                MVMHLLConfig *config = MVM_hll_get_config_for(tc, hll);
-                GET_REG(cur_op, 0).o = GET_REG(cur_op, 2).i64
+                MVMString    *hll     = GET_REG(cur_op, 4).s;
+                MVMHLLConfig *config  = MVM_hll_get_config_for(tc, hll);
+                MVMObject *bool_value = GET_REG(cur_op, 2).i64
                     ? config->true_value
                     : config->false_value;
+                if (!bool_value) {
+                    char *c_hll = MVM_string_utf8_encode_C_string(tc, hll);
+                    char *waste[] = { c_hll, NULL };
+                    MVM_exception_throw_adhoc_free(tc, waste, "Trying to hllboolfor a value, but '%s' doesn't have HLL bools", c_hll);
+                }
+                GET_REG(cur_op, 0).o = bool_value;
                 cur_op += 6;
                 goto NEXT;
             }


### PR DESCRIPTION
It currently doesn't check whether the fields it needs are present in
the HLLConfig returned from MVM_hll_get_config_for, which is fine because
all the names it's usually called with have existing and populated
HLLConfigs. But MVM_hll_get_config_for will create and return a mostly empty
HLLConfig if it *didn't* already exist for the given HLL name. So check and
throw an exception if the fields we need aren't populated.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`. Fixes https://github.com/Raku/nqp/issues/619, the given example now throws with `Trying to hllboolfor a value, but 'tcl' doesn't have HLL bools`.