### PR TITLE
Add stat repr and related syscalls

### DIFF
--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -187,6 +187,7 @@ OBJECTS2 = src/6model/reprs/MVMDLLSym@obj@ \
           src/6model/reprs/MVMStaticFrameSpesh@obj@ \
           src/6model/reprs/MVMCapture@obj@ \
           src/6model/reprs/MVMTracked@obj@ \
+          src/6model/reprs/MVMStat@obj@ \
           src/6model/6model@obj@ \
           src/6model/bootstrap@obj@ \
           src/6model/sc@obj@ \
@@ -373,6 +374,7 @@ HEADERS = src/moar.h \
           src/6model/reprs/MVMStaticFrameSpesh.h \
           src/6model/reprs/MVMCapture.h \
           src/6model/reprs/MVMTracked.h \
+          src/6model/reprs/MVMStat.h \
           src/6model/sc.h \
           src/disp/boot.h \
           src/disp/registry.h \

--- a/src/6model/bootstrap.c
+++ b/src/6model/bootstrap.c
@@ -667,6 +667,7 @@ void MVM_6model_bootstrap(MVMThreadContext *tc) {
     create_stub_boot_type(tc, MVM_REPR_ID_MVMSpeshCandidate, SpeshCandidate, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
     create_stub_boot_type(tc, MVM_REPR_ID_MVMCapture, boot_types.BOOTCapture, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
     create_stub_boot_type(tc, MVM_REPR_ID_MVMTracked, boot_types.BOOTTracked, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
+    create_stub_boot_type(tc, MVM_REPR_ID_MVMStat, boot_types.BOOTStat, 0, MVM_BOOL_MODE_NOT_TYPE_OBJECT);
 
     /* Bootstrap the KnowHOW type, giving it a meta-object. */
     bootstrap_KnowHOW(tc);
@@ -703,6 +704,7 @@ void MVM_6model_bootstrap(MVMThreadContext *tc) {
     meta_objectifier(tc, SpeshCandidate, "SpeshCandidate");
     meta_objectifier(tc, boot_types.BOOTCapture, "BOOTCapture");
     meta_objectifier(tc, boot_types.BOOTTracked, "BOOTTracked");
+    meta_objectifier(tc, boot_types.BOOTStat, "BOOTStat");
 
     /* Create the KnowHOWAttribute type. */
     create_KnowHOWAttribute(tc);

--- a/src/6model/reprs.c
+++ b/src/6model/reprs.c
@@ -288,6 +288,7 @@ void MVM_repr_initialize_registry(MVMThreadContext *tc) {
     register_core_repr(SpeshCandidate);
     register_core_repr(Capture);
     register_core_repr(Tracked);
+    register_core_repr(Stat);
 
     assert(tc->instance->num_reprs == MVM_REPR_CORE_COUNT);
 }

--- a/src/6model/reprs.h
+++ b/src/6model/reprs.h
@@ -45,6 +45,7 @@
 #include "6model/reprs/MVMStaticFrameSpesh.h"
 #include "6model/reprs/MVMSpeshCandidate.h"
 #include "6model/reprs/MVMTracked.h"
+#include "6model/reprs/MVMStat.h"
 
 /* REPR related functions. */
 void MVM_repr_initialize_registry(MVMThreadContext *tc);
@@ -100,8 +101,9 @@ const MVMREPROps * MVM_repr_get_by_name(MVMThreadContext *tc, MVMString *name);
 #define MVM_REPR_ID_MVMSpeshCandidate       43
 #define MVM_REPR_ID_MVMCapture              44
 #define MVM_REPR_ID_MVMTracked              45
+#define MVM_REPR_ID_MVMStat                 46
 
-#define MVM_REPR_CORE_COUNT                 46
+#define MVM_REPR_CORE_COUNT                 47
 #define MVM_REPR_MAX_COUNT                  64
 
 /* Default attribute functions for a REPR that lacks them. */

--- a/src/6model/reprs/MVMStat.c
+++ b/src/6model/reprs/MVMStat.c
@@ -1,0 +1,99 @@
+#include "moar.h"
+
+/* This representation's function pointer table. */
+static const MVMREPROps Stat_this_repr;
+
+/* Creates a new type object of this representation, and associates it with
+ * the given HOW. */
+static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
+    MVMSTable *st  = MVM_gc_allocate_stable(tc, &Stat_this_repr, HOW);
+
+    MVMROOT(tc, st, {
+        MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
+        MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
+        st->size = sizeof(MVMStat);
+    });
+
+    return st->WHAT;
+}
+
+/* Copies the body of one object to another. */
+static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *dest_root, void *dest) {
+    memcpy((MVMStatBody *)dest, (MVMStatBody *)src, sizeof(MVMStatBody));
+}
+
+/* Called by the VM in order to free memory associated with this object. */
+static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
+    MVM_free(((MVMStat *)obj)->body.uv_stat);
+}
+
+static const MVMStorageSpec storage_spec = {
+    MVM_STORAGE_SPEC_REFERENCE, /* inlineable */
+    0,                          /* bits */
+    0,                          /* align */
+    MVM_STORAGE_SPEC_BP_NONE,   /* boxed_primitive */
+    0,                          /* can_box */
+    0,                          /* is_unsigned */
+};
+
+
+/* Gets the storage specification for this representation. */
+static const MVMStorageSpec * get_storage_spec(MVMThreadContext *tc, MVMSTable *st) {
+    return &storage_spec;
+}
+
+/* Compose the representation. */
+static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info) {
+    /* Nothing to do for this REPR. */
+}
+
+/* Set the size of the STable. */
+static void deserialize_stable_size(MVMThreadContext *tc, MVMSTable *st, MVMSerializationReader *reader) {
+    st->size = sizeof(MVMStat);
+}
+
+/* Initializes the representation. */
+const MVMREPROps * MVMStat_initialize(MVMThreadContext *tc) {
+    return &Stat_this_repr;
+}
+
+static const MVMREPROps Stat_this_repr = {
+    type_object_for,
+    MVM_gc_allocate_object,
+    NULL, /* initialize */
+    copy_to,
+    MVM_REPR_DEFAULT_ATTR_FUNCS,
+    {
+        MVM_REPR_DEFAULT_SET_INT,
+        MVM_REPR_DEFAULT_GET_INT,
+        MVM_REPR_DEFAULT_SET_NUM,
+        MVM_REPR_DEFAULT_GET_NUM,
+        MVM_REPR_DEFAULT_SET_STR,
+        MVM_REPR_DEFAULT_GET_STR,
+        MVM_REPR_DEFAULT_SET_UINT,
+        MVM_REPR_DEFAULT_GET_UINT,
+        MVM_REPR_DEFAULT_GET_BOXED_REF
+    },    /* box_funcs */
+    MVM_REPR_DEFAULT_POS_FUNCS,
+    MVM_REPR_DEFAULT_ASS_FUNCS,
+    MVM_REPR_DEFAULT_ELEMS,
+    get_storage_spec,
+    NULL, /* change_type */
+    NULL, /* serialize */
+    NULL, /* deserialize */
+    NULL, /* serialize_repr_data */
+    NULL, /* deserialize_repr_data */
+    deserialize_stable_size,
+    NULL, /* gc_mark */
+    gc_free,
+    NULL, /* gc_cleanup */
+    NULL, /* gc_mark_repr_data */
+    NULL, /* gc_free_repr_data */
+    compose,
+    NULL, /* spesh */
+    "Stat", /* name */
+    MVM_REPR_ID_MVMStat,
+    NULL, /* unmanaged_size */
+    NULL, /* describe_refs */
+};
+

--- a/src/6model/reprs/MVMStat.h
+++ b/src/6model/reprs/MVMStat.h
@@ -1,0 +1,15 @@
+struct MVMStatBody {
+    uv_stat_t *uv_stat;
+    MVMint64   exists;
+#ifdef _WIN32
+    MVMString *filename;
+#endif
+};
+struct MVMStat {
+    MVMObject common;
+    MVMStatBody body;
+};
+
+/* Function for REPR setup. */
+const MVMREPROps * MVMStat_initialize(MVMThreadContext *tc);
+

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -24,6 +24,7 @@ struct MVMBootTypes {
     MVMObject *BOOTReentrantMutex;
     MVMObject *BOOTCapture;
     MVMObject *BOOTTracked;
+    MVMObject *BOOTStat;
 };
 
 /* Various raw types that don't need a HOW */

--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -27,6 +27,10 @@ static MVMint64 file_info_with_error(MVMThreadContext *tc, uv_stat_t* stat, MVMS
     return res;
 }
 
+MVMint64 MVM_file_info_with_error(MVMThreadContext *tc, uv_stat_t* stat, MVMString *filename, MVMint32 use_lstat) {
+    return file_info_with_error(tc, stat, filename, use_lstat);
+}
+
 static uv_stat_t file_info(MVMThreadContext *tc, MVMString *filename, MVMint32 use_lstat) {
     char * const a = MVM_string_utf8_c8_encode_C_string(tc, filename);
     uv_fs_t req;
@@ -41,6 +45,10 @@ static uv_stat_t file_info(MVMThreadContext *tc, MVMString *filename, MVMint32 u
 
     MVM_free(a);
     return req.statbuf;
+}
+
+uv_stat_t MVM_file_info(MVMThreadContext *tc, MVMString *filename, MVMint32 use_lstat) {
+    return file_info(tc, filename, use_lstat);
 }
 
 MVMint64 MVM_file_stat(MVMThreadContext *tc, MVMString *filename, MVMint64 status, MVMint32 use_lstat) {
@@ -296,6 +304,10 @@ static int are_we_group_member(MVMThreadContext *tc, gid_t group) {
     MVM_free(gids);
     return res;
 }
+MVMint64 MVM_are_we_group_member(MVMThreadContext *tc, gid_t group) {
+    return (MVMint64)are_we_group_member(tc, group);
+}
+
 #define FILE_IS(name, rwx) \
     MVMint64 MVM_file_is ## name (MVMThreadContext *tc, MVMString *filename, MVMint32 use_lstat) { \
         uv_stat_t statbuf; \

--- a/src/io/fileops.h
+++ b/src/io/fileops.h
@@ -1,3 +1,5 @@
+#include <sys/types.h>
+
 #define MVM_FILE_FLOCK_SHARED        1       /* Shared lock. Read lock */
 #define MVM_FILE_FLOCK_EXCLUSIVE     2       /* Exclusive lock. Write lock. */
 #define MVM_FILE_FLOCK_TYPEMASK      0x000F  /* a mask of lock type */
@@ -31,6 +33,8 @@ void MVM_file_rename(MVMThreadContext *tc, MVMString *src, MVMString *dest);
 void MVM_file_delete(MVMThreadContext *tc, MVMString *f);
 void MVM_file_chmod(MVMThreadContext *tc, MVMString *f, MVMint64 flag);
 void MVM_file_chown(MVMThreadContext *tc, MVMString *f, MVMuint64 uid, MVMuint64 gid);
+uv_stat_t MVM_file_info(MVMThreadContext *tc, MVMString *filename, MVMint32 use_lstat);
+MVMint64 MVM_file_info_with_error(MVMThreadContext *tc, uv_stat_t *stat, MVMString *filename, MVMint32 use_lstat);
 MVMint64 MVM_file_exists(MVMThreadContext *tc, MVMString *f, MVMint32 use_lstat);
 MVMint64 MVM_file_isreadable(MVMThreadContext *tc, MVMString *filename, MVMint32 use_lstat);
 MVMint64 MVM_file_iswritable(MVMThreadContext *tc, MVMString *filename, MVMint32 use_lstat);
@@ -40,3 +44,6 @@ MVMString * MVM_file_in_libpath(MVMThreadContext *tc, MVMString *orig);
 void MVM_file_link(MVMThreadContext *tc, MVMString *oldpath, MVMString *newpath);
 void MVM_file_symlink(MVMThreadContext *tc, MVMString *oldpath, MVMString *newpath);
 MVMString * MVM_file_readlink(MVMThreadContext *tc, MVMString *path);
+#ifndef _WIN32
+MVMint64 MVM_are_we_group_member(MVMThreadContext *tc, gid_t group);
+#endif

--- a/src/types.h
+++ b/src/types.h
@@ -334,3 +334,5 @@ typedef struct MVMDispSysCall MVMDispSysCall;
 typedef struct MVMDispSysCallHashEntry MVMDispSysCallHashEntry;
 typedef struct MVMTracked MVMTracked;
 typedef struct MVMTrackedBody MVMTrackedBody;
+typedef struct MVMStat MVMStat;
+typedef struct MVMStatBody MVMStatBody;


### PR DESCRIPTION
This way NQP and Rakudo can actually perform a `stat()` once, and then access all the different information returned without having to do a `stat()` again for each piece.

A version of https://github.com/MoarVM/MoarVM/pull/1762 that works more like the original `nqp::stat`.