### PR TITLE
Make rakudo available on the GNU Hurd

### DIFF
--- a/src/io/dirops.c
+++ b/src/io/dirops.c
@@ -9,6 +9,10 @@
 #  define IS_SLASH(c)     ((c) == '/')
 #endif
 
+#ifndef PATH_MAX
+#  define PATH_MAX 2048
+#endif
+
 #ifdef _WIN32
 static wchar_t * UTF8ToUnicode(char *str)
 {

--- a/src/platform/posix/time.c
+++ b/src/platform/posix/time.c
@@ -4,7 +4,7 @@
 #include <errno.h>
 #include <sys/time.h>
 
-#ifdef __MACH__
+#if defined(__APPLE__) && defined(__MACH__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
@@ -14,7 +14,7 @@
 
 MVMuint64 MVM_platform_now(void)
 {
-#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+#if defined(__APPLE__) && defined(__MACH__) // OS X does not have clock_gettime, use clock_get_time
     clock_serv_t    cclock;
     mach_timespec_t ts;
     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);

--- a/src/platform/random.c
+++ b/src/platform/random.c
@@ -11,7 +11,7 @@
     #endif
 #endif
 /* Linux added getrandom to the kernel in 3.17 */
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__)
     #include <sys/syscall.h>
     #if defined(SYS_getrandom)
     /* With glibc you are supposed to declare _GNU_SOURCE to use the
@@ -78,7 +78,7 @@
             /* If using /dev/urandom fails (maybe we're in a chroot), on BSD's
              * use arc4random, which is likely seeded from the system's random
              * number generator */
-            #if defined(BSD)
+            #if defined(BSD) && !defined(__GNU__)
                 #include <stdlib.h>
                 arc4random_buf(out, size);
                 return 1;


### PR DESCRIPTION
It currently needs a libuv patch available at 

https://github.com/libuv/libuv/pull/3450

It works:
```
# raku
Welcome to Rakudo™ v2021.12.
Implementing the Raku® Programming Language v6.d.
Built on MoarVM version 2021.12.

You may want to `zef install Readline`, `zef install Linenoise`, or `zef install Terminal::LineEditor` or use rlwrap for a line editor

To exit type 'exit' or '^D'
> $*KERNEL
gnu
>
```