### PR TITLE
Fix nqp::objprimunsigned handling of unsigned or sized integers

### DIFF
--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -4702,7 +4702,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 MVMObject *type = GET_REG(cur_op, 2).o;
                 if (type) {
                     const MVMStorageSpec *ss = REPR(type)->get_storage_spec(tc, STABLE(type));
-                    GET_REG(cur_op, 0).i64 = ss->boxed_primitive == 1 ? ss->is_unsigned : 0;
+                    GET_REG(cur_op, 0).i64 = ss->boxed_primitive ? ss->is_unsigned : 0;
                 }
                 else {
                     GET_REG(cur_op, 0).i64 = 0;

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -2662,7 +2662,7 @@
     (nz $1)
     (let: (($ss (^storage_spec $1)))
       (if
-        (eq (^getf $ss MVMStorageSpec boxed_primitive) (^one))
+        (nz (^getf $ss MVMStorageSpec boxed_primitive))
         (^getf_ucast $ss MVMStorageSpec is_unsigned int_sz)
         (^zero)))
     (^zero)))

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1762,8 +1762,9 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov FUNCTION, STABLE:ARG2->REPR;
         | mov FUNCTION, REPR:FUNCTION->get_storage_spec;
         | call FUNCTION;
-        | cmp word STORAGESPEC:RV->boxed_primitive, 1;
-        | jne >1;
+        | movzx TMP6, word STORAGESPEC:RV->boxed_primitive;
+        | test TMP6, TMP6;
+        | jz >1;
         | movzx TMP6, byte STORAGESPEC:RV->is_unsigned;
         | mov WORK[dst], TMP6;
         | jmp >2;


### PR DESCRIPTION
This would compare the `boxed_primitive` flag against `MVM_STORAGE_SPEC_BP_INT` before returning the `is_unsigned` flag, but this excludes the other sizes of `int`, as well as `uint` altogether. Give this the same check as `nqp::objprimbits`; encourage stringy types to default to zero themselves.

Required in order for https://github.com/Raku/nqp/pull/781 to pass its tests.