### PR TITLE
Implement return prioritization

### DIFF
--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -953,6 +953,7 @@ typedef struct {
     MVMuint8  *abs_addr;
     MVMuint32  rel_addr;
     void      *jit_return_label;
+    MVMPostUnwind post_unwind_callback;
 } MVMUnwindData;
 static void mark_unwind_data(MVMThreadContext *tc, void *sr_data, MVMGCWorklist *worklist) {
     MVMUnwindData *ud  = (MVMUnwindData *)sr_data;
@@ -964,10 +965,12 @@ static void continue_unwind(MVMThreadContext *tc, void *sr_data) {
     MVMuint8 *abs_addr = ud->abs_addr;
     MVMuint32 rel_addr = ud->rel_addr;
     void *jit_return_label = ud->jit_return_label;
-    MVM_frame_unwind_to(tc, frame, abs_addr, rel_addr, NULL, jit_return_label);
+    MVMPostUnwind post_unwind_callback = ud->post_unwind_callback;
+    MVM_frame_unwind_to(tc, frame, abs_addr, rel_addr, NULL, jit_return_label, post_unwind_callback);
 }
 void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_addr,
-                         MVMuint32 rel_addr, MVMObject *return_value, void *jit_return_label) {
+                         MVMuint32 rel_addr, MVMObject *return_value,
+                         void *jit_return_label, MVMPostUnwind post_unwind_callback) {
     /* Lazy deopt means that we might have located an exception handler in
      * optimized code, but then at the point we call MVM_callstack_unwind_frame we'll
      * end up deoptimizing it. That means the address here will be out of date.
@@ -1019,6 +1022,7 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
                 ud->abs_addr = abs_addr;
                 ud->rel_addr = rel_addr;
                 ud->jit_return_label = jit_return_label;
+                ud->post_unwind_callback = post_unwind_callback;
                 cur_frame->flags |= MVM_FRAME_FLAG_EXIT_HAND_RUN;
                 MVMCallStackArgsFromC *args_record = MVM_callstack_allocate_args_from_c(tc,
                         MVM_callsite_get_common(tc, MVM_CALLSITE_ID_OBJ_OBJ));
@@ -1063,6 +1067,9 @@ void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_ad
 
     if (return_value)
         MVM_args_set_result_obj(tc, return_value, 1);
+
+    if (post_unwind_callback)
+        post_unwind_callback(tc);
 }
 
 /* Gets a code object for a frame, lazily deserializing it if needed. */

--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -16,6 +16,9 @@ typedef void (* MVMSpecialReturn)(MVMThreadContext *tc, void *data);
 typedef void (* MVMSpecialReturnMark)(MVMThreadContext *tc, void *data,
                                       MVMGCWorklist *worklist);
 
+/* Function pointer called after an unwind finished. */
+typedef void (* MVMPostUnwind)(MVMThreadContext *tc);
+
 /* This represents an call frame, aka invocation record. It may exist either on
  * the heap, in which case its header will have the MVM_CF_FRAME flag set, or
  * in on a thread-local stack, in which case the collectable header will be
@@ -148,7 +151,8 @@ void MVM_frame_setup_deopt(MVMThreadContext *tc, MVMFrame *frame, MVMStaticFrame
 MVM_PUBLIC MVMuint64 MVM_frame_try_return(MVMThreadContext *tc);
 MVM_PUBLIC MVMuint64 MVM_frame_try_return_no_exit_handlers(MVMThreadContext *tc);
 void MVM_frame_unwind_to(MVMThreadContext *tc, MVMFrame *frame, MVMuint8 *abs_addr,
-                         MVMuint32 rel_addr, MVMObject *return_value, void *jit_return_label);
+                         MVMuint32 rel_addr, MVMObject *return_value,
+                         void *jit_return_label, MVMPostUnwind post_unwind_callback);
 MVM_PUBLIC void MVM_frame_destroy(MVMThreadContext *tc, MVMFrame *frame);
 MVM_PUBLIC MVMObject * MVM_frame_get_code_object(MVMThreadContext *tc, MVMCode *code);
 MVM_PUBLIC void MVM_frame_capturelex(MVMThreadContext *tc, MVMObject *code);

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -57,6 +57,8 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
      * need to check. */
     tc->last_payload = instance->VMNull;
 
+    tc->active_control_handler = NULL;
+
     /* Note that the last assignment above is repeated in
      * MVM_6model_bootstrap because VMNull doesn't exist yet when the very
      * first tc is created. */

--- a/src/core/threadcontext.h
+++ b/src/core/threadcontext.h
@@ -208,6 +208,9 @@ struct MVMThreadContext {
     /* Last payload made available in a payload-goto exception handler. */
     MVMObject *last_payload;
 
+    /* Handler the currently active CONTROL exception is unwinding to. */
+    MVMActiveHandler *active_control_handler;
+
     /************************************************************************
      * Specialization and JIT compilation
      ************************************************************************/


### PR DESCRIPTION
Calling &return triggers a stack unwind which can cause code (e.g. in `LEAVE` phasers) to run. That code can also call `&return`. In such situations one usually wants the return to win that unwinds more of the stack. This is the behavior implemented by this change. Previously the later return always won.

Related to Raku/problem-solving#417. As that issue hasn't reached a conclustion yet, this PR shouldn't be merged either.