### PR TITLE
Some nativeref optimizations and fixes

### DIFF
--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -592,7 +592,7 @@ static void native_ref_store_u(MVMThreadContext *tc, MVMObject *cont, MVMuint64 
         MVM_exception_throw_adhoc(tc, "This container does not reference a native integer");
     switch (repr_data->ref_kind) {
         case MVM_NATIVEREF_LEX:
-            MVM_nativeref_write_lex_i(tc, cont, value); /* FIXME need a MVM_nativeref_write_lex_u */
+            MVM_nativeref_write_lex_u(tc, cont, value);
             break;
         case MVM_NATIVEREF_ATTRIBUTE:
             MVM_nativeref_write_attribute_u(tc, cont, value);

--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -720,14 +720,13 @@ static void native_ref_configure_container_spec(MVMThreadContext *tc, MVMSTable 
 }
 
 void *MVM_container_devirtualize_fetch_for_jit(MVMThreadContext *tc, MVMSTable *st, MVMuint16 type) {
-    if (type != MVM_reg_int64)
-        return NULL;
     if (st->container_spec == &native_ref_spec) {
         MVMNativeRefREPRData *repr_data = (MVMNativeRefREPRData *)st->REPR_data;
         switch (repr_data->ref_kind) {
             case MVM_NATIVEREF_LEX:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_read_lex_i;
+                    case MVM_reg_uint64: return MVM_nativeref_read_lex_i;
                     case MVM_reg_num64: return MVM_nativeref_read_lex_n;
                     case MVM_reg_str:   return MVM_nativeref_read_lex_s;
                 }
@@ -735,6 +734,7 @@ void *MVM_container_devirtualize_fetch_for_jit(MVMThreadContext *tc, MVMSTable *
             case MVM_NATIVEREF_ATTRIBUTE:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_read_attribute_i;
+                    case MVM_reg_uint64: return MVM_nativeref_read_attribute_u;
                     case MVM_reg_num64: return MVM_nativeref_read_attribute_n;
                     case MVM_reg_str:   return MVM_nativeref_read_attribute_s;
                 }
@@ -742,6 +742,7 @@ void *MVM_container_devirtualize_fetch_for_jit(MVMThreadContext *tc, MVMSTable *
             case MVM_NATIVEREF_POSITIONAL:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_read_positional_i;
+                    case MVM_reg_uint64: return MVM_nativeref_read_positional_u;
                     case MVM_reg_num64: return MVM_nativeref_read_positional_n;
                     case MVM_reg_str:   return MVM_nativeref_read_positional_s;
                 }
@@ -749,6 +750,7 @@ void *MVM_container_devirtualize_fetch_for_jit(MVMThreadContext *tc, MVMSTable *
             case MVM_NATIVEREF_MULTIDIM:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_read_multidim_i;
+                    case MVM_reg_uint64: return MVM_nativeref_read_multidim_u;
                     case MVM_reg_num64: return MVM_nativeref_read_multidim_n;
                     case MVM_reg_str:   return MVM_nativeref_read_multidim_s;
                 }
@@ -761,14 +763,13 @@ void *MVM_container_devirtualize_fetch_for_jit(MVMThreadContext *tc, MVMSTable *
 }
 
 void *MVM_container_devirtualize_store_for_jit(MVMThreadContext *tc, MVMSTable *st, MVMuint16 type) {
-    if (type != MVM_reg_int64)
-        return NULL;
     if (st->container_spec == &native_ref_spec) {
         MVMNativeRefREPRData *repr_data = (MVMNativeRefREPRData *)st->REPR_data;
         switch (repr_data->ref_kind) {
             case MVM_NATIVEREF_LEX:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_write_lex_i;
+                    case MVM_reg_uint64: return MVM_nativeref_write_lex_u;
                     case MVM_reg_num64: return MVM_nativeref_write_lex_n;
                     case MVM_reg_str:   return MVM_nativeref_write_lex_s;
                 }
@@ -776,6 +777,7 @@ void *MVM_container_devirtualize_store_for_jit(MVMThreadContext *tc, MVMSTable *
             case MVM_NATIVEREF_ATTRIBUTE:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_write_attribute_i;
+                    case MVM_reg_uint64: return MVM_nativeref_write_attribute_u;
                     case MVM_reg_num64: return MVM_nativeref_write_attribute_n;
                     case MVM_reg_str:   return MVM_nativeref_write_attribute_s;
                 }
@@ -783,6 +785,7 @@ void *MVM_container_devirtualize_store_for_jit(MVMThreadContext *tc, MVMSTable *
             case MVM_NATIVEREF_POSITIONAL:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_write_positional_i;
+                    case MVM_reg_uint64: return MVM_nativeref_write_positional_u;
                     case MVM_reg_num64: return MVM_nativeref_write_positional_n;
                     case MVM_reg_str:   return MVM_nativeref_write_positional_s;
                 }
@@ -790,6 +793,7 @@ void *MVM_container_devirtualize_store_for_jit(MVMThreadContext *tc, MVMSTable *
             case MVM_NATIVEREF_MULTIDIM:
                 switch (type) {
                     case MVM_reg_int64: return MVM_nativeref_write_multidim_i;
+                    case MVM_reg_uint64: return MVM_nativeref_write_multidim_u;
                     case MVM_reg_num64: return MVM_nativeref_write_multidim_n;
                     case MVM_reg_str:   return MVM_nativeref_write_multidim_s;
                 }

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -572,16 +572,10 @@ void MVM_nativeref_write_lex_i(MVMThreadContext *tc, MVMObject *ref_obj, MVMint6
     MVMRegister *var = &(ref->body.u.lex.frame->env[ref->body.u.lex.env_idx]);
     switch (ref->body.u.lex.type) {
         case MVM_reg_uint8:
-            var->u8 = (MVMuint8)value;
-            break;
         case MVM_reg_uint16:
-            var->u16 = (MVMuint16)value;
-            break;
         case MVM_reg_uint32:
-            var->u32 = (MVMuint32)value;
-            break;
         case MVM_reg_uint64:
-            var->u64 = (MVMuint64)value;
+            MVM_exception_throw_adhoc("Attempting to MVM_nativeref_write_lex_i (%ld) to an unsigned variable", value);
             break;
         case MVM_reg_int8:
             var->i8 = (MVMint8)value;
@@ -601,6 +595,12 @@ void MVM_nativeref_write_lex_u(MVMThreadContext *tc, MVMObject *ref_obj, MVMuint
     MVMNativeRef *ref = (MVMNativeRef *)ref_obj;
     MVMRegister *var = &(ref->body.u.lex.frame->env[ref->body.u.lex.env_idx]);
     switch (ref->body.u.lex.type) {
+        case MVM_reg_int8:
+        case MVM_reg_int16:
+        case MVM_reg_int32:
+        case MVM_reg_int64:
+            MVM_exception_throw_adhoc("Attempting to MVM_nativeref_write_lex_u (%lu) to a signed variable", value);
+            break;
         case MVM_reg_uint8:
             var->u8 = (MVMuint8)value;
             break;
@@ -610,20 +610,8 @@ void MVM_nativeref_write_lex_u(MVMThreadContext *tc, MVMObject *ref_obj, MVMuint
         case MVM_reg_uint32:
             var->u32 = (MVMuint32)value;
             break;
-        case MVM_reg_uint64:
-            var->u64 = value;
-            break;
-        case MVM_reg_int8:
-            var->i8 = (MVMint8)value;
-            break;
-        case MVM_reg_int16:
-            var->i16 = (MVMint16)value;
-            break;
-        case MVM_reg_int32:
-            var->i32 = (MVMint32)value;
-            break;
         default:
-            var->i64 = (MVMint64)value;
+            var->u64 = value;
             break;
     }
 }

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -651,10 +651,10 @@ void MVM_nativeref_write_attribute_i(MVMThreadContext *tc, MVMObject *ref_obj, M
     MVM_repr_bind_attr_inso(tc, ref->body.u.attribute.obj, ref->body.u.attribute.class_handle,
         ref->body.u.attribute.name, MVM_NO_HINT, r, MVM_reg_int64);
 }
-void MVM_nativeref_write_attribute_u(MVMThreadContext *tc, MVMObject *ref_obj, MVMint64 value) {
+void MVM_nativeref_write_attribute_u(MVMThreadContext *tc, MVMObject *ref_obj, MVMuint64 value) {
     MVMNativeRef *ref = (MVMNativeRef *)ref_obj;
     MVMRegister r;
-    r.i64 = value;
+    r.u64 = value;
     MVM_repr_bind_attr_inso(tc, ref->body.u.attribute.obj, ref->body.u.attribute.class_handle,
         ref->body.u.attribute.name, MVM_NO_HINT, r, MVM_reg_uint64);
 }

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -597,6 +597,36 @@ void MVM_nativeref_write_lex_i(MVMThreadContext *tc, MVMObject *ref_obj, MVMint6
             break;
     }
 }
+void MVM_nativeref_write_lex_u(MVMThreadContext *tc, MVMObject *ref_obj, MVMuint64 value) {
+    MVMNativeRef *ref = (MVMNativeRef *)ref_obj;
+    MVMRegister *var = &(ref->body.u.lex.frame->env[ref->body.u.lex.env_idx]);
+    switch (ref->body.u.lex.type) {
+        case MVM_reg_uint8:
+            var->u8 = (MVMuint8)value;
+            break;
+        case MVM_reg_uint16:
+            var->u16 = (MVMuint16)value;
+            break;
+        case MVM_reg_uint32:
+            var->u32 = (MVMuint32)value;
+            break;
+        case MVM_reg_uint64:
+            var->u64 = value;
+            break;
+        case MVM_reg_int8:
+            var->i8 = (MVMint8)value;
+            break;
+        case MVM_reg_int16:
+            var->i16 = (MVMint16)value;
+            break;
+        case MVM_reg_int32:
+            var->i32 = (MVMint32)value;
+            break;
+        default:
+            var->i64 = (MVMint64)value;
+            break;
+    }
+}
 void MVM_nativeref_write_lex_n(MVMThreadContext *tc, MVMObject *ref_obj, MVMnum64 value) {
     MVMNativeRef *ref = (MVMNativeRef *)ref_obj;
     MVMRegister *var = &(ref->body.u.lex.frame->env[ref->body.u.lex.env_idx]);

--- a/src/6model/reprs/NativeRef.h
+++ b/src/6model/reprs/NativeRef.h
@@ -88,7 +88,7 @@ void MVM_nativeref_write_lex_u(MVMThreadContext *tc, MVMObject *ref, MVMuint64 v
 void MVM_nativeref_write_lex_n(MVMThreadContext *tc, MVMObject *ref, MVMnum64 value);
 void MVM_nativeref_write_lex_s(MVMThreadContext *tc, MVMObject *ref, MVMString *value);
 void MVM_nativeref_write_attribute_i(MVMThreadContext *tc, MVMObject *ref, MVMint64 value);
-void MVM_nativeref_write_attribute_u(MVMThreadContext *tc, MVMObject *ref, MVMint64 value);
+void MVM_nativeref_write_attribute_u(MVMThreadContext *tc, MVMObject *ref, MVMuint64 value);
 void MVM_nativeref_write_attribute_n(MVMThreadContext *tc, MVMObject *ref, MVMnum64 value);
 void MVM_nativeref_write_attribute_s(MVMThreadContext *tc, MVMObject *ref, MVMString *value);
 void MVM_nativeref_write_positional_i(MVMThreadContext *tc, MVMObject *ref, MVMint64 value);

--- a/src/6model/reprs/NativeRef.h
+++ b/src/6model/reprs/NativeRef.h
@@ -84,6 +84,7 @@ MVMuint64 MVM_nativeref_read_multidim_u(MVMThreadContext *tc, MVMObject *ref);
 MVMnum64 MVM_nativeref_read_multidim_n(MVMThreadContext *tc, MVMObject *ref);
 MVMString * MVM_nativeref_read_multidim_s(MVMThreadContext *tc, MVMObject *ref);
 void MVM_nativeref_write_lex_i(MVMThreadContext *tc, MVMObject *ref, MVMint64 value);
+void MVM_nativeref_write_lex_u(MVMThreadContext *tc, MVMObject *ref, MVMuint64 value);
 void MVM_nativeref_write_lex_n(MVMThreadContext *tc, MVMObject *ref, MVMnum64 value);
 void MVM_nativeref_write_lex_s(MVMThreadContext *tc, MVMObject *ref, MVMString *value);
 void MVM_nativeref_write_attribute_i(MVMThreadContext *tc, MVMObject *ref, MVMint64 value);

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1258,8 +1258,10 @@ static MVMint32 consume_reprop(MVMThreadContext *tc, MVMJitGraph *jg,
                                          { MVM_JIT_REG_VAL, { dst } },
                                          { reg_type == MVM_reg_num64 ? MVM_JIT_REG_VAL_F : MVM_JIT_REG_VAL, { val } } };
 
-                if (st->container_spec == NULL)
+                if (st->container_spec == NULL) {
+                    MVM_spesh_graph_add_comment(tc, jg->sg, ins, "JIT: not devirtualized (null container spec)");
                     goto skipdevirt;
+                }
 
                 function = MVM_container_devirtualize_store_for_jit(tc, st, reg_type);
 


### PR DESCRIPTION
NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

I struggled to find a benchmark, but `my uint $a = 0; my uint $b; my uint $c; my uint $d; while $a++ < 10_000_000 { $b = $a; $c = $b; $d = $c; }; say now - INIT now; say($a); say($b); say($c); say($d)` before was ~1.25s and after was ~1.19s and callgrind reported ~10m fewer instructions. A spesh log confirmed that `decont_u` was being devirtualized before and double-devirtualized after.