### PR TITLE
Switch free_at_safepoint linked list (back) to a vector

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -219,9 +219,9 @@ struct MVMInstance {
     MVMPtrHashTable     object_ids;
     uv_mutex_t    mutex_object_ids;
 
-    /* Linked list of memory to free at the next safepoint, and a mutex to guard
+    /* Vector of memory to free at the next safepoint, and a mutex to guard
      * access to it. */
-    MVMAllocSafepointFreeListEntry *free_at_safepoint;
+    MVM_VECTOR_DECL(void *, free_at_safepoint);
     uv_mutex_t mutex_free_at_safepoint;
 
     /* Whether the --full-cleanup flag was passed. */

--- a/src/moar.c
+++ b/src/moar.c
@@ -155,7 +155,6 @@ MVMInstance * MVM_vm_create_instance(void) {
     init_cond(instance->cond_blocked_can_continue, "GC thread unblock");
 
     /* Safe point free list. */
-    instance->free_at_safepoint = NULL;
     init_mutex(instance->mutex_free_at_safepoint, "safepoint free list");
 
     /* Set up REPR registry mutex. */
@@ -742,9 +741,10 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     /* Clean up event loop mutex. */
     uv_mutex_destroy(&instance->mutex_event_loop);
 
-    /* Clean up safepoint free list. */
+    /* Clean up safepoint free vector. */
     uv_mutex_destroy(&instance->mutex_free_at_safepoint);
     MVM_alloc_safepoint(instance->main_thread);
+    MVM_VECTOR_DESTROY(instance->free_at_safepoint);
 
     /* Destroy main thread contexts and thread list mutex. */
     MVM_tc_destroy(instance->main_thread);

--- a/src/types.h
+++ b/src/types.h
@@ -60,7 +60,6 @@ typedef struct MVMExtOpRegistry MVMExtOpRegistry;
 typedef struct MVMExtRegistry MVMExtRegistry;
 typedef struct MVMRegionAlloc MVMRegionAlloc;
 typedef struct MVMRegionBlock MVMRegionBlock;
-typedef struct MVMAllocSafepointFreeListEntry MVMAllocSafepointFreeListEntry;
 typedef struct MVMFrame MVMFrame;
 typedef struct MVMFrameExtra MVMFrameExtra;
 typedef struct MVMFrameHandler MVMFrameHandler;


### PR DESCRIPTION
This way we don't need to alloc every time something is added, and actually performing the free of the elements should be faster since we don't have to pointer chase through a linked list.

Heaptrack reports ~11m fewer allocation functions called and CORE.c's stage parse seems to be about 1s faster. However, this is not safe. Adding to the list with just a bare MVM_VECTOR_PUSH seems to cause problems in random spectests. But wrapping it in `uv_mutex_lock(&(tc->instance->mutex_free_at_safepoint)); ...; uv_mutex_unlock(&(tc->instance->mutex_free_at_safepoint));` is incredibly slow. Is there a safe-but-faster way?