### PR TITLE
Fix segfault after capture-replace-literal-arg with different kind

### DIFF
--- a/src/6model/reprs/MVMCapture.c
+++ b/src/6model/reprs/MVMCapture.c
@@ -465,7 +465,10 @@ MVMObject * MVM_capture_replace_arg(MVMThreadContext *tc, MVMObject *capture_obj
      * The callsite MUST be created after we allocated as it may contain named
      * arguments, i.e. contain pointers to strings which wouldn't get marked. */
     MVMCallsite *callsite = capture->body.callsite;
-    MVMCallsite *new_callsite = MVM_callsite_replace_positional(tc, capture->body.callsite, idx, kind);
+    if ((callsite->arg_flags[idx] & MVM_CALLSITE_ARG_TYPE_MASK) != kind)
+        MVM_exception_throw_adhoc(tc, "Cannot replace capture argument with different kind %d -> %d", callsite->arg_flags[idx], kind);
+
+    MVMCallsite *new_callsite = MVM_callsite_replace_positional(tc, callsite, idx, kind);
     new_callsite->arg_flags[idx] = kind;
 
     /* Form a new arguments buffer, replacing the specified argument. */


### PR DESCRIPTION
A comment above MVM_capture_replace_arg already said: "The callsite argument
type is expected to be the same". Sadly comments are easy to miss and when
arguments are replaced with values of different kinds, we can end up with e.g.
a literal number for a callsite argument with kind obj and may try to
dereference what we wrongly believe to be a pointer.

Fix by actually enforcing this rule. Fixes the segfault reported in GH #1656