### PR TITLE
Prepare for msvc toolchain c11 atomics

### DIFF
--- a/build/setup.pm
+++ b/build/setup.pm
@@ -419,7 +419,7 @@ our %COMPILERS = (
         ld => 'link',
         as => 'ml64',
 
-        ccmiscflags  => '/nologo /MT /std:c++latest',
+        ccmiscflags  => '/nologo /MT /std:c17',
         ccwarnflags  => '',
         ccoptiflags  => '/Ox /GL /DNDEBUG',
         ccdebugflags => '/Zi',

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -956,7 +956,8 @@ static void send_thread_info(MVMThreadContext *dtc, cmp_ctx_t *ctx, request_data
         cmp_write_bool(ctx, cur_thread->body.app_lifetime);
 
         cmp_write_str(ctx, "suspended", 9);
-        cmp_write_bool(ctx, (MVM_load(&cur_thread->body.tc->gc_status) & MVMSUSPENDSTATUS_MASK) != MVMSuspendState_NONE);
+        AO_t curr_gc_status = MVM_load(&cur_thread->body.tc->gc_status);
+        cmp_write_bool(ctx, (curr_gc_status & MVMSUSPENDSTATUS_MASK) != MVMSuspendState_NONE);
 
         cmp_write_str(ctx, "num_locks", 9);
         cmp_write_integer(ctx, MVM_thread_lock_count(dtc, (MVMObject *)cur_thread));

--- a/src/gc/orchestrate.h
+++ b/src/gc/orchestrate.h
@@ -50,14 +50,7 @@ typedef enum {
 #define MVM_GC_DEBUG_ENABLED(flags) \
     ((MVM_GC_DEBUG_LOG_FLAGS) & (flags))
 
-#ifdef _MSC_VER
-# define GCDEBUG_LOG(tc, flags, msg, ...) \
-    if (MVM_GC_DEBUG_ENABLED(flags)) \
-        printf((msg), (tc)->thread_id, \
-            (int)MVM_load(&(tc)->instance->gc_seq_number), __VA_ARGS__)
-#else
 # define GCDEBUG_LOG(tc, flags, msg, ...) \
     if (MVM_GC_DEBUG_ENABLED(flags)) \
         printf((msg), (tc)->thread_id, \
             (int)MVM_load(&(tc)->instance->gc_seq_number) , ##__VA_ARGS__)
-#endif


### PR DESCRIPTION
Visual Studio 2022 version 17.8 Preview 2 supports c11 atomics when using the `/experimental:c11atomics` flag. However, the microsoft c11 atomics implementation does not work in _cplusplus mode. This updates the build system to use `c17` instead of `c++latest`, which allows MoarVM to compile with microsoft c11 atomics (assuming it is available). This also updates a Windows macro that worked using `c++latest` but not `c17` to use the same macro as everything else.