### PR TITLE
Add definition of AI_NUMERICSERV, fixes build on MacOS 10.6 for ppc

### DIFF
--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -5,6 +5,10 @@
 #define snprintf _snprintf
 #endif
 
+#ifndef AI_NUMERICSERV
+#define AI_NUMERICSERV 0
+#endif
+
 /* Assumed maximum packet size. If ever changing this to something beyond a
  * 16-bit number, then make sure to change the receive offsets in the data
  * structure below. */


### PR DESCRIPTION
This fixes a build on 10.6 for `ppc` and closes my own ticket: https://github.com/MoarVM/MoarVM/issues/1704

The fix is borrowed from `graphviz` code: https://gitlab.com/graphviz/graphviz/-/blob/main/cmd/lefty/os/unix/io.c
See also: https://trac.macports.org/ticket/41916