### PR TITLE
callercode no longer prevents inlining

### DIFF
--- a/src/core/oplist
+++ b/src/core/oplist
@@ -476,7 +476,7 @@ ctxouter            w(obj) r(obj) :pure
 ctxcaller           w(obj) r(obj) :pure
 ctxlexpad           w(obj) r(obj) :pure
 curcode             w(obj) :pure
-callercode          w(obj) :pure :noinline
+callercode          w(obj) :pure
 add_I               w(obj) r(obj) r(obj) r(obj) :pure
 sub_I               w(obj) r(obj) r(obj) r(obj) :pure
 mul_I               w(obj) r(obj) r(obj) r(obj) :pure

--- a/src/core/ops.c
+++ b/src/core/ops.c
@@ -6794,7 +6794,7 @@ static const MVMOpInfo MVM_op_infos[] = {
         0,
         0,
         0,
-        1,
+        0,
         0,
         0,
         0,

--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -474,6 +474,14 @@ static void rewrite_curcode(MVMThreadContext *tc, MVMSpeshGraph *g,
     MVM_spesh_usages_add_by_reg(tc, g, code_ref_reg, ins);
 }
 
+/* Make a callercode instruction turn into curcode so it refers to
+ * the inliner's code object */
+static void rewrite_callercode(MVMThreadContext *tc, MVMSpeshGraph *g,
+        MVMSpeshIns *ins, MVMuint16 num_locals) {
+    ins->operands[0].reg.orig += num_locals;
+    ins->info = MVM_op_get_op(MVM_OP_curcode);
+}
+
 /* Rewrites a lexical lookup to an outer to be done via. a register holding
  * the outer coderef. */
 static void rewrite_outer_lookup(MVMThreadContext *tc, MVMSpeshGraph *g,
@@ -641,6 +649,9 @@ static MVMSpeshBB * merge_graph(MVMThreadContext *tc, MVMSpeshGraph *inliner,
             }
             else if (opcode == MVM_OP_curcode) {
                 rewrite_curcode(tc, inliner, ins, inliner->num_locals, code_ref_reg);
+            }
+            else if (opcode == MVM_OP_callercode) {
+                rewrite_callercode(tc, inliner, ins, inliner->num_locals);
             }
             else if (opcode == MVM_OP_sp_getlex_o && ins->operands[1].lex.outers > 0) {
                 rewrite_outer_lookup(tc, inliner, ins, inliner->num_locals,

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1547,6 +1547,8 @@ static void optimize_runbytecode(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpes
         /* Do not try to inline calls from inlined basic blocks! Otherwise the new inlinees would
          * get added to the inlines table after the original inlinee which they are nested in and
          * the frame walker would find the outer inlinee first, giving wrong results */
+        /* Inicidentally, the rewrite_callercode function in inline.c also
+         * relies on "no nested inlines" */
         MVMSpeshGraph *inline_graph = bb->inlined ? NULL : MVM_spesh_inline_try_get_graph(tc, g,
             target_sf, target_sf->body.spesh->body.spesh_candidates[spesh_cand],
             ins, &no_inline_reason, &effective_size, &no_inline_info);


### PR DESCRIPTION
assuming that an inliner's curcode is what an inlinee's callercode
is supposed to return, we can just turn callercode into
curcode when inlining. There is already a guard that prevents
an inlining block from immediately inlining another so we can't for
example by accident skip over one level of
code objects AFAICT.

here's a simple script that tries to provoke a mistake from this:

```
use nqp;

my $idval = 0;
my $other-idval = 0;

my $number-of-changes = 0;

sub update-and-say($new-idval) {
    if $idval != $new-idval {
        $idval = $new-idval;
        say "outer callercode results in: $idval";
        $number-of-changes++;
    }
}

sub update-and-say-second($new-idval) {
    if $other-idval != $new-idval {
        $other-idval = $new-idval;
        say "inner callercode results in: $other-idval";
        $number-of-changes++;
    }
}

sub second-level-inline() {
    update-and-say-second(nqp::objectid(nqp::callercode()));
}

sub to-inline() {
    my $new-idval = nqp::objectid(nqp::callercode());
    update-and-say($new-idval);
    second-level-inline();
}

sub inliner() {
    to-inline()
}

for ^100000 {
    inliner;
}

if $number-of-changes != 2 {
    die "there should have been exactly two values in total for the callercode results";
}
```