### PR TITLE
Fix MVM_platform_lseek() on win32

### DIFF
--- a/src/platform/win32/io.c
+++ b/src/platform/win32/io.c
@@ -37,7 +37,7 @@ MVMint64 MVM_platform_lseek(int fd, MVMint64 offset, int origin)
     li.QuadPart = offset;
     li.LowPart = SetFilePointer(hf, li.LowPart, &li.HighPart, origin);
 
-    if (li.LowPart == INVALID_SET_FILE_POINTER) {
+    if (li.LowPart == INVALID_SET_FILE_POINTER && GetLastError() != NO_ERROR) {
         errno = ESPIPE;
         return -1;
     }


### PR DESCRIPTION
The condition `li.LowPart == INVALID_SET_FILE_POINTER` is only necessary, but not sufficient to indicate an error:

As we use the  64-bit version of `SetFilePointer()`, the function will return the lower bits of the new file position. Purely by happenstance, this value may agree with the error value `(DWORD)-1`, so we need to check `GetLastError()` as well to corroborate.

See https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilepointer#remarks for details.