### PR TITLE
Store short strings inside string's body

### DIFF
--- a/src/6model/reprs/MVMString.c
+++ b/src/6model/reprs/MVMString.c
@@ -46,6 +46,10 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
             memcpy(dest_body->storage.strands, src_body->storage.strands,
                 dest_body->num_strands * sizeof(MVMStringStrand));
             break;
+        case MVM_STRING_IN_SITU:
+            memcpy(dest_body->storage.in_situ, src_body->storage.in_situ,
+                src_body->num_graphs * sizeof(MVMGrapheme8));
+            break;
         default:
             MVM_exception_throw_adhoc(tc, "Internal string corruption");
     }
@@ -65,7 +69,8 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 /* Called by the VM in order to free memory associated with this object. */
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMString *str = (MVMString *)obj;
-    MVM_free(str->body.storage.any);
+    if (str->body.storage_type != MVM_STRING_IN_SITU)
+        MVM_free(str->body.storage.any);
     str->body.num_graphs = str->body.num_strands = 0;
 }
 

--- a/src/6model/reprs/MVMString.c
+++ b/src/6model/reprs/MVMString.c
@@ -46,8 +46,9 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
             memcpy(dest_body->storage.strands, src_body->storage.strands,
                 dest_body->num_strands * sizeof(MVMStringStrand));
             break;
-        case MVM_STRING_IN_SITU:
-            memcpy(dest_body->storage.in_situ, src_body->storage.in_situ,
+        case MVM_STRING_IN_SITU_8:
+        case MVM_STRING_IN_SITU_32:
+            memcpy(dest_body->storage.in_situ_8, src_body->storage.in_situ_8,
                 src_body->num_graphs * sizeof(MVMGrapheme8));
             break;
         default:
@@ -69,7 +70,7 @@ static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorkli
 /* Called by the VM in order to free memory associated with this object. */
 static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMString *str = (MVMString *)obj;
-    if (str->body.storage_type != MVM_STRING_IN_SITU)
+    if (str->body.storage_type != MVM_STRING_IN_SITU_8 && str->body.storage_type != MVM_STRING_IN_SITU_32)
         MVM_free(str->body.storage.any);
     str->body.num_graphs = str->body.num_strands = 0;
 }

--- a/src/6model/reprs/MVMString.c
+++ b/src/6model/reprs/MVMString.c
@@ -47,9 +47,12 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
                 dest_body->num_strands * sizeof(MVMStringStrand));
             break;
         case MVM_STRING_IN_SITU_8:
-        case MVM_STRING_IN_SITU_32:
             memcpy(dest_body->storage.in_situ_8, src_body->storage.in_situ_8,
                 src_body->num_graphs * sizeof(MVMGrapheme8));
+            break;
+        case MVM_STRING_IN_SITU_32:
+            memcpy(dest_body->storage.in_situ_32, src_body->storage.in_situ_32,
+                src_body->num_graphs * sizeof(MVMGrapheme32));
             break;
         default:
             MVM_exception_throw_adhoc(tc, "Internal string corruption");

--- a/src/6model/reprs/MVMString.c
+++ b/src/6model/reprs/MVMString.c
@@ -102,6 +102,9 @@ static MVMuint64 unmanaged_size(MVMThreadContext *tc, MVMSTable *st, void *data)
             return sizeof(MVMGrapheme32) * body->num_graphs;
         case MVM_STRING_STRAND:
             return sizeof(MVMStringStrand) * body->num_strands;
+        case MVM_STRING_IN_SITU_8:
+        case MVM_STRING_IN_SITU_32:
+            return 0;
         default:
             return body->num_graphs;
     }

--- a/src/6model/reprs/MVMString.h
+++ b/src/6model/reprs/MVMString.h
@@ -25,7 +25,8 @@ typedef MVMint8  MVMGrapheme8;       /* Future use */
 #define MVM_STRING_GRAPHEME_ASCII   1
 #define MVM_STRING_GRAPHEME_8       2
 #define MVM_STRING_STRAND           3
-#define MVM_STRING_IN_SITU          4
+#define MVM_STRING_IN_SITU_8        4
+#define MVM_STRING_IN_SITU_32       5
 
 /* String index data type, for when we talk about indexes. */
 typedef MVMuint32 MVMStringIndex;
@@ -43,7 +44,8 @@ struct MVMStringBody {
         MVMGraphemeASCII *blob_ascii;
         MVMGrapheme8     *blob_8;
         MVMStringStrand  *strands;
-        MVMGrapheme8     in_situ[8];
+        MVMGrapheme8     in_situ_8[8];
+        MVMGrapheme32    in_situ_32[2];
         void             *any;
     } storage;
     MVMuint16 storage_type;

--- a/src/6model/reprs/MVMString.h
+++ b/src/6model/reprs/MVMString.h
@@ -25,6 +25,7 @@ typedef MVMint8  MVMGrapheme8;       /* Future use */
 #define MVM_STRING_GRAPHEME_ASCII   1
 #define MVM_STRING_GRAPHEME_8       2
 #define MVM_STRING_STRAND           3
+#define MVM_STRING_IN_SITU          4
 
 /* String index data type, for when we talk about indexes. */
 typedef MVMuint32 MVMStringIndex;
@@ -42,6 +43,7 @@ struct MVMStringBody {
         MVMGraphemeASCII *blob_ascii;
         MVMGrapheme8     *blob_8;
         MVMStringStrand  *strands;
+        MVMGrapheme8     in_situ[8];
         void             *any;
     } storage;
     MVMuint16 storage_type;

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -903,10 +903,20 @@ MVMObject * MVM_coerce_sI(MVMThreadContext *tc, MVMString *s, MVMObject *type) {
         case MVM_STRING_GRAPHEME_8:
             memcpy(buf, s->body.storage.blob_8, sizeof(MVMGrapheme8) * s->body.num_graphs);
             break;
+        case MVM_STRING_IN_SITU_8:
+            memcpy(buf, s->body.storage.in_situ_8, sizeof(MVMGrapheme8) * s->body.num_graphs);
+            break;
         case MVM_STRING_GRAPHEME_32:
             for (i = 0; i < s->body.num_graphs; i++) {
                 buf[i] = can_fit_into_8bit(s->body.storage.blob_32[i])
                     ? s->body.storage.blob_32[i]
+                    : '?'; /* Add a filler bogus char if it can't fit */
+            }
+            break;
+        case MVM_STRING_IN_SITU_32:
+            for (i = 0; i < s->body.num_graphs; i++) {
+                buf[i] = can_fit_into_8bit(s->body.storage.in_situ_32[i])
+                    ? s->body.storage.in_situ_32[i]
                     : '?'; /* Add a filler bogus char if it can't fit */
             }
             break;

--- a/src/strings/iter.h
+++ b/src/strings/iter.h
@@ -144,8 +144,14 @@ MVM_STATIC_INLINE MVMStringIndex MVM_string_gi_graphs_left_in_strand(MVMThreadCo
 MVM_STATIC_INLINE MVMGrapheme8 * MVM_string_gi_active_blob_8_pos(MVMThreadContext *tc, MVMGraphemeIter *gi) {
     return gi->active_blob.blob_8 + gi->pos;
 }
+MVM_STATIC_INLINE MVMGrapheme8 * MVM_string_gi_active_in_situ_8_pos(MVMThreadContext *tc, MVMGraphemeIter *gi) {
+    return gi->active_blob.in_situ_8 + gi->pos;
+}
 MVM_STATIC_INLINE MVMGrapheme32 * MVM_string_gi_active_blob_32_pos(MVMThreadContext *tc, MVMGraphemeIter *gi) {
     return gi->active_blob.blob_32 + gi->pos;
+}
+MVM_STATIC_INLINE MVMGrapheme32 * MVM_string_gi_active_in_situ_32_pos(MVMThreadContext *tc, MVMGraphemeIter *gi) {
+    return gi->active_blob.in_situ_32 + gi->pos;
 }
 MVM_STATIC_INLINE MVMuint16 MVM_string_gi_blob_type(MVMThreadContext *tc, MVMGraphemeIter *gi) {
     return gi->blob_type;

--- a/src/strings/iter.h
+++ b/src/strings/iter.h
@@ -5,7 +5,8 @@ struct MVMGraphemeIter {
         MVMGrapheme32    *blob_32;
         MVMGraphemeASCII *blob_ascii;
         MVMGrapheme8     *blob_8;
-        MVMGrapheme8     in_situ[8];
+        MVMGrapheme8     in_situ_8[8];
+        MVMGrapheme32    in_situ_32[2];
         void             *any;
     } active_blob;
 
@@ -164,8 +165,10 @@ MVM_STATIC_INLINE MVMGrapheme32 MVM_string_gi_get_grapheme(MVMThreadContext *tc,
                     return gi->active_blob.blob_ascii[gi->pos++];
                 case MVM_STRING_GRAPHEME_8:
                     return gi->active_blob.blob_8[gi->pos++];
-                case MVM_STRING_IN_SITU:
-                    return gi->active_blob.in_situ[gi->pos++];
+                case MVM_STRING_IN_SITU_8:
+                    return gi->active_blob.in_situ_8[gi->pos++];
+                case MVM_STRING_IN_SITU_32:
+                    return gi->active_blob.in_situ_32[gi->pos++];
                 }
         }
         else if (gi->repetitions) {
@@ -199,8 +202,10 @@ MVM_STATIC_INLINE MVMGrapheme32 MVM_string_get_grapheme_at_nocheck(MVMThreadCont
             return a->body.storage.blob_ascii[index];
         case MVM_STRING_GRAPHEME_8:
             return a->body.storage.blob_8[index];
-        case MVM_STRING_IN_SITU:
-            return a->body.storage.in_situ[index];
+        case MVM_STRING_IN_SITU_8:
+            return a->body.storage.in_situ_8[index];
+        case MVM_STRING_IN_SITU_32:
+            return a->body.storage.in_situ_32[index];
         case MVM_STRING_STRAND: {
             MVMGraphemeIter gi;
             MVM_string_gi_init(tc, &gi, a);

--- a/src/strings/iter.h
+++ b/src/strings/iter.h
@@ -5,6 +5,7 @@ struct MVMGraphemeIter {
         MVMGrapheme32    *blob_32;
         MVMGraphemeASCII *blob_ascii;
         MVMGrapheme8     *blob_8;
+        MVMGrapheme8     in_situ[8];
         void             *any;
     } active_blob;
 
@@ -163,6 +164,8 @@ MVM_STATIC_INLINE MVMGrapheme32 MVM_string_gi_get_grapheme(MVMThreadContext *tc,
                     return gi->active_blob.blob_ascii[gi->pos++];
                 case MVM_STRING_GRAPHEME_8:
                     return gi->active_blob.blob_8[gi->pos++];
+                case MVM_STRING_IN_SITU:
+                    return gi->active_blob.in_situ[gi->pos++];
                 }
         }
         else if (gi->repetitions) {
@@ -196,6 +199,8 @@ MVM_STATIC_INLINE MVMGrapheme32 MVM_string_get_grapheme_at_nocheck(MVMThreadCont
             return a->body.storage.blob_ascii[index];
         case MVM_STRING_GRAPHEME_8:
             return a->body.storage.blob_8[index];
+        case MVM_STRING_IN_SITU:
+            return a->body.storage.in_situ[index];
         case MVM_STRING_STRAND: {
             MVMGraphemeIter gi;
             MVM_string_gi_init(tc, &gi, a);

--- a/src/strings/latin1.c
+++ b/src/strings/latin1.c
@@ -45,7 +45,6 @@ MVMString * MVM_string_latin1_decode(MVMThreadContext *tc, const MVMObject *resu
 
     if (result->body.storage_type == MVM_STRING_GRAPHEME_8 && result_graphs <= 8) {
         MVMGrapheme8 *old = result->body.storage.blob_8;
-        char *result_c;
         memcpy(result->body.storage.in_situ, old, result_graphs * sizeof(MVMGrapheme8));
         result->body.storage_type = MVM_STRING_IN_SITU;
         MVM_free(old);

--- a/src/strings/latin1.c
+++ b/src/strings/latin1.c
@@ -45,8 +45,14 @@ MVMString * MVM_string_latin1_decode(MVMThreadContext *tc, const MVMObject *resu
 
     if (result->body.storage_type == MVM_STRING_GRAPHEME_8 && result_graphs <= 8) {
         MVMGrapheme8 *old = result->body.storage.blob_8;
-        memcpy(result->body.storage.in_situ, old, result_graphs * sizeof(MVMGrapheme8));
-        result->body.storage_type = MVM_STRING_IN_SITU;
+        memcpy(result->body.storage.in_situ_8, old, result_graphs * sizeof(MVMGrapheme8));
+        result->body.storage_type = MVM_STRING_IN_SITU_8;
+        MVM_free(old);
+    }
+    else if (result->body.storage_type == MVM_STRING_GRAPHEME_32 && result_graphs <= 2) {
+        MVMGrapheme32 *old = result->body.storage.blob_32;
+        memcpy(result->body.storage.in_situ_32, old, result_graphs * sizeof(MVMGrapheme32));
+        result->body.storage_type = MVM_STRING_IN_SITU_32;
         MVM_free(old);
     }
 

--- a/src/strings/latin1.c
+++ b/src/strings/latin1.c
@@ -43,6 +43,14 @@ MVMString * MVM_string_latin1_decode(MVMThreadContext *tc, const MVMObject *resu
     }
     result->body.num_graphs = result_graphs;
 
+    if (result->body.storage_type == MVM_STRING_GRAPHEME_8 && result_graphs <= 8) {
+        MVMGrapheme8 *old = result->body.storage.blob_8;
+        char *result_c;
+        memcpy(result->body.storage.in_situ, old, result_graphs * sizeof(MVMGrapheme8));
+        result->body.storage_type = MVM_STRING_IN_SITU;
+        MVM_free(old);
+    }
+
     return result;
 }
 

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -199,8 +199,14 @@ static void turn_32bit_into_8bit_unchecked(MVMThreadContext *tc, MVMString *str)
     MVMStringIndex i;
     MVMGrapheme8 *dest_buf = NULL;
     MVMStringIndex num_graphs = MVM_string_graphs_nocheck(tc, str);
-    str->body.storage_type   = MVM_STRING_GRAPHEME_8;
-    dest_buf = str->body.storage.blob_8 = MVM_malloc(str->body.num_graphs * sizeof(MVMGrapheme8));
+    if (num_graphs <= 8) {
+        str->body.storage_type   = MVM_STRING_IN_SITU_8;
+        dest_buf = str->body.storage.in_situ_8;
+    }
+    else {
+        str->body.storage_type   = MVM_STRING_GRAPHEME_8;
+        dest_buf = str->body.storage.blob_8 = MVM_malloc(str->body.num_graphs * sizeof(MVMGrapheme8));
+    }
     MVM_VECTORIZE_LOOP
     for (i = 0; i < num_graphs; i++) {
         dest_buf[i] = old_buf[i];

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2889,9 +2889,8 @@ MVMString * MVM_string_chr(MVMThreadContext *tc, MVMint64 cp) {
 
     s = (MVMString *)REPR(tc->instance->VMString)->allocate(tc, STABLE(tc->instance->VMString));
     if (can_fit_into_8bit(g)) {
-        s->body.storage_type       = MVM_STRING_GRAPHEME_8;
-        s->body.storage.blob_8     = MVM_malloc(sizeof(MVMGrapheme8));
-        s->body.storage.blob_8[0]  = g;
+        s->body.storage_type       = MVM_STRING_IN_SITU;
+        s->body.storage.in_situ[0] = g;
     } else {
         s->body.storage_type       = MVM_STRING_GRAPHEME_32;
         s->body.storage.blob_32    = MVM_malloc(sizeof(MVMGrapheme32));

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2209,6 +2209,14 @@ MVMint64 MVM_string_char_at_in_string(MVMThreadContext *tc, MVMString *a, MVMint
                     return i;
         }
         break;
+    case MVM_STRING_IN_SITU:
+        if (can_fit_into_8bit(search)) {
+            MVMStringIndex i;
+            for (i = 0; i < bgraphs; i++)
+                if (b->body.storage.in_situ[i] == search)
+                    return i;
+        }
+        break;
     case MVM_STRING_STRAND: {
         MVMGraphemeIter gi;
         MVMStringIndex  i;

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -341,9 +341,18 @@ static void iterate_gi_into_string(MVMThreadContext *tc, MVMGraphemeIter *gi, MV
         MVMuint8 i;
         MVMGrapheme8 *old = result->body.storage.blob_8;
         for (i = 0; i < result->body.num_graphs; i++) {
-            result->body.storage.in_situ[i] = old[i];
+            result->body.storage.in_situ_8[i] = old[i];
         }
-        result->body.storage_type    = MVM_STRING_IN_SITU;
+        result->body.storage_type    = MVM_STRING_IN_SITU_8;
+        MVM_free(old);
+    }
+    else if (result->body.num_graphs <= 2 && result->body.storage_type == MVM_STRING_GRAPHEME_32) {
+        MVMuint8 i;
+        MVMGrapheme32 *old = result->body.storage.blob_32;
+        for (i = 0; i < result->body.num_graphs; i++) {
+            result->body.storage.in_situ_32[i] = old[i];
+        }
+        result->body.storage_type    = MVM_STRING_IN_SITU_32;
         MVM_free(old);
     }
 }
@@ -2188,11 +2197,11 @@ MVMint64 MVM_string_char_at_in_string(MVMThreadContext *tc, MVMString *a, MVMint
         return -2;
 
     search  = MVM_string_get_grapheme_at_nocheck(tc, a, offset);
+
     H_graphs = MVM_string_graphs_nocheck(tc, Haystack);
     switch (Haystack->body.storage_type) {
     case MVM_STRING_GRAPHEME_32:
         return MVM_string_memmem_grapheme32(tc, Haystack->body.storage.blob_32, &search, 0, H_graphs, 1);
-
     case MVM_STRING_GRAPHEME_ASCII:
         if (can_fit_into_ascii(search)) {
             MVMStringIndex i;
@@ -2209,14 +2218,22 @@ MVMint64 MVM_string_char_at_in_string(MVMThreadContext *tc, MVMString *a, MVMint
                     return i;
         }
         break;
-    case MVM_STRING_IN_SITU:
+    case MVM_STRING_IN_SITU_8:
         if (can_fit_into_8bit(search)) {
             MVMStringIndex i;
             for (i = 0; i < bgraphs; i++)
-                if (b->body.storage.in_situ[i] == search)
+                if (b->body.storage.in_situ_8[i] == search)
                     return i;
         }
         break;
+    case MVM_STRING_IN_SITU_32: {
+        MVMStringIndex i;
+        for (i = 0; i < bgraphs; i++)
+            if (b->body.storage.in_situ_32[i] == search)
+                return i;
+        break;
+    }
+
     case MVM_STRING_STRAND: {
         MVMGraphemeIter gi;
         MVMStringIndex  i;
@@ -2889,12 +2906,11 @@ MVMString * MVM_string_chr(MVMThreadContext *tc, MVMint64 cp) {
 
     s = (MVMString *)REPR(tc->instance->VMString)->allocate(tc, STABLE(tc->instance->VMString));
     if (can_fit_into_8bit(g)) {
-        s->body.storage_type       = MVM_STRING_IN_SITU;
-        s->body.storage.in_situ[0] = g;
+        s->body.storage_type         = MVM_STRING_IN_SITU_8;
+        s->body.storage.in_situ_8[0] = g;
     } else {
-        s->body.storage_type       = MVM_STRING_GRAPHEME_32;
-        s->body.storage.blob_32    = MVM_malloc(sizeof(MVMGrapheme32));
-        s->body.storage.blob_32[0] = g;
+        s->body.storage_type          = MVM_STRING_IN_SITU_32;
+        s->body.storage.in_situ_32[0] = g;
     }
     s->body.num_graphs         = 1;
     return s;

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -546,6 +546,15 @@ MVMint64 MVM_string_substrings_equal_nocheck(MVMThreadContext *tc, MVMString *a,
                     b->body.storage.blob_32 + startb,
                     length * sizeof(MVMGrapheme32));
             break;
+        case MVM_STRING_IN_SITU_32:
+            if (b->body.storage_type == MVM_STRING_IN_SITU_32) {
+                assert(length <= 2);
+                return 0 == memcmp(
+                    a->body.storage.in_situ_32 + starta,
+                    b->body.storage.in_situ_32 + startb,
+                    length * sizeof(MVMGrapheme32));
+            }
+            break;
         case MVM_STRING_GRAPHEME_ASCII:
         case MVM_STRING_GRAPHEME_8:
             if (b->body.storage_type == MVM_STRING_GRAPHEME_ASCII ||
@@ -554,6 +563,15 @@ MVMint64 MVM_string_substrings_equal_nocheck(MVMThreadContext *tc, MVMString *a,
                     a->body.storage.blob_8 + starta,
                     b->body.storage.blob_8 + startb,
                     length);
+            break;
+        case MVM_STRING_IN_SITU_8:
+            if (b->body.storage_type == MVM_STRING_IN_SITU_8) {
+                assert(length <= 8);
+                return 0 == memcmp(
+                    a->body.storage.in_situ_8 + starta,
+                    b->body.storage.in_situ_8 + startb,
+                    length);
+            }
             break;
     }
 

--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2221,15 +2221,15 @@ MVMint64 MVM_string_char_at_in_string(MVMThreadContext *tc, MVMString *a, MVMint
     case MVM_STRING_IN_SITU_8:
         if (can_fit_into_8bit(search)) {
             MVMStringIndex i;
-            for (i = 0; i < bgraphs; i++)
-                if (b->body.storage.in_situ_8[i] == search)
+            for (i = 0; i < H_graphs; i++)
+                if (Haystack->body.storage.in_situ_8[i] == search)
                     return i;
         }
         break;
     case MVM_STRING_IN_SITU_32: {
         MVMStringIndex i;
-        for (i = 0; i < bgraphs; i++)
-            if (b->body.storage.in_situ_32[i] == search)
+        for (i = 0; i < H_graphs; i++)
+            if (Haystack->body.storage.in_situ_32[i] == search)
                 return i;
         break;
     }

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -292,8 +292,8 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
         }
         MVM_free(buffer);
         if (count <= 8) {
-            memcpy(result->body.storage.in_situ, new_buffer, count * sizeof(MVMGrapheme8));
-            result->body.storage_type    = MVM_STRING_IN_SITU;
+            memcpy(result->body.storage.in_situ_8, new_buffer, count * sizeof(MVMGrapheme8));
+            result->body.storage_type    = MVM_STRING_IN_SITU_8;
         } else {
             result->body.storage.blob_8  = new_buffer;
             result->body.storage_type    = MVM_STRING_GRAPHEME_8;
@@ -302,11 +302,18 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
         /* just keep the same buffer as the MVMString's buffer.  Later
          * we can add heuristics to resize it if we have enough free
          * memory */
-        if (bufsize - count > 4) {
-            buffer = MVM_realloc(buffer, count * sizeof(MVMGrapheme32));
+        if (count <= 2) {
+            memcpy(result->body.storage.in_situ_32, buffer, count * sizeof(MVMGrapheme32));
+            result->body.storage_type    = MVM_STRING_IN_SITU_32;
+            MVM_free(buffer);
         }
-        result->body.storage.blob_32 = buffer;
-        result->body.storage_type    = MVM_STRING_GRAPHEME_32;
+        else {
+            if (bufsize - count > 4) {
+                buffer = MVM_realloc(buffer, count * sizeof(MVMGrapheme32));
+            }
+            result->body.storage.blob_32 = buffer;
+            result->body.storage_type    = MVM_STRING_GRAPHEME_32;
+        }
     }
     result->body.num_graphs      = count;
 

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -294,6 +294,7 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
         if (count <= 8) {
             memcpy(result->body.storage.in_situ_8, new_buffer, count * sizeof(MVMGrapheme8));
             result->body.storage_type    = MVM_STRING_IN_SITU_8;
+            MVM_free(new_buffer);
         } else {
             result->body.storage.blob_8  = new_buffer;
             result->body.storage_type    = MVM_STRING_GRAPHEME_8;

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -291,8 +291,13 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
             new_buffer[ready] = buffer[ready];
         }
         MVM_free(buffer);
-        result->body.storage.blob_8  = new_buffer;
-        result->body.storage_type    = MVM_STRING_GRAPHEME_8;
+        if (count <= 8) {
+            memcpy(result->body.storage.in_situ, new_buffer, count * sizeof(MVMGrapheme8));
+            result->body.storage_type    = MVM_STRING_IN_SITU;
+        } else {
+            result->body.storage.blob_8  = new_buffer;
+            result->body.storage_type    = MVM_STRING_GRAPHEME_8;
+        }
     } else {
         /* just keep the same buffer as the MVMString's buffer.  Later
          * we can add heuristics to resize it if we have enough free


### PR DESCRIPTION
Uses the 8 bytes that the pointer to a buffer usually takes and puts up to eight 8-bit or two 32-bit characters into it.

Started by @timo++.

The time reported by micro-benchmark `MVM_SPESH_BLOCKING=1 nqp-m -e 'my str $s; my int $i := 0; my $n := nqp::time; while $i++ < 10_000_000 { $s := $i }; say(nqp::div_n(nqp::time - $n, 1000000000e0)); say($s)'` drops from ~0.270s to ~0.145s, the number of instructions (for 1m iterations) drops from ~628m to ~555m, and the number of allocation functions called as reported by heaptrack drops from ~10m to ~252k.

However, another micro-benchmark `MVM_SPESH_BLOCKING=1 nqp-m -e 'my str $s := "ab.cd.ef.gh.ij.kl.mn.op.qr.st.uv.wx.yz"; my int $i := 0; my @a; nqp::setelems(@a, 30); my $n := nqp::time; while $i++ < 1_000_000 { @a := nqp::split(".", $s); }; say(nqp::div_n(nqp::time - $n, 1000000000e0)); say(@a[0])'` has no significant change in time reported, and the instruction count increased from ~10.2b to ~11.9b, even though the allocation functions called as reported by heaptrack drops from ~15.2m to ~2.2m.