### PR TITLE
Restore jitting of sp_getarg_[inso]

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -1807,6 +1807,11 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_sp_sub_I:
     case MVM_OP_sp_mul_I:
     case MVM_OP_sp_bool_I:
+        /* Specialized argument reading */
+    case MVM_OP_sp_getarg_i:
+    case MVM_OP_sp_getarg_n:
+    case MVM_OP_sp_getarg_s:
+    case MVM_OP_sp_getarg_o:
         jg_append_primitive(tc, jg, ins);
         break;
         /* Unspecialized parameter access */


### PR DESCRIPTION
These appear to have been accidentally removed in
3f6ffa19c70be6bb8adc6e9d8be36157fb153bdf (which didn't remove their
implementation in emic.dasc).

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`. A random spesh log now no longer shows a `JIT: bailed completely` in `find_method` because of `sp_getarg_i`