### PR TITLE
Bump minimum supported version to windows 8

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -499,7 +499,7 @@ my %OS_WIN32 = (
 my %OS_MINGW32 = (
     %OS_WIN32,
 
-    defs => [ @{$OS_WIN32{defs}}, qw( _WIN32_WINNT=0x0600 ) ],
+    defs => [ @{$OS_WIN32{defs}}, qw( _WIN32_WINNT=0x0602 ) ],
 );
 
 my %OS_POSIX = (


### PR DESCRIPTION
libuv sets _WIN32_WINNT to 602 during its build - https://github.com/bnoordhuis/libuv/blob/1400601e590a4b7e00811efbb85bc536611276d2/CMakeLists.txt#L101 On an ARM Windows 11 VM I started getting a "unresolved external symbol _GetSystemTimePreciseAsFileTime" error, which is an API introduced in Windows 8 (which is 602). This updates the _WIN32_WINNT flag to set a minimum version for Windows of 8, which should provide the expected `GetSystemTimePreciseAsFileTime`