### PR TITLE
Slightly optimize creating backtraces

### DIFF
--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -561,9 +561,7 @@ MVMObject * MVM_exception_backtrace(MVMThreadContext *tc, MVMObject *ex_obj) {
             MVMBytecodeAnnotation *annot = MVM_bytecode_resolve_annotation(tc, &cur_frame->static_info->body,
                                                 offset > 0 ? offset - 1 : 0);
             MVMuint32             fshi   = annot ? (MVMint32)annot->filename_string_heap_index : -1;
-            char         line_number[11] = {0}; // 11 == 10 (max # of decimal digits in an MVMuint32) + 1 (NULL terminator)
             MVMString      *filename_str;
-            snprintf(line_number, 11, "%d", annot ? annot->line_number : 1);
 
             /* annotations hash will contain "file" and "line" */
             annotations = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTHash);
@@ -577,7 +575,7 @@ MVMObject * MVM_exception_backtrace(MVMThreadContext *tc, MVMObject *ex_obj) {
             MVM_repr_bind_key_o(tc, annotations, k_file, value);
 
             /* line */
-            value = (MVMObject *)MVM_string_ascii_decode_nt(tc, tc->instance->VMString, line_number);
+            value = (MVMObject *)MVM_coerce_u_s(tc, annot ? annot->line_number : 1);
             value = MVM_repr_box_str(tc, MVM_hll_current(tc)->str_box_type, (MVMString *)value);
             MVM_repr_bind_key_o(tc, annotations, k_line, value);
 


### PR DESCRIPTION
Instead of using snprintf just to convert a number into a C string and then converting that C string into an MVMString, just use MVM_coerce_u_s to convert the number directly an MVMString.

The number of instructions reported by `MVM_SPESH_BLOCKING=1 valgrind --tool=callgrind raku -e 'my $a; $a = Backtrace.new(1) for ^1_000; say $a'` decreases from ~1.375b to ~1.369b and the time reported by `raku -e 'my $a; $a = Backtrace.new(1) for ^100_000; say now - INIT now; say $a'` decreases from ~0.76s to ~0.67s.