### PR TITLE
Implement return prioritization (2nd try)

### DIFF
--- a/src/core/frame.h
+++ b/src/core/frame.h
@@ -5,6 +5,7 @@
 #define MVM_FRAME_FLAG_HLL_2            1 << 4
 #define MVM_FRAME_FLAG_HLL_3            1 << 5
 #define MVM_FRAME_FLAG_HLL_4            1 << 6
+#define MVM_FRAME_FLAG_RETURNING        1 << 7
 
 /* Function pointer type of special return handler. These are used to allow
  * return to be intercepted in some way, for things that need to do multiple
@@ -114,6 +115,11 @@ struct MVMFrameExtra {
      * we have a void caller, then we stash it here so we can pass it to the
      * exit handler. */
     MVMObject *exit_handler_result;
+
+    /* When calling an exit handler while returning to this frame we save the
+     * return value here. It's needed when the exit handler manages to escape
+     * the unwind (e.g. via a return). It will be retrieved by lastexpayload. */
+    MVMObject *unwind_result;
 };
 
 /* Checks if a frame is allocated on a call stack or on the heap. If it is on

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -4914,7 +4914,10 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 goto NEXT;
             }
             OP(lastexpayload):
-                GET_REG(cur_op, 0).o = tc->last_payload;
+                if (tc->cur_frame->flags & MVM_FRAME_FLAG_RETURNING)
+                    GET_REG(cur_op, 0).o = tc->cur_frame->extra->unwind_result;
+                else
+                    GET_REG(cur_op, 0).o = tc->last_payload;
                 cur_op += 2;
                 goto NEXT;
             OP(cancelnotify):

--- a/src/gc/roots.c
+++ b/src/gc/roots.c
@@ -423,6 +423,8 @@ void MVM_gc_root_add_frame_roots_to_worklist(MVMThreadContext *tc, MVMGCWorklist
         if (e->dynlex_cache_name)
             MVM_gc_worklist_add(tc, worklist, &e->dynlex_cache_name);
         MVM_gc_worklist_add(tc, worklist, &e->exit_handler_result);
+        if (cur_frame->flags & MVM_FRAME_FLAG_RETURNING)
+            MVM_gc_worklist_add(tc, worklist, &e->unwind_result);
     }
 
     /* Scan the registers. */

--- a/src/jit/core_templates.expr
+++ b/src/jit/core_templates.expr
@@ -2691,7 +2691,9 @@
       (carg $1 ptr))))
 
 (template: lastexpayload
-  (^getf (tc) MVMThreadContext last_payload))
+  (if (nz (and (^getf (^frame) MVMFrame flags) (const (&QUOTE MVM_FRAME_FLAG_RETURNING) 1)))
+    (^getf (^getf (^frame) MVMFrame flags) MVMFrameExtra unwind_result)
+    (^getf (tc) MVMThreadContext last_payload)))
 
 (template: decoderaddbytes
   (dov

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -88,6 +88,7 @@
 /* type declarations */
 |.type REGISTER, MVMRegister
 |.type FRAME, MVMFrame
+|.type FRAMEEXTRA, MVMFrameExtra
 |.type ARGCTX, MVMArgProcContext
 |.type CALLSITE, MVMCallsite
 |.type CALLSITEPTR, MVMCallsite*
@@ -2220,7 +2221,15 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
     }
     case MVM_OP_lastexpayload: {
         MVMint16 dst = ins->operands[0].reg.orig;
+        | mov TMP1, TC->cur_frame;
+        | test word FRAME:TMP1->flags, MVM_FRAME_FLAG_RETURNING;
+        | jnz >1;
         | mov TMP3, aword TC->last_payload;
+        | jmp >2;
+        |1:
+        | mov TMP1, aword FRAME:TMP1->extra;
+        | mov TMP3, aword FRAMEEXTRA:TMP1->unwind_result;
+        |2:
         | mov aword WORK[dst], TMP3;
         break;
     }


### PR DESCRIPTION
In general, if a &return was called in a routine, we don't want any other code in exit handlers to interfere with that return from returning.

It's possible for exit handlers to escape normal control flow (e.g. via a &return). In that case instead of reaching the handler the unwind targets, we would return to the frame's return_address. To make things right, we tune the unwind target frame's return address to point to the handler. Also set that frames RETURNING flag and preserve the return value, getlexpayload can then pick it up again.

JIT implementation of `lastexpayload` is TBD.

Related to Raku/problem-solving#417