### PR TITLE
Address bug in twoway_memmem_uint32 use of memcmp (Fixes R#5550)

### DIFF
--- a/src/platform/memmem32.c
+++ b/src/platform/memmem32.c
@@ -140,7 +140,7 @@ static char *twoway_memmem_uint32(const uint32_t *h, const uint32_t *z, const ui
 	else p = p0;
 
 	/* Periodic needle? */
-	if (memcmp(n, n+p, ms+1)) {
+	if (memcmp(n, n+p, (ms+1) * sizeof(uint32_t))) {
 		mem0 = 0;
 		p = MVM_MAX(ms, l-ms-1) + 1;
 	} else mem0 = l-p;


### PR DESCRIPTION
tl;dr -- The `memcmp` call was not considering the 32-bit shape of the byte strings being passed.

More information available in the commit message.

Also included a performance improvement from the upstream FreeBSD/musl implementation of `memmem` ([further details ](https://reviews.freebsd.org/rG7dbcd06e63101d51e6a777f7315cfde794411e53)).