### PR TITLE
Add missing _u cases to disp program callsite code

### DIFF
--- a/src/spesh/disp.c
+++ b/src/spesh/disp.c
@@ -73,14 +73,17 @@ MVMCallsite * MVM_spesh_disp_callsite_for_dispatch_op(MVMuint16 opcode, MVMuint8
         case MVM_OP_sp_runnativecall_v:
             return (MVMCallsite *)GET_UI64(args, 2);
         case MVM_OP_sp_runbytecode_i:
+        case MVM_OP_sp_runbytecode_u:
         case MVM_OP_sp_runbytecode_n:
         case MVM_OP_sp_runbytecode_s:
         case MVM_OP_sp_runbytecode_o:
         case MVM_OP_sp_runcfunc_i:
+        case MVM_OP_sp_runcfunc_u:
         case MVM_OP_sp_runcfunc_n:
         case MVM_OP_sp_runcfunc_s:
         case MVM_OP_sp_runcfunc_o:
         case MVM_OP_sp_runnativecall_i:
+        case MVM_OP_sp_runnativecall_u:
         case MVM_OP_sp_runnativecall_n:
         case MVM_OP_sp_runnativecall_s:
         case MVM_OP_sp_runnativecall_o:


### PR DESCRIPTION
Fixes the `MoarVM panic: Unknown dispatch op when resolving callsite` in
HTTP::HPACK.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.