### PR TITLE
Fix Windows build

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -479,7 +479,7 @@ our %COMPILERS = (
 my %OS_WIN32 = (
     exe      => '.exe',
     defs     => [ qw( WIN32 AO_ASSUME_WINDOWS98 ) ],
-    syslibs  => [ qw( shell32 ws2_32 mswsock rpcrt4 advapi32 psapi iphlpapi userenv user32 bcrypt ) ],
+    syslibs  => [ qw( shell32 ws2_32 mswsock rpcrt4 advapi32 psapi iphlpapi userenv user32 bcrypt dbghelp ole32 ) ],
     platform => '$(PLATFORM_WIN32)',
 
     translate_newline_output => 1,


### PR DESCRIPTION
In the libuv bump to 1.45.0 there was a change introducing more libs to link to:

https://github.com/libuv/libuv/commit/748d894e82abcdfff7429cf745003e182c47f163

The libs that commit introduced into the libuv build system are:

dbghelp, ole32, uuid

Looking at the commit it seems no symbol in uuid is used. So I left it out in this commit. MoarVM builds, so I guess it's fine.