### PR TITLE
Fix potential invalid free in nativecall

### DIFF
--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -282,50 +282,47 @@ double MVM_nativecall_unmarshal_double(MVMThreadContext *tc, MVMObject *value) {
     return (double)MVM_repr_get_num(tc, value);
 }
 
+char * MVM_nativecall_encode_string(MVMThreadContext *tc, MVMString *value_str, MVMint16 type, MVMint16 *free, MVMint16 unmarshal_kind, const MVMREPROps *repr) {
+    /* Encode string. */
+    char *str;
+    switch (type & MVM_NATIVECALL_ARG_TYPE_MASK) {
+        case MVM_NATIVECALL_ARG_ASCIISTR:
+            str = MVM_string_ascii_encode_malloc(tc, value_str);
+            break;
+        case MVM_NATIVECALL_ARG_UTF16STR:
+        {
+            MVMuint64 output_size;
+            /* This adds a (two byte) U-0000 at the end, but doesn't include
+             * that code point in the returned output_size. */
+            char *temp = MVM_string_utf16_encode_substr(tc, value_str, &output_size, 0, -1, NULL, 0);
+            /* output_size is in 2 byte units, and doesn't include the
+             * terminating U-0000, which was written. */
+            size_t octet_len = 2 * (output_size + 1);
+            str = malloc(octet_len);
+            memcpy(str, temp, octet_len);
+            MVM_free(temp);
+            break;
+        }
+        default:
+            str = MVM_string_utf8_encode_C_string_malloc(tc, value_str);
+    }
+
+
+    /* Set whether to free it or not. */
+    if (free) {
+        if (repr->ID == MVM_REPR_ID_MVMCStr)
+            *free = 0; /* Manually managed. */
+        else if (type & MVM_NATIVECALL_ARG_FREE_STR_MASK)
+            *free = 1;
+        else
+            *free = 0;
+    }
+
+    return str;
+}
+
 char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, MVMint16 type, MVMint16 *free, MVMint16 unmarshal_kind) {
-    if (IS_CONCRETE(value)) {
-        MVMString *value_str = MVM_repr_get_str(tc, value);
-
-        /* Encode string. */
-        char *str;
-        switch (type & MVM_NATIVECALL_ARG_TYPE_MASK) {
-            case MVM_NATIVECALL_ARG_ASCIISTR:
-                str = MVM_string_ascii_encode_malloc(tc, value_str);
-                break;
-            case MVM_NATIVECALL_ARG_UTF16STR:
-            {
-                MVMuint64 output_size;
-                /* This adds a (two byte) U-0000 at the end, but doesn't include
-                 * that code point in the returned output_size. */
-                char *temp = MVM_string_utf16_encode_substr(tc, value_str, &output_size, 0, -1, NULL, 0);
-                /* output_size is in 2 byte units, and doesn't include the
-                 * terminating U-0000, which was written. */
-                size_t octet_len = 2 * (output_size + 1);
-                str = malloc(octet_len);
-                memcpy(str, temp, octet_len);
-                MVM_free(temp);
-                break;
-            }
-            default:
-                str = MVM_string_utf8_encode_C_string_malloc(tc, value_str);
-        }
-
-
-        /* Set whether to free it or not. */
-        if (free) {
-            if (REPR(value)->ID == MVM_REPR_ID_MVMCStr)
-                *free = 0; /* Manually managed. */
-            else if (free && type & MVM_NATIVECALL_ARG_FREE_STR_MASK)
-                *free = 1;
-            else
-                *free = 0;
-        }
-
-        return str;
-    }
-    else {
-        return NULL;
-    }
+    return IS_CONCRETE(value) ? MVM_nativecall_encode_string(tc, MVM_repr_get_str(tc, value), type, free, unmarshal_kind, REPR(value)) : NULL;
 }
 
 MVM_NO_RETURN static void unmarshal_error(MVMThreadContext *tc, char *desired_repr, MVMObject *value, MVMint16 unmarshal_kind) MVM_NO_RETURN_ATTRIBUTE;

--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -322,7 +322,9 @@ char * MVM_nativecall_encode_string(MVMThreadContext *tc, MVMString *value_str, 
 }
 
 char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, MVMint16 type, MVMint16 *free, MVMint16 unmarshal_kind) {
-    return IS_CONCRETE(value) ? MVM_nativecall_encode_string(tc, MVM_repr_get_str(tc, value), type, free, unmarshal_kind, REPR(value)) : NULL;
+    return IS_CONCRETE(value)
+        ? MVM_nativecall_encode_string(tc, MVM_repr_get_str(tc, value), type, free, unmarshal_kind, REPR(value))
+        : NULL;
 }
 
 MVM_NO_RETURN static void unmarshal_error(MVMThreadContext *tc, char *desired_repr, MVMObject *value, MVMint16 unmarshal_kind) MVM_NO_RETURN_ATTRIBUTE;

--- a/src/core/nativecall.h
+++ b/src/core/nativecall.h
@@ -129,6 +129,7 @@ unsigned long long  MVM_nativecall_unmarshal_ulonglong(MVMThreadContext *tc, MVM
 float               MVM_nativecall_unmarshal_float(MVMThreadContext *tc, MVMObject *value);
 double              MVM_nativecall_unmarshal_double(MVMThreadContext *tc, MVMObject *value);
 
+char * MVM_nativecall_encode_string(MVMThreadContext *tc, MVMString *value_str, MVMint16 type, MVMint16 *free, MVMint16 unmarshal_kind, const MVMREPROps *repr);
 char * MVM_nativecall_unmarshal_string(MVMThreadContext *tc, MVMObject *value, MVMint16 type, MVMint16 *free, MVMint16 unmarshal_kind);
 void * MVM_nativecall_unmarshal_cstruct(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);
 void * MVM_nativecall_unmarshal_cppstruct(MVMThreadContext *tc, MVMObject *value, MVMint16 unmarshal_kind);

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -1292,7 +1292,11 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
     /* Free any memory that we need to. */
     if (free_strs)
         for (i = 0; i < num_strs; i++)
+#ifdef MVM_USE_MIMALLOC
+            free(free_strs[i]);
+#else
             MVM_free(free_strs[i]);
+#endif
 
     /* Finally, free call VM. */
     dcFree(vm);

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -1086,18 +1086,9 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                 case MVM_NATIVECALL_ARG_UTF8STR:
                 case MVM_NATIVECALL_ARG_UTF16STR:
                     {
-                        char *str;
-                        switch (arg_types[i] & MVM_NATIVECALL_ARG_TYPE_MASK) {
-                            case MVM_NATIVECALL_ARG_ASCIISTR:
-                                str = MVM_string_ascii_encode_any(tc, value);
-                                break;
-                            case MVM_NATIVECALL_ARG_UTF16STR:
-                                str = MVM_string_utf16_encode(tc, value, 0);
-                                break;
-                            default:
-                                str = MVM_string_utf8_encode_C_string(tc, value);
-                        }
-                        if (arg_types[i] & MVM_NATIVECALL_ARG_FREE_STR_MASK) {
+                        MVMint16 free = 0;
+                        char *str = MVM_nativecall_encode_string(tc, value, arg_types[i], &free, i, REPR(value));
+                        if (free) {
                             if (!free_strs)
                                 free_strs = (char**)alloca(num_args * sizeof(char *));
                             free_strs[num_strs] = str;

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -1078,18 +1078,9 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                 case MVM_NATIVECALL_ARG_UTF8STR:
                 case MVM_NATIVECALL_ARG_UTF16STR:
                     {
-                        char *str;
-                        switch (arg_types[i] & MVM_NATIVECALL_ARG_TYPE_MASK) {
-                            case MVM_NATIVECALL_ARG_ASCIISTR:
-                                str = MVM_string_ascii_encode_any(tc, value);
-                                break;
-                            case MVM_NATIVECALL_ARG_UTF16STR:
-                                str = MVM_string_utf16_encode(tc, value, 0);
-                                break;
-                            default:
-                                str = MVM_string_utf8_encode_C_string(tc, value);
-                        }
-                        if (arg_types[i] & MVM_NATIVECALL_ARG_FREE_STR_MASK) {
+                        MVMint16 free = 0;
+                        char *str = MVM_nativecall_encode_string(tc, value, arg_types[i], &free, i, REPR(value));
+                        if (free) {
                             if (!free_strs)
                                 free_strs = (char**)alloca(num_args * sizeof(char *));
                             free_strs[num_strs] = str;

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -1243,7 +1243,11 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
     /* Free any memory that we need to. */
     if (free_strs)
         for (i = 0; i < num_strs; i++)
+#ifdef MVM_USE_MIMALLOC
+            free(free_strs[i]);
+#else
             MVM_free(free_strs[i]);
+#endif
 
     MVM_telemetry_interval_stop(tc, interval_id, "nativecall invoke");
 }


### PR DESCRIPTION
When using mimalloc this particular memory comes from libc's malloc(), so
we have to use libc's free().