### PR TITLE
Fix sign comparison warnings in coerce_su implementation

### DIFF
--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -337,8 +337,8 @@ MVMint64 MVM_coerce_s_i(MVMThreadContext *tc, MVMString *str) {
     MVMint64       result = 0;
     MVMint32       any = 0, negative = 0;
 
-    signed long long cutoff;
-    MVMint32  cutlim;
+    MVMint64 cutoff;
+    MVMint32 cutlim;
 
     if (!strgraphs)
         return result;
@@ -495,8 +495,8 @@ MVMuint64 MVM_coerce_s_u(MVMThreadContext *tc, MVMString *str) {
     MVMuint64      result = 0;
     MVMint32       any = 0, negative = 0;
 
-    signed long long cutoff;
-    MVMint32  cutlim;
+    MVMuint64 cutoff;
+    MVMint32 cutlim;
 
     if (!strgraphs)
         return result;
@@ -505,7 +505,7 @@ MVMuint64 MVM_coerce_s_u(MVMThreadContext *tc, MVMString *str) {
  * Copyright (c) 1990 The Regents of the University of California.
  * All rights reserved.
  *
- * copied from https://github.com/gcc-mirror/gcc/blob/0c0f453c4af4880c522c8472c33eef42bee9eda1/libiberty/strtoll.c
+ * copied from https://github.com/gcc-mirror/gcc/blob/0c0f453c4af4880c522c8472c33eef42bee9eda1/libiberty/strtoull.c
  * with minor modifications to simplify and work in MoarVM
  *
  * Redistribution and use in source and binary forms, with or without
@@ -569,7 +569,7 @@ MVMuint64 MVM_coerce_s_u(MVMThreadContext *tc, MVMString *str) {
             c = *s++;
         }
 
-        cutoff = negative ? -(unsigned long long)LLONG_MIN : LLONG_MAX;
+        cutoff = (unsigned long long)LLONG_MAX;
         cutlim = cutoff % (unsigned long long)10;
         cutoff /= (unsigned long long)10;
 
@@ -617,7 +617,7 @@ MVMuint64 MVM_coerce_s_u(MVMThreadContext *tc, MVMString *str) {
             ord = MVM_string_ci_get_codepoint(tc, &ci);
         }
 
-        cutoff = negative ? -(unsigned long long)LLONG_MIN : LLONG_MAX;
+        cutoff = (unsigned long long)LLONG_MAX;
         cutlim = cutoff % (unsigned long long)10;
         cutoff /= (unsigned long long)10;
 


### PR DESCRIPTION
The implementation had been copied from coerce_si, which was based on
gcc's strtoll, so adjust it to be based on strtoull instead. GCC no longer gives these warnings:
```
src/core/coerce.c: In function ‘MVM_coerce_s_u’:
src/core/coerce.c:582:35: warning: comparison of integer expressions of different signedness: ‘MVMuint64’ {aka ‘long unsigned int’} and ‘long long int’ [-Wsign-compare]
  582 |             if (any < 0 || result > cutoff || (result == cutoff && c > cutlim))
      |                                   ^
src/core/coerce.c:582:55: warning: comparison of integer expressions of different signedness: ‘MVMuint64’ {aka ‘long unsigned int’} and ‘long long int’ [-Wsign-compare]
  582 |             if (any < 0 || result > cutoff || (result == cutoff && c > cutlim))
      |                                                       ^~
src/core/coerce.c:630:35: warning: comparison of integer expressions of different signedness: ‘MVMuint64’ {aka ‘long unsigned int’} and ‘long long int’ [-Wsign-compare]
  630 |             if (any < 0 || result > cutoff || (result == cutoff && ord > cutlim))
      |                                   ^
src/core/coerce.c:630:55: warning: comparison of integer expressions of different signedness: ‘MVMuint64’ {aka ‘long unsigned int’} and ‘long long int’ [-Wsign-compare]
  630 |             if (any < 0 || result > cutoff || (result == cutoff && ord > cutlim))
      |                                                       ^~
```