### PR TITLE
Don't lose return value with LEAVE phasers

### DIFF
--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -953,6 +953,7 @@ typedef struct {
     MVMuint8  *abs_addr;
     MVMuint32  rel_addr;
     void      *jit_return_label;
+    MVMObject *payload;
 } MVMUnwindData;
 static void mark_unwind_data(MVMThreadContext *tc, void *sr_data, MVMGCWorklist *worklist) {
     MVMUnwindData *ud  = (MVMUnwindData *)sr_data;
@@ -964,6 +965,7 @@ static void continue_unwind(MVMThreadContext *tc, void *sr_data) {
     MVMuint8 *abs_addr = ud->abs_addr;
     MVMuint32 rel_addr = ud->rel_addr;
     void *jit_return_label = ud->jit_return_label;
+    tc->last_payload = ud->payload;
     MVM_frame_unwind_to(tc, frame, abs_addr, rel_addr, NULL, jit_return_label);
 }
 void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_addr,
@@ -1019,6 +1021,7 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
                 ud->abs_addr = abs_addr;
                 ud->rel_addr = rel_addr;
                 ud->jit_return_label = jit_return_label;
+                ud->payload = tc->last_payload;
                 cur_frame->flags |= MVM_FRAME_FLAG_EXIT_HAND_RUN;
                 MVMCallStackArgsFromC *args_record = MVM_callstack_allocate_args_from_c(tc,
                         MVM_callsite_get_common(tc, MVM_CALLSITE_ID_OBJ_OBJ));


### PR DESCRIPTION
Fixes https://github.com/rakudo/rakudo/issues/4521.

When using &return an exception is thrown and the return value saved in `tc->last_payload`. LEAVE phasers interupt the stack unwind and call the LEAVE code block. Code in there can and often does make use of `tc->last_payload` via &return or other means. This overwrites the original value which is then lost. Fix by saving / restoring the original value in the special return stack frame. That frame is added to the call stack before calling the LEAVE code block and the value can be restored once we are back to that stack frame.

I suspect more needs to be done to make the JIT also recognize this.
@MasterDuke17 Any pointers to where I could start looking into the JIT?