### PR TITLE
Serialize bigints in base 32, not base 10

### DIFF
--- a/src/6model/serialization.c
+++ b/src/6model/serialization.c
@@ -10,7 +10,7 @@
 
 /* Version of the serialization format that we are currently at and lowest
  * version we support. */
-#define CURRENT_VERSION 24
+#define CURRENT_VERSION 25
 #define MIN_VERSION     23
 
 /* Various sizes (in bytes). */


### PR DESCRIPTION
A work in progress, but posted as I'd like to avoid duplication of effort

Todo

1) thorough tests
2) benchmarks
3) the Java version (in the nqp repository)
4) remove that assertion
