### PR TITLE
The result of a getenv() call should not be freed

### DIFF
--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -250,7 +250,6 @@ MVMint64 MVM_file_isexecutable(MVMThreadContext *tc, MVMString *filename, MVMint
                 }
             }
             MVM_free(ext);
-            MVM_free(pext);
         }
     }
     return r;


### PR DESCRIPTION
"The string pointed to by the return value of getenv() may be statically
allocated, and can be modified by a subsequent call to getenv(), putenv(3),
setenv(3), or unsetenv(3)." - man 3 getenv