### PR TITLE
Bump the mimiumum support serialization format to 23.

### DIFF
--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -493,19 +493,9 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
 static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
     MVMCArrayREPRData *repr_data = (MVMCArrayREPRData *) MVM_malloc(sizeof(MVMCArrayREPRData));
 
-    if (reader->root.version >= 19) {
-        repr_data->elem_size = MVM_serialization_read_int(tc, reader);
-    } else {
-        repr_data->elem_size = MVM_serialization_read_int64(tc, reader);
-    }
-
+    repr_data->elem_size = MVM_serialization_read_int(tc, reader);
     repr_data->elem_type = MVM_serialization_read_ref(tc, reader);
-
-    if (reader->root.version >= 19) {
-        repr_data->elem_kind = MVM_serialization_read_int(tc, reader);
-    } else {
-        repr_data->elem_kind = MVM_serialization_read_int64(tc, reader);
-    }
+    repr_data->elem_kind = MVM_serialization_read_int(tc, reader);
 
     st->REPR_data = repr_data;
 }

--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -825,9 +825,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMint32 i, num_classes, num_slots;
 
     repr_data->struct_size    = MVM_serialization_read_int(tc, reader);
-    if (reader->root.version >= 17) {
-        repr_data->struct_align = MVM_serialization_read_int(tc, reader);
-    }
+    repr_data->struct_align   = MVM_serialization_read_int(tc, reader);
     repr_data->num_attributes = MVM_serialization_read_int(tc, reader);
     repr_data->num_child_objs = MVM_serialization_read_int(tc, reader);
 

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -882,9 +882,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMint32 i, num_classes, num_slots;
 
     repr_data->struct_size = MVM_serialization_read_int(tc, reader);
-    if (reader->root.version >= 17) {
-        repr_data->struct_align = MVM_serialization_read_int(tc, reader);
-    }
+    repr_data->struct_align = MVM_serialization_read_int(tc, reader);
     repr_data->num_attributes = MVM_serialization_read_int(tc, reader);
     repr_data->num_child_objs = MVM_serialization_read_int(tc, reader);
 

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -773,9 +773,7 @@ static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerial
     MVMint32 i, num_classes, num_slots;
 
     repr_data->struct_size = MVM_serialization_read_int(tc, reader);
-    if (reader->root.version >= 17) {
-        repr_data->struct_align = MVM_serialization_read_int(tc, reader);
-    }
+    repr_data->struct_align = MVM_serialization_read_int(tc, reader);
     repr_data->num_attributes = MVM_serialization_read_int(tc, reader);
     repr_data->num_child_objs = MVM_serialization_read_int(tc, reader);
 

--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -451,11 +451,7 @@ static void serialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializ
 static void deserialize_repr_data(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
     MVMint64 num_dims;
 
-    if (reader->root.version >= 19) {
-        num_dims = MVM_serialization_read_int(tc, reader);
-    } else {
-        num_dims = MVM_serialization_read_int64(tc, reader);
-    }
+    num_dims = MVM_serialization_read_int(tc, reader);
 
     if (num_dims > 0) {
         MVMMultiDimArrayREPRData *repr_data = (MVMMultiDimArrayREPRData *)MVM_malloc(sizeof(MVMMultiDimArrayREPRData));


### PR DESCRIPTION
Remove all code for serialization versions earlier than 23, and bytecode versions earlier than 7

Code compiled with earlier versions assumes "old" dispatch, meaning that the ops it needs will now throw exceptions.
