### PR TITLE
Fix incompatible function pointer types with clang16

### DIFF
--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -114,7 +114,7 @@ static const MVMContainerSpec code_pair_spec = {
     code_pair_fetch_s,
     code_pair_store,
     code_pair_store_i,
-    code_pair_store_i, /* FIXME need a code_pair_store_u but lacking tests showing this need */
+    (void *)code_pair_store_i, /* FIXME need a code_pair_store_u but lacking tests showing this need */
     code_pair_store_n,
     code_pair_store_s,
     code_pair_store,
@@ -371,7 +371,7 @@ static const MVMContainerSpec value_desc_cont_spec = {
     value_desc_cont_fetch_s,
     value_desc_cont_store,
     value_desc_cont_store_i,
-    value_desc_cont_store_i, /* FIXME need a value_desc_cont_store_u but lacking tests showing this need */
+    (void *)value_desc_cont_store_i, /* FIXME need a value_desc_cont_store_u but lacking tests showing this need */
     value_desc_cont_store_n,
     value_desc_cont_store_s,
     value_desc_cont_store_unchecked,


### PR DESCRIPTION
Clang 16 enables -Werror=implicit-function-declaration by default. This results in the following error:
```
src/6model/containers.c:117:5: error: incompatible function pointer types initializing
      'void (*)(MVMThreadContext *, MVMObject *, MVMuint64)' (aka 'void (*)(struct MVMThreadContext *, struct MVMObject *, unsigned long)') with an expression of
      type 'void (MVMThreadContext *, MVMObject *, MVMint64)' (aka 'void (struct MVMThreadContext *, struct MVMObject *, long)')
      [-Wincompatible-function-pointer-types]
    code_pair_store_i, /* FIXME need a code_pair_store_u but lacking tests showing this need */
    ^~~~~~~~~~~~~~~~~
src/6model/containers.c:374:5: error: incompatible function pointer types initializing
      'void (*)(MVMThreadContext *, MVMObject *, MVMuint64)' (aka 'void (*)(struct MVMThreadContext *, struct MVMObject *, unsigned long)') with an expression of
      type 'void (MVMThreadContext *, MVMObject *, MVMint64)' (aka 'void (struct MVMThreadContext *, struct MVMObject *, long)')
      [-Wincompatible-function-pointer-types]
    value_desc_cont_store_i, /* FIXME need a value_desc_cont_store_u but lacking tests showing this need */
    ^~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```
This patch temporarily fixes the build error, but a more proper fix would be having a value_desc_cont_store_u and code_pair_store_i as mentioned in containers.c

Bug: https://bugs.gentoo.org/881335