### PR TITLE
Enable c11 atomics on msvc 17.8+

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -419,7 +419,7 @@ our %COMPILERS = (
         ld => 'link',
         as => 'ml64',
 
-        ccmiscflags  => '/nologo /MT /std:c++latest',
+        ccmiscflags  => '/nologo /MT /std:c17 /experimental:c11atomics',
         ccwarnflags  => '',
         ccoptiflags  => '/Ox /GL /DNDEBUG',
         ccdebugflags => '/Zi',

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -419,7 +419,10 @@ our %COMPILERS = (
         ld => 'link',
         as => 'ml64',
 
-        ccmiscflags  => '/nologo /MT /std:c17 /experimental:c11atomics',
+        # /wd9002 ignores invalid parameters, such as /experimental:c11atomics on older msvc
+        # toolchains. It can be removed when the /experimental flag is no longer needed for
+        # c11 atomics to work on newer msvc toolchains.
+        ccmiscflags  => '/nologo /MT /std:c17 /experimental:c11atomics /wd9002',
         ccwarnflags  => '',
         ccoptiflags  => '/Ox /GL /DNDEBUG',
         ccdebugflags => '/Zi',

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -956,7 +956,8 @@ static void send_thread_info(MVMThreadContext *dtc, cmp_ctx_t *ctx, request_data
         cmp_write_bool(ctx, cur_thread->body.app_lifetime);
 
         cmp_write_str(ctx, "suspended", 9);
-        cmp_write_bool(ctx, (MVM_load(&cur_thread->body.tc->gc_status) & MVMSUSPENDSTATUS_MASK) != MVMSuspendState_NONE);
+        AO_t curr_gc_status = MVM_load(&cur_thread->body.tc->gc_status);
+        cmp_write_bool(ctx, (curr_gc_status & MVMSUSPENDSTATUS_MASK) != MVMSuspendState_NONE);
 
         cmp_write_str(ctx, "num_locks", 9);
         cmp_write_integer(ctx, MVM_thread_lock_count(dtc, (MVMObject *)cur_thread));

--- a/src/gc/orchestrate.h
+++ b/src/gc/orchestrate.h
@@ -50,14 +50,7 @@ typedef enum {
 #define MVM_GC_DEBUG_ENABLED(flags) \
     ((MVM_GC_DEBUG_LOG_FLAGS) & (flags))
 
-#ifdef _MSC_VER
-# define GCDEBUG_LOG(tc, flags, msg, ...) \
-    if (MVM_GC_DEBUG_ENABLED(flags)) \
-        printf((msg), (tc)->thread_id, \
-            (int)MVM_load(&(tc)->instance->gc_seq_number), __VA_ARGS__)
-#else
 # define GCDEBUG_LOG(tc, flags, msg, ...) \
     if (MVM_GC_DEBUG_ENABLED(flags)) \
         printf((msg), (tc)->thread_id, \
             (int)MVM_load(&(tc)->instance->gc_seq_number) , ##__VA_ARGS__)
-#endif


### PR DESCRIPTION
Starting with MSVC 17.8 Preview 2, c11 atomics can be used to build with a msvc toolchain. To get c11 atomics to work we need to do a few things:

* Pass the /experimental:c11atomics flag until msvc implements locking atomics
* Use c17 instead of c++latest, as the microsoft C11 atomics ops implementation doesn't work if it is in _cplusplus mode
* Fix a couple spots where the compiler complained, presumably because of the change from c++latest to c17

I don't know how well this works as an unrelated failure prevents me from testing it. But it does compile now  with --c11-atomics when using the latest preview build of MSVC.

See:
https://devblogs.microsoft.com/cppblog/c11-threads-in-visual-studio-2022-version-17-8-preview-2/