### PR TITLE
Inline ascii ctype

### DIFF
--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -1,6 +1,5 @@
 #include "moar.h"
 #include "ryu/ryu.h"
-#include <ctype.h>
 
 #if defined(_MSC_VER)
 #define strtoll _strtoi64
@@ -395,7 +394,8 @@ MVMint64 MVM_coerce_s_i(MVMThreadContext *tc, MVMString *str) {
              * They all return 0, and we don't need to optimise their handling,
              * so we simply drop through into the rest of the code with c == ' '
              * for them. */
-        } while (i != strgraphs && isspace(c));
+            /* isspace(...) is any of "\t\n\v\f\r ", ie [9 .. 13, 32] */
+        } while (i != strgraphs && (c == ' ' || (c >= '\t' && c <= '\r')));
 
         /* `i` counts how many octets we have read. Hence `i == strgraphs` at
          * the point where `c` holds the final ASCII character of the string,
@@ -416,7 +416,7 @@ MVMint64 MVM_coerce_s_i(MVMThreadContext *tc, MVMString *str) {
         cutoff /= (unsigned long long)10;
 
         while (1) {
-            if (isdigit(c))
+            if (c >= '0' && c <= '9')
                 c -= '0';
             else
                 break;
@@ -445,7 +445,7 @@ MVMint64 MVM_coerce_s_i(MVMThreadContext *tc, MVMString *str) {
 
         do {
             ord = MVM_string_ci_get_codepoint(tc, &ci);
-        } while (isspace(ord) && MVM_string_ci_has_more(tc, &ci));
+        } while ((ord == ' ' || (ord >= '\t' && ord <= '\r')) && MVM_string_ci_has_more(tc, &ci));
 
         if (ord == '-') {
             negative = 1;
@@ -464,7 +464,7 @@ MVMint64 MVM_coerce_s_i(MVMThreadContext *tc, MVMString *str) {
         cutoff /= (unsigned long long)10;
 
         while (1) {
-            if (isdigit(ord))
+            if (ord >= '0' && ord <= '9')
                 ord -= '0';
             else
                 break;


### PR DESCRIPTION
The first commit eliminates some new regressions for corner cases. For example, currently on master we have:

```
$ ./nqp-m -e 'nqp::say(nqp::coerce_si("-"));'
Iteration past end of grapheme iterator
   at -e:1  (<ephemeral file>:<mainline>)
 from gen/moar/stage2/NQPHLL.nqp:1949  (/home/nick/Perl/nqp/NQPHLL.moarvm:eval)
 from gen/moar/stage2/NQPHLL.nqp:2059  (/home/nick/Perl/nqp/NQPHLL.moarvm:)
 from gen/moar/stage2/NQPHLL.nqp:2114  (/home/nick/Perl/nqp/NQPHLL.moarvm:command_eval)
 from gen/moar/stage2/NQPHLL.nqp:2039  (/home/nick/Perl/nqp/NQPHLL.moarvm:command_line)
 from gen/moar/stage2/NQP.nqp:4111  (nqp.moarvm:MAIN)
 from gen/moar/stage2/NQP.nqp:1  (nqp.moarvm:<mainline>)
 from <unknown>:1  (nqp.moarvm:<main>)
 from <unknown>:1  (nqp.moarvm:<entry>)
```

whereas for all releases we have:

```
$ ./nqp-m -e 'nqp::say(nqp::coerce_si("-"));'
0
```

I doubt that anything is depending on **this** exact behaviour, but I think that there were some other (harder to test) corner cases which might have become off-the-end reads in the ASCII specific code in commit b80996fff3edbdd06f3d24cd02a022770e338035

The second commit eliminates the dependency on `<ctype.h>` and instead directly codes the ASCII locale implementation of `isspace` and `isdigit`.

With these changes nqp-m passes all the tests proposed in Raku/nqp#759