### PR TITLE
Provide some mechanisms for introspecting file mode

### DIFF
--- a/src/io/io.h
+++ b/src/io/io.h
@@ -83,6 +83,7 @@ struct MVMIOLockable {
 struct MVMIOIntrospection {
     MVMint64 (*is_tty) (MVMThreadContext *tc, MVMOSHandle *h);
     MVMint64 (*native_descriptor) (MVMThreadContext *tc, MVMOSHandle *h);
+    MVMint64 (*mvm_open_mode) (MVMThreadContext *tc, MVMOSHandle *h);
 };
 
 MVMint64 MVM_io_close(MVMThreadContext *tc, MVMObject *oshandle);


### PR DESCRIPTION
In order to avoid adding yet-another member variable
to IO::Handle, we instead provide some new syscalls
for inquiring about the mode of the underlying
BOOTIO object.

Due to ambiguity created by O_RONLY being 0, we
need to set a second flag variable that only cares about
the r/w/rw distinction. We can do this directly in the
existing flag determination by adding a new parameter
and storing it at the right location.

We then expose our own values for simplified open file mode
(ro = 1, wo = 2, rw = 3) through a single syscall and let the
HLL check against it with new constants representing
the above mapping.

_EDITED: The above reflects the current commit message._