### PR TITLE
Avoid implicit function declarations in pthread_setname_np probe

### DIFF
--- a/build/probe.pm
+++ b/build/probe.pm
@@ -1015,6 +1015,7 @@ sub pthread_yield {
 #include <stdlib.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <string.h>
 
 int main(int argc, char **argv) {
 #ifdef _POSIX_PRIORITY_SCHEDULING


### PR DESCRIPTION
Future compilers are likely to disable support for implicit function declarations by default, and the probe will then always fail, independently of actual availability of the feature.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
