### PR TITLE
Remove temporary define for migrating Rakudo extops

### DIFF
--- a/src/core/callstack.h
+++ b/src/core/callstack.h
@@ -507,6 +507,3 @@ MVM_STATIC_INLINE MVMCallStackRecord * MVM_callstack_prev_significant_record(
         prev = prev->prev;
     return prev;
 }
-
-/* Migration to callstack-based special return in Rakudo extops. */
-#define MVM_CALLSTACK_SPECIAL_RETURN 1


### PR DESCRIPTION
This reverts commit 776a1e3c622b0ab0 which is no longer needed, as the C code in Rakudo was updated as part of commit rakudo/rakudo@969ae326d9bca4e4