### PR TITLE
Attach the spawn_result when it contains an error code

### DIFF
--- a/src/io/procops.c
+++ b/src/io/procops.c
@@ -788,6 +788,7 @@ static void spawn_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
                     MVMObject *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
                     MVM_repr_push_o(tc, arr, error_cb);
                     MVM_repr_push_o(tc, arr, msg_box);
+                    MVM_repr_push_o(tc, arr, MVM_repr_box_int(tc, tc->instance->boot_types.BOOTInt, spawn_result));
                     MVM_repr_push_o(tc, ((MVMAsyncTask *)async_task)->body.queue, arr);
                 });
             }


### PR DESCRIPTION
Previously this was only accessible via parsing the provided error message instead. The error code itself is useful for setting the exit code of the (failed) invocation attempt.

Part of fixing R#1590.