### PR TITLE
Replace MVMROOT(... {...}); with MVMROOT(...) {...}

### DIFF
--- a/build/config.c.in
+++ b/build/config.c.in
@@ -10,11 +10,11 @@
 
 #define add_entry(tc, hash, name, value) do { \
     MVMString * const key = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, (name)); \
-    MVMROOT(tc, key, { \
+    MVMROOT(tc, key) { \
         MVMString * const value_str = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, (value)); \
         MVMObject * const boxed_value = MVM_repr_box_str(tc, MVM_hll_current(tc)->str_box_type, value_str); \
         MVM_repr_bind_key_o(tc, hash, key, boxed_value); \
-    }); \
+    } \
 } while (0)
 
 MVMObject *MVM_backend_config(MVMThreadContext *tc) {
@@ -23,9 +23,9 @@ MVMObject *MVM_backend_config(MVMThreadContext *tc) {
         return config;
 
     config = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTHash);
-    MVMROOT(tc, config, {
+    MVMROOT(tc, config) {
 @backendconfig@
-    });
+    }
     tc->instance->cached_backend_config = config;
 
     return config;

--- a/docs/gc.markdown
+++ b/docs/gc.markdown
@@ -79,10 +79,10 @@ unoptimized) path for boxing strings:
         MVMString *val
     ) {
         MVMObject *res;
-        MVMROOT(tc, val, {
+        MVMROOT(tc, val) {
             res = MVM_repr_alloc_init(tc, type);
             MVM_repr_set_str(tc, res, val);
-        });
+        }
         return res;
     }
 
@@ -97,5 +97,5 @@ considers and updates, thus ensuring that even if the allocation of the box
 triggers garbage collection, this code won’t end up with an old `val` pointer.
 
 There is also an `MVMROOT2`, `MVMROOT3`, and `MVMROOT4` macro to root 2, 3, or 4
-things at once, which saves an indentation level (and possibly a little work, but
-C compilers are probably smart enough these days for it not to matter).
+things at once, up to 6, which saves an indentation level (and possibly a little
+work, but C compilers are probably smart enough these days for it not to matter).

--- a/src/6model/bootstrap.c
+++ b/src/6model/bootstrap.c
@@ -201,7 +201,7 @@ static void compose(MVMThreadContext *tc, MVMArgs arg_info) {
         MVMObject *attr_info = REPR(BOOTHash)->allocate(tc, STABLE(BOOTHash));
         MVMKnowHOWAttributeREPR *attribute = (MVMKnowHOWAttributeREPR *)
             MVM_repr_at_pos_o(tc, attributes, i);
-        MVMROOT2(tc, attr_info, attribute, {
+        MVMROOT2(tc, attr_info, attribute) {
             if (REPR((MVMObject *)attribute)->ID != MVM_REPR_ID_KnowHOWAttributeREPR)
                 MVM_exception_throw_adhoc(tc, "KnowHOW attributes must use KnowHOWAttributeREPR");
 
@@ -214,7 +214,7 @@ static void compose(MVMThreadContext *tc, MVMArgs arg_info) {
             }
 
             MVM_repr_push_o(tc, attr_info_list, attr_info);
-        });
+        }
     }
 
     /* ...followed by a list of parents (none). */
@@ -332,7 +332,7 @@ static void add_meta_object(MVMThreadContext *tc, MVMObject *type_obj, char *nam
 
     /* Create meta-object. */
     meta_obj = MVM_repr_alloc_init(tc, STABLE(tc->instance->KnowHOW)->HOW);
-    MVMROOT(tc, meta_obj, {
+    MVMROOT(tc, meta_obj) {
         /* Put it in place. */
         MVM_ASSIGN_REF(tc, &(STABLE(type_obj)->header), STABLE(type_obj)->HOW, meta_obj);
 
@@ -340,7 +340,7 @@ static void add_meta_object(MVMThreadContext *tc, MVMObject *type_obj, char *nam
         name_str = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, name);
         MVM_ASSIGN_REF(tc, &(meta_obj->header), ((MVMKnowHOWREPR *)meta_obj)->body.name, name_str);
         type_obj->st->debug_name = MVM_strdup(name);
-    });
+    }
 }
 
 /* Creates a new attribute meta-object. */
@@ -435,7 +435,7 @@ static void create_KnowHOWAttribute(MVMThreadContext *tc) {
 
     /* Create meta-object. */
     meta_obj = MVM_repr_alloc_init(tc, STABLE(tc->instance->KnowHOW)->HOW);
-    MVMROOT(tc, meta_obj, {
+    MVMROOT(tc, meta_obj) {
         /* Add methods. */
         add_knowhow_how_method(tc, (MVMKnowHOWREPR *)meta_obj, "new", attr_new);
         add_knowhow_how_method(tc, (MVMKnowHOWREPR *)meta_obj, "compose", attr_compose);
@@ -456,7 +456,7 @@ static void create_KnowHOWAttribute(MVMThreadContext *tc) {
         MVM_gc_root_add_permanent_desc(tc,
             (MVMCollectable **)&tc->instance->KnowHOWAttribute,
             "KnowHOWAttribute");
-    });
+    }
 }
 
 /* Bootstraps a typed array. */
@@ -466,25 +466,25 @@ static MVMObject * boot_typed_array(MVMThreadContext *tc, char *name, MVMObject 
     MVMInstance  *instance  = tc->instance;
     const MVMREPROps *repr  = MVM_repr_get_by_id(tc, MVM_REPR_ID_VMArray);
     MVMObject  *array = repr->type_object_for(tc, NULL);
-    MVMROOT(tc, array, {
+    MVMROOT(tc, array) {
         /* Give it a meta-object. */
         add_meta_object(tc, array, name);
 
         /* Now need to compose it with the specified type. */
         repr_info = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTHash);
-        MVMROOT(tc, repr_info, {
+        MVMROOT(tc, repr_info) {
             MVMObject *arr_info = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTHash);
             MVM_repr_bind_key_o(tc, arr_info, instance->str_consts.type, type);
             MVM_repr_bind_key_o(tc, repr_info, instance->str_consts.array, arr_info);
             MVM_repr_compose(tc, array, repr_info);
-        });
+        }
 
         /* Also give it a boolification spec. */
         bs = MVM_malloc(sizeof(MVMBoolificationSpec));
         bs->mode = MVM_BOOL_MODE_HAS_ELEMS;
         bs->method = NULL;
         array->st->boolification_spec = bs;
-    });
+    }
     return array;
 }
 

--- a/src/6model/containers.c
+++ b/src/6model/containers.c
@@ -141,7 +141,7 @@ static void code_pair_set_container_spec(MVMThreadContext *tc, MVMSTable *st) {
 
 static void code_pair_configure_container_spec(MVMThreadContext *tc, MVMSTable *st, MVMObject *config) {
     CodePairContData *data = (CodePairContData *)st->container_data;
-    MVMROOT2(tc, config, st, {
+    MVMROOT2(tc, config, st) {
         MVMString *fetch = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "fetch");
 
         if (!MVM_repr_exists_key(tc, config, fetch))
@@ -159,7 +159,7 @@ static void code_pair_configure_container_spec(MVMThreadContext *tc, MVMSTable *
         if (!MVM_code_iscode(tc, store_code))
             MVM_exception_throw_adhoc(tc, "Container spec 'code_pair' must be configured with a code handle");
         MVM_ASSIGN_REF(tc, &(st->header), data->store_code, store_code);
-    });
+    }
 }
 
 static MVMContainerConfigurer CodePairContainerConfigurer = {
@@ -241,25 +241,25 @@ static void value_desc_cont_store(MVMThreadContext *tc, MVMObject *cont, MVMObje
 
 static void value_desc_cont_store_i(MVMThreadContext *tc, MVMObject *cont, MVMint64 value) {
     MVMObject *boxed;
-    MVMROOT(tc, cont, {
+    MVMROOT(tc, cont) {
         boxed = MVM_repr_box_int(tc, MVM_hll_current(tc)->int_box_type, value);
-    });
+    }
     value_desc_cont_store(tc, cont, boxed);
 }
 
 static void value_desc_cont_store_n(MVMThreadContext *tc, MVMObject *cont, MVMnum64 value) {
     MVMObject *boxed;
-    MVMROOT(tc, cont, {
+    MVMROOT(tc, cont) {
         boxed = MVM_repr_box_num(tc, MVM_hll_current(tc)->num_box_type, value);
-    });
+    }
     value_desc_cont_store(tc, cont, boxed);
 }
 
 static void value_desc_cont_store_s(MVMThreadContext *tc, MVMObject *cont, MVMString *value) {
     MVMObject *boxed;
-    MVMROOT(tc, cont, {
+    MVMROOT(tc, cont) {
         boxed = MVM_repr_box_str(tc, MVM_hll_current(tc)->str_box_type, value);
-    });
+    }
     value_desc_cont_store(tc, cont, boxed);
 }
 
@@ -398,16 +398,16 @@ static void value_desc_cont_set_container_spec(MVMThreadContext *tc, MVMSTable *
 
 static MVMObject * grab_one_value(MVMThreadContext *tc, MVMObject *config, const char *key) {
     MVMString *key_str;
-    MVMROOT(tc, config, {
+    MVMROOT(tc, config) {
         key_str = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, key);
-    });
+    }
     if (!MVM_repr_exists_key(tc, config, key_str))
         MVM_exception_throw_adhoc(tc, "Container spec must be configured with a '%s'", key);
     return MVM_repr_at_key_o(tc, config, key_str);
 }
 static void value_desc_cont_configure_container_spec(MVMThreadContext *tc, MVMSTable *st, MVMObject *config) {
     MVMValueDescContainer *data = (MVMValueDescContainer *)st->container_data;
-    MVMROOT2(tc, st, config, {
+    MVMROOT2(tc, st, config) {
         MVMObject *value;
         value = grab_one_value(tc, config, "store");
         if (!MVM_code_iscode(tc, value))
@@ -431,7 +431,7 @@ static void value_desc_cont_configure_container_spec(MVMThreadContext *tc, MVMST
         MVM_ASSIGN_REF(tc, &(st->header), data->value_attr, MVM_repr_get_str(tc, value));
         value = grab_one_value(tc, config, "descriptor_attr");
         MVM_ASSIGN_REF(tc, &(st->header), data->descriptor_attr, MVM_repr_get_str(tc, value));
-    });
+    }
     calculate_attr_offsets(tc, st, data);
 }
 

--- a/src/6model/parametric.c
+++ b/src/6model/parametric.c
@@ -15,10 +15,10 @@ void MVM_6model_parametric_setup(MVMThreadContext *tc, MVMObject *type, MVMObjec
     /* For now, we use a simple pairwise array, with parameters and the type
      * that is based on those parameters interleaved. It does make resolution
      * O(n), so we might like to do some hash in the future. */
-    MVMROOT2(tc, st, parameterizer, {
+    MVMROOT2(tc, st, parameterizer) {
         MVMObject *lookup = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
         MVM_ASSIGN_REF(tc, &(st->header), st->paramet.ric.lookup, lookup);
-    });
+    }
 
      /* Store the parameterizer. (Note, we do this after the allocation
       * above, since the array allocation may cause GC, but we didn't mark
@@ -56,7 +56,7 @@ static void finish_parameterizing(MVMThreadContext *tc, void *sr_data) {
      * the table won't be bitten.
      * We may trigger garbage collection while holding the lock, so we need
      * to mark the thread as blocked for GC while waiting for the lock. */
-    MVMROOT2(tc, parameters, parametric_type, {
+    MVMROOT2(tc, parameters, parametric_type) {
         MVM_gc_mark_thread_blocked(tc);
         uv_mutex_lock(&tc->instance->mutex_parameterization_add);
         MVM_gc_mark_thread_unblocked(tc);
@@ -68,15 +68,15 @@ static void finish_parameterizing(MVMThreadContext *tc, void *sr_data) {
         }
         else {
             MVMObject *copy = MVM_repr_clone(tc, parametric_type->st->paramet.ric.lookup);
-            MVMROOT(tc, copy, {
+            MVMROOT(tc, copy) {
                 MVM_repr_push_o(tc, copy, parameters);
                 MVM_repr_push_o(tc, copy, prd->result->o);
-            });
+            }
             MVM_ASSIGN_REF(tc, &(parametric_type->st->header),
                 parametric_type->st->paramet.ric.lookup, copy);
         }
         uv_mutex_unlock(&tc->instance->mutex_parameterization_add);
-    });
+    }
 }
 static void mark_parameterize_sr_data(MVMThreadContext *tc, void *sr_data, MVMGCWorklist *worklist) {
     ParameterizeReturnData *prd = (ParameterizeReturnData *)sr_data;

--- a/src/6model/reprconv.c
+++ b/src/6model/reprconv.c
@@ -17,9 +17,9 @@ MVMObject * MVM_repr_alloc_init(MVMThreadContext *tc, MVMObject *type) {
     MVMObject *obj = REPR(type)->allocate(tc, STABLE(type));
 
     if (REPR(obj)->initialize) {
-        MVMROOT(tc, obj, {
+        MVMROOT(tc, obj) {
             REPR(obj)->initialize(tc, STABLE(obj), obj, OBJECT_BODY(obj));
-        });
+        }
     }
 
     return obj;
@@ -72,10 +72,10 @@ void MVM_repr_set_dimensions(MVMThreadContext *tc, MVMObject *obj, MVMObject *di
 
 MVM_PUBLIC MVMObject * MVM_repr_pos_slice(MVMThreadContext *tc, MVMObject *src, MVMint64 start, MVMint64 end) {
     MVMObject *dest = NULL;
-    MVMROOT(tc, src, {
+    MVMROOT(tc, src) {
         dest = MVM_repr_alloc_init(tc, src);
         REPR(src)->pos_funcs.slice(tc, STABLE(src), src, OBJECT_BODY(src), dest, start, end);
-    });
+    }
     return dest;
 }
 
@@ -735,10 +735,10 @@ MVMObject * MVM_repr_box_num(MVMThreadContext *tc, MVMObject *type, MVMnum64 val
 
 MVMObject * MVM_repr_box_str(MVMThreadContext *tc, MVMObject *type, MVMString *val) {
     MVMObject *res;
-    MVMROOT(tc, val, {
+    MVMROOT(tc, val) {
         res = MVM_repr_alloc_init(tc, type);
         MVM_repr_set_str(tc, res, val);
-    });
+    }
     return res;
 }
 

--- a/src/6model/reprs/CArray.c
+++ b/src/6model/reprs/CArray.c
@@ -8,11 +8,11 @@ static const MVMREPROps CArray_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &CArray_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCArray);
-    });
+    }
 
     return st->WHAT;
 }
@@ -308,12 +308,12 @@ static void at_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *d
                 /* If not, we need to produce and cache it. */
                 else {
                     void **storage = (void **)body->storage;
-                    MVMROOT(tc, root, {
+                    MVMROOT(tc, root) {
                         MVMObject **child_objs = body->child_objs;
                         MVMObject *wrapped = make_wrapper(tc, st, storage[index]);
                         MVM_ASSIGN_REF(tc, &(root->header), child_objs[index], wrapped);
                         value->o = wrapped;
-                    });
+                    }
                 }
             }
             else {
@@ -335,12 +335,12 @@ static void at_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *d
                 /* No cached object, but non-NULL pointer in array. Construct object,
                  * put it in the cache and return it. */
                 else if (storage[index]) {
-                    MVMROOT(tc, root, {
+                    MVMROOT(tc, root) {
                         MVMObject **child_objs = body->child_objs;
                         MVMObject *wrapped = make_wrapper(tc, st, storage[index]);
                         MVM_ASSIGN_REF(tc, &(root->header), child_objs[index], wrapped);
                         value->o = wrapped;
-                    });
+                    }
                 }
 
                 /* NULL pointer in the array; result is the type object. */

--- a/src/6model/reprs/CPPStruct.c
+++ b/src/6model/reprs/CPPStruct.c
@@ -107,9 +107,9 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMSTable *st,
                                         MVMObject *repr_info, MVMCPPStructREPRData *repr_data) {
     /* Compute index mapping table and get flat list of attributes. */
     MVMObject *flat_list;
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         flat_list = index_mapping_and_flat_list(tc, repr_info, repr_data, st);
-    });
+    }
 
     /* If we have no attributes in the index mapping, then just the header. */
     if (repr_data->name_to_index_mapping[0].class_key == NULL) {
@@ -378,11 +378,11 @@ static MVMint32 try_get_slot(MVMThreadContext *tc, MVMCPPStructREPRData *repr_da
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &CPPStruct_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCPPStruct);
-    });
+    }
 
     return st->WHAT;
 }
@@ -472,7 +472,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                     /* No cached object. */
                     void *cobj = get_ptr_at_offset(body->cppstruct, repr_data->struct_offsets[slot]);
                     if (cobj) {
-                        MVMROOT(tc, root, {
+                        MVMROOT(tc, root) {
                             if (type == MVM_CPPSTRUCT_ATTR_CARRAY) {
                                 obj = MVM_nativecall_make_carray(tc, typeobj, cobj);
                             }
@@ -501,13 +501,13 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                                 obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
                             }
                             else if(type == MVM_CPPSTRUCT_ATTR_STRING) {
-                                MVMROOT(tc, typeobj, {
+                                MVMROOT(tc, typeobj) {
                                     MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
                                         cobj, strlen(cobj));
                                     obj = MVM_repr_box_str(tc, typeobj, str);
-                                });
+                                }
                             }
-                        });
+                        }
                         MVM_ASSIGN_REF(tc, &(root->header), body->child_objs[real_slot], obj);
                     }
                     else {

--- a/src/6model/reprs/CPointer.c
+++ b/src/6model/reprs/CPointer.c
@@ -8,11 +8,11 @@ static const MVMREPROps CPointer_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &CPointer_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCPointer);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/CStr.c
+++ b/src/6model/reprs/CStr.c
@@ -8,11 +8,11 @@ static const MVMREPROps CStr_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &CStr_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCStr);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -396,11 +396,11 @@ static MVMint32 try_get_slot(MVMThreadContext *tc, MVMCStructREPRData *repr_data
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &CStruct_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCStruct);
-    });
+    }
 
     return st->WHAT;
 }
@@ -488,7 +488,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 MVMObject *obj     = body->child_objs[real_slot];
                 if (!obj) {
                     /* No cached object. */
-                    MVMROOT(tc, root, {
+                    MVMROOT(tc, root) {
                         //make it if it's inlined
                         if (repr_data->attribute_locations[slot] & MVM_CSTRUCT_ATTR_INLINED) {
                             if (type == MVM_CSTRUCT_ATTR_CARRAY) {
@@ -528,18 +528,18 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                                     obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
                                 }
                                 else if(type == MVM_CSTRUCT_ATTR_STRING) {
-                                    MVMROOT(tc, typeobj, {
+                                    MVMROOT(tc, typeobj) {
                                         MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
                                             cobj, strlen(cobj));
                                         obj = MVM_repr_box_str(tc, typeobj, str);
-                                    });
+                                    }
                                 }
                             }
                             else {
                                 obj = typeobj;
                             }
                         }
-                    });
+                    }
                     MVM_ASSIGN_REF(tc, &(root->header), ((MVMCStruct*)root)->body.child_objs[real_slot], obj);
                     }
                 result_reg->o = obj;
@@ -643,7 +643,7 @@ static void bind_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                             break;
                         }
                         else
-                            cobj = ((MVMCStruct *)value)->body.cstruct; 
+                            cobj = ((MVMCStruct *)value)->body.cstruct;
                     }
                     else if (type == MVM_CSTRUCT_ATTR_CPPSTRUCT) {
                         if (REPR(value)->ID != MVM_REPR_ID_MVMCPPStruct)

--- a/src/6model/reprs/CUnion.c
+++ b/src/6model/reprs/CUnion.c
@@ -334,11 +334,11 @@ static MVMint32 try_get_slot(MVMThreadContext *tc, MVMCUnionREPRData *repr_data,
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &CUnion_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCUnion);
-    });
+    }
 
     return st->WHAT;
 }
@@ -426,7 +426,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 MVMObject *obj     = body->child_objs[real_slot];
                 if (!obj) {
                     /* No cached object. */
-                    MVMROOT(tc, root, {
+                    MVMROOT(tc, root) {
                         if (repr_data->attribute_locations[slot] & MVM_CUNION_ATTR_INLINED) {
                             if (type == MVM_CUNION_ATTR_CSTRUCT) {
                                 obj = MVM_nativecall_make_cstruct(tc, typeobj,
@@ -460,18 +460,18 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                                     obj = MVM_nativecall_make_cpointer(tc, typeobj, cobj);
                                 }
                                 else if(type == MVM_CUNION_ATTR_STRING) {
-                                    MVMROOT(tc, typeobj, {
+                                    MVMROOT(tc, typeobj) {
                                         MVMString *str = MVM_string_utf8_decode(tc, tc->instance->VMString,
                                             cobj, strlen(cobj));
                                         obj = MVM_repr_box_str(tc, typeobj, str);
-                                    });
+                                    }
                                 }
                             }
                             else {
                                 obj = typeobj;
                             }
                         }
-                    });
+                    }
                     MVM_ASSIGN_REF(tc, &(root->header), body->child_objs[real_slot], obj);
                 }
                 result_reg->o = obj;

--- a/src/6model/reprs/ConcBlockingQueue.c
+++ b/src/6model/reprs/ConcBlockingQueue.c
@@ -8,11 +8,11 @@ static const MVMREPROps ConcBlockingQueue_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &ConcBlockingQueue_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMConcBlockingQueue);
-    });
+    }
 
     return st->WHAT;
 }
@@ -118,11 +118,11 @@ static void at_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *d
         MVMConcBlockingQueueNode *peeked;
         unsigned int interval_id;
         interval_id = MVM_telemetry_interval_start(tc, "ConcBlockingQueue.at_pos");
-        MVMROOT(tc, root, {
+        MVMROOT(tc, root) {
             MVM_gc_mark_thread_blocked(tc);
             uv_mutex_lock(&body->head_lock);
             MVM_gc_mark_thread_unblocked(tc);
-        });
+        }
         peeked = body->head->next;
         value->o = peeked ? peeked->value : tc->instance->VMNull;
         uv_mutex_unlock(&body->head_lock);
@@ -155,11 +155,11 @@ static void push(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *dat
     add = MVM_calloc(1, sizeof(MVMConcBlockingQueueNode));
 
     interval_id = MVM_telemetry_interval_start(tc, "ConcBlockingQueue.push");
-    MVMROOT2(tc, root, to_add, {
+    MVMROOT2(tc, root, to_add) {
         MVM_gc_mark_thread_blocked(tc);
         uv_mutex_lock(&body->tail_lock);
         MVM_gc_mark_thread_unblocked(tc);
-    });
+    }
     MVM_ASSIGN_REF(tc, &(root->header), add->value, to_add);
     body->tail->next = add;
     body->tail = add;
@@ -167,11 +167,11 @@ static void push(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *dat
     uv_mutex_unlock(&body->tail_lock);
 
     if (orig_elems == 0) {
-        MVMROOT(tc, root, {
+        MVMROOT(tc, root) {
             MVM_gc_mark_thread_blocked(tc);
             uv_mutex_lock(&body->head_lock);
             MVM_gc_mark_thread_unblocked(tc);
-        });
+        }
         uv_cond_signal(&body->head_cond);
         uv_mutex_unlock(&body->head_lock);
     }
@@ -201,12 +201,12 @@ static void unshift(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *
     /* We'll need to hold both the head and the tail lock, in case head == tail
      * and push would update tail->next - without the tail lock, this could
      * race. Ensure that we lock in the same order */
-    MVMROOT2(tc, root, to_add, {
+    MVMROOT2(tc, root, to_add) {
         MVM_gc_mark_thread_blocked(tc);
         uv_mutex_lock(&cbq->tail_lock);
         uv_mutex_lock(&cbq->head_lock);
         MVM_gc_mark_thread_unblocked(tc);
-    });
+    }
 
     MVM_ASSIGN_REF(tc, &(root->header), add->value, to_add);
     add->next = cbq->head->next;
@@ -235,7 +235,7 @@ static void shift(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *da
         MVM_exception_throw_adhoc(tc, "Can only shift objects from a ConcBlockingQueue");
 
     interval_id = MVM_telemetry_interval_start(tc, "ConcBlockingQueue.shift");
-    MVMROOT(tc, root, {
+    MVMROOT(tc, root) {
         MVM_gc_mark_thread_blocked(tc);
         uv_mutex_lock(&body->head_lock);
         MVM_gc_mark_thread_unblocked(tc);
@@ -245,7 +245,7 @@ static void shift(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *da
                 uv_cond_wait(&body->head_cond, &body->head_lock);
                 MVM_gc_mark_thread_unblocked(tc);
         }
-    });
+    }
 
     taken = body->head->next;
     MVM_free(body->head);
@@ -338,11 +338,11 @@ MVMObject * MVM_concblockingqueue_poll(MVMThreadContext *tc, MVMConcBlockingQueu
     unsigned int interval_id;
 
     interval_id = MVM_telemetry_interval_start(tc, "ConcBlockingQueue.poll");
-    MVMROOT(tc, cbq, { /* No need to root result as VMNull is always in gen2 */
+    MVMROOT(tc, cbq) { /* No need to root result as VMNull is always in gen2 */
         MVM_gc_mark_thread_blocked(tc);
         uv_mutex_lock(&body->head_lock);
         MVM_gc_mark_thread_unblocked(tc);
-    });
+    }
 
     if (MVM_load(&body->elems) > 0) {
         taken = body->head->next;

--- a/src/6model/reprs/ConditionVariable.c
+++ b/src/6model/reprs/ConditionVariable.c
@@ -8,11 +8,11 @@ static const MVMREPROps ConditionVariable_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &ConditionVariable_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMConditionVariable);
-    });
+    }
 
     return st->WHAT;
 }
@@ -106,9 +106,9 @@ MVMObject * MVM_conditionvariable_from_lock(MVMThreadContext *tc, MVMReentrantMu
     if (REPR(type)->ID != MVM_REPR_ID_ConditionVariable)
         MVM_exception_throw_adhoc(tc, "Condition variable must have ConditionVariable REPR");
 
-    MVMROOT(tc, lock, {
+    MVMROOT(tc, lock) {
         cv = (MVMConditionVariable *)MVM_gc_allocate_object(tc, STABLE(type));
-    });
+    }
     cv->body.condvar = MVM_malloc(sizeof(uv_cond_t));
     if ((init_stat = uv_cond_init(cv->body.condvar)) < 0) {
         MVM_free_null(cv->body.condvar);
@@ -137,11 +137,11 @@ void MVM_conditionvariable_wait(MVMThreadContext *tc, MVMConditionVariable *cv) 
     MVM_store(&rm->body.holder_id, 0);
     MVM_store(&rm->body.lock_count, 0);
 
-    MVMROOT2(tc, cv, rm, {
+    MVMROOT2(tc, cv, rm) {
         MVM_gc_mark_thread_blocked(tc);
         uv_cond_wait(cv->body.condvar, rm->body.mutex);
         MVM_gc_mark_thread_unblocked(tc);
-    });
+    }
 
     MVM_store(&rm->body.holder_id, tc->thread_id);
     MVM_store(&rm->body.lock_count, orig_rec_level);

--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -8,11 +8,11 @@ static const MVMREPROps Decoder_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &Decoder_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMDecoder);
-    });
+    }
 
     return st->WHAT;
 }
@@ -251,9 +251,9 @@ MVMString * MVM_decoder_take_chars(MVMThreadContext *tc, MVMDecoder *decoder, MV
                                    MVMint64 eof) {
     MVMString *result = NULL;
     enter_single_user(tc, decoder);
-    MVMROOT(tc, decoder, {
+    MVMROOT(tc, decoder) {
         result = MVM_string_decodestream_get_chars(tc, get_ds(tc, decoder), (MVMint32)chars, eof);
-    });
+    }
     exit_single_user(tc, decoder);
     return result;
 }
@@ -262,9 +262,9 @@ MVMString * MVM_decoder_take_chars(MVMThreadContext *tc, MVMDecoder *decoder, MV
 MVMString * MVM_decoder_take_all_chars(MVMThreadContext *tc, MVMDecoder *decoder) {
     MVMString *result = NULL;
     enter_single_user(tc, decoder);
-    MVMROOT(tc, decoder, {
+    MVMROOT(tc, decoder) {
         result = MVM_string_decodestream_get_all(tc, get_ds(tc, decoder));
-    });
+    }
     exit_single_user(tc, decoder);
     return result;
 }
@@ -273,9 +273,9 @@ MVMString * MVM_decoder_take_all_chars(MVMThreadContext *tc, MVMDecoder *decoder
 MVMString * MVM_decoder_take_available_chars(MVMThreadContext *tc, MVMDecoder *decoder) {
     MVMString *result = NULL;
     enter_single_user(tc, decoder);
-    MVMROOT(tc, decoder, {
+    MVMROOT(tc, decoder) {
         result = MVM_string_decodestream_get_available(tc, get_ds(tc, decoder));
-    });
+    }
     exit_single_user(tc, decoder);
     return result;
 }
@@ -287,11 +287,11 @@ MVMString * MVM_decoder_take_line(MVMThreadContext *tc, MVMDecoder *decoder,
     MVMDecodeStreamSeparators *sep_spec = get_sep_spec(tc, decoder);
     MVMString *result = NULL;
     enter_single_user(tc, decoder);
-    MVMROOT(tc, decoder, {
+    MVMROOT(tc, decoder) {
         result = incomplete_ok
             ? MVM_string_decodestream_get_until_sep_eof(tc, ds, sep_spec, (MVMint32)chomp)
             : MVM_string_decodestream_get_until_sep(tc, ds, sep_spec, (MVMint32)chomp);
-    });
+    }
     exit_single_user(tc, decoder);
     return result;
 }

--- a/src/6model/reprs/HashAttrStore.c
+++ b/src/6model/reprs/HashAttrStore.c
@@ -8,11 +8,11 @@ static const MVMREPROps HashAttrStore_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &HashAttrStore_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMHashAttrStore);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/KnowHOWAttributeREPR.c
+++ b/src/6model/reprs/KnowHOWAttributeREPR.c
@@ -8,11 +8,11 @@ static const MVMREPROps KnowHOWAttributeREPR_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &KnowHOWAttributeREPR_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMKnowHOWAttributeREPR);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/KnowHOWREPR.c
+++ b/src/6model/reprs/KnowHOWREPR.c
@@ -8,11 +8,11 @@ static const MVMREPROps KnowHOWREPR_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &KnowHOWREPR_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMKnowHOWREPR);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMAsyncTask.c
+++ b/src/6model/reprs/MVMAsyncTask.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMAsyncTask_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &MVMAsyncTask_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMAsyncTask);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMCFunction.c
+++ b/src/6model/reprs/MVMCFunction.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMCFunction_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMCFunction_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCFunction);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMCapture.c
+++ b/src/6model/reprs/MVMCapture.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMCapture_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMCapture_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCapture);
-    });
+    }
 
     return st->WHAT;
 }
@@ -319,13 +319,13 @@ MVMObject * MVM_capture_get_nameds(MVMThreadContext *tc, MVMObject *capture) {
     /* Set up an args processing context and use the standard slurpy args
      * handler to extract all nameds */
     MVMObject *result;
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         MVMArgs capture_args = MVM_capture_to_args(tc, capture);
         MVMArgProcContext capture_ctx;
         MVM_args_proc_setup(tc, &capture_ctx, capture_args);
         result = MVM_args_slurpy_named(tc, &capture_ctx);
         MVM_args_proc_cleanup(tc, &capture_ctx);
-    });
+    }
     return result;
 }
 
@@ -357,9 +357,9 @@ MVMObject * MVM_capture_drop_args(MVMThreadContext *tc, MVMObject *capture_obj, 
     /* Allocate a new capture before we begin; this is the only GC allocation
      * we do. */
     MVMObject *new_capture;
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         new_capture = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTCapture);
-    });
+    }
 
     /* We need a callsite without the arguments that are being dropped. */
     MVMCallsite *new_callsite = MVM_callsite_drop_positionals(tc, capture->body.callsite, idx, count);
@@ -397,16 +397,16 @@ MVMObject * MVM_capture_insert_arg(MVMThreadContext *tc, MVMObject *capture_obj,
     /* Allocate a new capture before we begin; this is the only GC allocation
      * we do. */
     MVMObject *new_capture;
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         if (kind & (MVM_CALLSITE_ARG_OBJ | MVM_CALLSITE_ARG_STR)) {
-            MVMROOT(tc, value.o, {
+            MVMROOT(tc, value.o) {
                 new_capture = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTCapture);
-            });
+            }
         }
         else {
             new_capture = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTCapture);
         }
-    });
+    }
 
     /* We need a callsite with the argument that is being inserted. */
     MVMCallsite *new_callsite = MVM_callsite_insert_positional(tc, capture->body.callsite,
@@ -445,16 +445,16 @@ MVMObject * MVM_capture_replace_arg(MVMThreadContext *tc, MVMObject *capture_obj
     /* Allocate a new capture before we begin; this is the only GC allocation
      * we do. */
     MVMObject *new_capture;
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         if (kind & (MVM_CALLSITE_ARG_OBJ | MVM_CALLSITE_ARG_STR)) {
-            MVMROOT(tc, value.o, {
+            MVMROOT(tc, value.o) {
                 new_capture = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTCapture);
-            });
+            }
         }
         else {
             new_capture = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTCapture);
         }
-    });
+    }
 
     /* We need a new callsite with the argument flag replaced.
      * The callsite MUST be created after we allocated as it may contain named

--- a/src/6model/reprs/MVMCode.c
+++ b/src/6model/reprs/MVMCode.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMCode_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMCode_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCode);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMCompUnit.c
+++ b/src/6model/reprs/MVMCompUnit.c
@@ -9,11 +9,11 @@ static const MVMREPROps MVMCompUnit_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMCompUnit_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMCompUnit);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMContext.c
+++ b/src/6model/reprs/MVMContext.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMContext_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMContext_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMContext);
-    });
+    }
 
     return st->WHAT;
 }
@@ -298,11 +298,11 @@ MVMObject * MVM_context_from_frame(MVMThreadContext *tc, MVMFrame *f) {
     MVMObject *ctx;
     f = MVM_frame_force_to_heap(tc, f);
     snapshot_frame_callees(tc, f);
-    MVMROOT(tc, f, {
+    MVMROOT(tc, f) {
         ctx = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTContext);
         MVM_ASSIGN_REF(tc, &(ctx->header), ((MVMContext *)ctx)->body.context, f);
         ((MVMContext *)ctx)->body.traversable = 1;
-    });
+    }
     return ctx;
 }
 
@@ -311,10 +311,10 @@ MVMObject * MVM_context_from_frame(MVMThreadContext *tc, MVMFrame *f) {
 MVMObject * MVM_context_from_frame_non_traversable(MVMThreadContext *tc, MVMFrame *f) {
     MVMObject *ctx;
     f = MVM_frame_force_to_heap(tc, f);
-    MVMROOT(tc, f, {
+    MVMROOT(tc, f) {
         ctx = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTContext);
         MVM_ASSIGN_REF(tc, &(ctx->header), ((MVMContext *)ctx)->body.context, f);
-    });
+    }
     return ctx;
 }
 
@@ -348,9 +348,9 @@ MVMObject * MVM_context_apply_traversal(MVMThreadContext *tc, MVMContext *ctx, M
     if (traversal_exists(tc, ctx->body.context, new_traversals, new_num_traversals)) {
         /* Yes, make a new context object and return it. */
         MVMContext *result;
-        MVMROOT(tc, ctx, {
+        MVMROOT(tc, ctx) {
             result = (MVMContext *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTContext);
-        });
+        }
         MVM_ASSIGN_REF(tc, &(result->common.header), result->body.context, ctx->body.context);
         result->body.traversals = new_traversals;
         result->body.num_traversals = new_num_traversals;

--- a/src/6model/reprs/MVMContinuation.c
+++ b/src/6model/reprs/MVMContinuation.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMContinuation_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMContinuation_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMContinuation);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMDLLSym.c
+++ b/src/6model/reprs/MVMDLLSym.c
@@ -5,11 +5,11 @@ static const MVMREPROps MVMDLLSym_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMDLLSym_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMDLLSym);
-    });
+    }
 
     return st->WHAT;
 }
@@ -45,12 +45,12 @@ static void compose(MVMThreadContext *tc, MVMSTable *st, MVMObject *info) {
 const MVMREPROps * MVMDLLSym_initialize(MVMThreadContext *tc) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMDLLSym_this_repr, NULL);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *WHAT = MVM_gc_allocate_type_object(tc, st);
         tc->instance->raw_types.RawDLLSym = WHAT;
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, WHAT);
         st->size = sizeof(MVMDLLSym);
-    });
+    }
 
     MVM_gc_root_add_permanent_desc(tc,
         (MVMCollectable **)&tc->instance->raw_types.RawDLLSym,

--- a/src/6model/reprs/MVMException.c
+++ b/src/6model/reprs/MVMException.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMException_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMException_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMException);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -14,11 +14,11 @@ MVM_STATIC_INLINE MVMString * get_string_key(MVMThreadContext *tc, MVMObject *ke
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMHash_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMHash);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMIter.c
+++ b/src/6model/reprs/MVMIter.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMIter_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMIter_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMIter);
-    });
+    }
 
     return st->WHAT;
 }
@@ -221,7 +221,7 @@ MVMObject * MVM_iter(MVMThreadContext *tc, MVMObject *target) {
     if (!IS_CONCRETE(target)) {
         MVM_exception_throw_adhoc(tc, "Cannot iterate over a %s type object", MVM_6model_get_debug_name(tc, target));
     }
-    MVMROOT(tc, target, {
+    MVMROOT(tc, target) {
         if (REPR(target)->ID == MVM_REPR_ID_VMArray) {
             iterator = (MVMIter *)MVM_repr_alloc_init(tc,
                 MVM_hll_current(tc)->array_iterator_type);
@@ -253,7 +253,7 @@ MVMObject * MVM_iter(MVMThreadContext *tc, MVMObject *target) {
             MVM_exception_throw_adhoc(tc, "Cannot iterate object with %s representation (%s)",
                 REPR(target)->name, MVM_6model_get_debug_name(tc, target));
         }
-    });
+    }
     return (MVMObject *)iterator;
 }
 

--- a/src/6model/reprs/MVMNull.c
+++ b/src/6model/reprs/MVMNull.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMNull_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &MVMNull_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMNull);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMOSHandle.c
+++ b/src/6model/reprs/MVMOSHandle.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMOSHandle_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &MVMOSHandle_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMOSHandle);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMSpeshCandidate.c
+++ b/src/6model/reprs/MVMSpeshCandidate.c
@@ -8,11 +8,11 @@ static const MVMREPROps SpeshCandidate_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &SpeshCandidate_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMSpeshCandidate);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMSpeshLog.c
+++ b/src/6model/reprs/MVMSpeshLog.c
@@ -8,11 +8,11 @@ static const MVMREPROps SpeshLog_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &SpeshLog_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMSpeshLog);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMStat.c
+++ b/src/6model/reprs/MVMStat.c
@@ -8,11 +8,11 @@ static const MVMREPROps Stat_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &Stat_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMStat);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMStaticFrame.c
+++ b/src/6model/reprs/MVMStaticFrame.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMStaticFrame_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMStaticFrame_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMStaticFrame);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMStaticFrameSpesh.c
+++ b/src/6model/reprs/MVMStaticFrameSpesh.c
@@ -8,11 +8,11 @@ static const MVMREPROps StaticFrameSpesh_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &StaticFrameSpesh_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMStaticFrameSpesh);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMString.c
+++ b/src/6model/reprs/MVMString.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMString_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMString_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMString);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMThread.c
+++ b/src/6model/reprs/MVMThread.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMThread_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &MVMThread_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMThread);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/MVMTracked.c
+++ b/src/6model/reprs/MVMTracked.c
@@ -8,11 +8,11 @@ static const MVMREPROps MVMTracked_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &MVMTracked_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMTracked);
-    });
+    }
 
     return st->WHAT;
 }
@@ -87,9 +87,9 @@ static const MVMREPROps MVMTracked_this_repr = {
 MVMObject * MVM_tracked_create(MVMThreadContext *tc, MVMRegister value, MVMCallsiteFlags kind) {
     MVMObject *tracked;
     if (kind & (MVM_CALLSITE_ARG_OBJ | MVM_CALLSITE_ARG_STR)) {
-        MVMROOT(tc, value.o, {
+        MVMROOT(tc, value.o) {
             tracked = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTTracked);
-        });
+        }
     }
     else {
         tracked = MVM_repr_alloc(tc, tc->instance->boot_types.BOOTTracked);

--- a/src/6model/reprs/MultiDimArray.c
+++ b/src/6model/reprs/MultiDimArray.c
@@ -44,11 +44,11 @@ MVM_STATIC_INLINE size_t indices_to_flat_index(MVMThreadContext *tc, MVMint64 nu
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &MultiDimArray_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMMultiDimArray);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/NFA.c
+++ b/src/6model/reprs/NFA.c
@@ -8,11 +8,11 @@ static const MVMREPROps NFA_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &NFA_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMNFA);
-    });
+    }
 
     return st->WHAT;
 }
@@ -378,7 +378,7 @@ MVMObject * MVM_nfa_from_statelist(MVMThreadContext *tc, MVMObject *states, MVMO
     MVMNFABody *nfa;
     MVMint64    i, j, num_states;
 
-    MVMROOT2(tc, states, nfa_type, {
+    MVMROOT2(tc, states, nfa_type) {
         /* Create NFA object. */
         nfa_obj = MVM_repr_alloc_init(tc, nfa_type);
         nfa = (MVMNFABody *)OBJECT_BODY(nfa_obj);
@@ -462,7 +462,7 @@ MVMObject * MVM_nfa_from_statelist(MVMThreadContext *tc, MVMObject *states, MVMO
                 cur_edge++;
             }
         }
-    });
+    }
 
     sort_states_and_add_synth_cp_node(tc, nfa);
 

--- a/src/6model/reprs/NativeCall.c
+++ b/src/6model/reprs/NativeCall.c
@@ -8,11 +8,11 @@ static const MVMREPROps NativeCall_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &NativeCall_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMNativeCall);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -8,11 +8,11 @@ static const MVMREPROps NativeRef_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &NativeRef_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMNativeRef);
-    });
+    }
 
     return st->WHAT;
 }
@@ -205,9 +205,9 @@ void MVM_nativeref_ensure(MVMThreadContext *tc, MVMObject *type, MVMuint16 wantp
 static MVMObject * lex_ref(MVMThreadContext *tc, MVMObject *type, MVMFrame *f,
                            MVMuint16 env_idx, MVMuint16 reg_type) {
     MVMNativeRef *ref;
-    MVMROOT(tc, f, {
+    MVMROOT(tc, f) {
         ref = (MVMNativeRef *)MVM_gc_allocate_object(tc, STABLE(type));
-    });
+    }
     MVM_ASSIGN_REF(tc, &(ref->common.header), ref->body.u.lex.frame, f);
     ref->body.u.lex.env_idx = env_idx;
     ref->body.u.lex.type = reg_type;
@@ -336,9 +336,9 @@ static MVMObject * lexref_by_name(MVMThreadContext *tc, MVMObject *type, MVMStri
 }
 MVMObject * MVM_nativeref_lex_name_i(MVMThreadContext *tc, MVMString *name) {
     MVMObject *ref_type;
-    MVMROOT(tc, name, {
+    MVMROOT(tc, name) {
         MVM_frame_force_to_heap(tc, tc->cur_frame);
-    });
+    }
     ref_type = MVM_hll_current(tc)->int_lex_ref;
     if (ref_type)
         /* LEXREF_ANY_INT will allow int8..int64 as well as uint8..uint64 */
@@ -347,9 +347,9 @@ MVMObject * MVM_nativeref_lex_name_i(MVMThreadContext *tc, MVMString *name) {
 }
 MVMObject * MVM_nativeref_lex_name_u(MVMThreadContext *tc, MVMString *name) {
     MVMObject *ref_type;
-    MVMROOT(tc, name, {
+    MVMROOT(tc, name) {
         MVM_frame_force_to_heap(tc, tc->cur_frame);
-    });
+    }
     ref_type = MVM_hll_current(tc)->uint_lex_ref;
     if (ref_type)
         /* LEXREF_ANY_INT will allow int8..int64 as well as uint8..uint64 */
@@ -358,9 +358,9 @@ MVMObject * MVM_nativeref_lex_name_u(MVMThreadContext *tc, MVMString *name) {
 }
 MVMObject * MVM_nativeref_lex_name_n(MVMThreadContext *tc, MVMString *name) {
     MVMObject *ref_type;
-    MVMROOT(tc, name, {
+    MVMROOT(tc, name) {
         MVM_frame_force_to_heap(tc, tc->cur_frame);
-    });
+    }
     ref_type = MVM_hll_current(tc)->num_lex_ref;
     if (ref_type)
         return lexref_by_name(tc, ref_type, name, MVM_reg_num64);
@@ -368,9 +368,9 @@ MVMObject * MVM_nativeref_lex_name_n(MVMThreadContext *tc, MVMString *name) {
 }
 MVMObject * MVM_nativeref_lex_name_s(MVMThreadContext *tc, MVMString *name) {
     MVMObject *ref_type;
-    MVMROOT(tc, name, {
+    MVMROOT(tc, name) {
         MVM_frame_force_to_heap(tc, tc->cur_frame);
-    });
+    }
     ref_type = MVM_hll_current(tc)->str_lex_ref;
     if (ref_type)
         return lexref_by_name(tc, ref_type, name, MVM_reg_str);
@@ -380,12 +380,12 @@ MVMObject * MVM_nativeref_lex_name_s(MVMThreadContext *tc, MVMString *name) {
 /* Creation of native references for attributes. */
 static MVMObject * attrref(MVMThreadContext *tc, MVMObject *type, MVMObject *obj, MVMObject *class_handle, MVMString *name) {
     MVMNativeRef *ref;
-    MVMROOT3(tc, obj, class_handle, name, {
+    MVMROOT3(tc, obj, class_handle, name) {
         ref = (MVMNativeRef *)MVM_gc_allocate_object(tc, STABLE(type));
         MVM_ASSIGN_REF(tc, &(ref->common.header), ref->body.u.attribute.obj, obj);
         MVM_ASSIGN_REF(tc, &(ref->common.header), ref->body.u.attribute.class_handle, class_handle);
         MVM_ASSIGN_REF(tc, &(ref->common.header), ref->body.u.attribute.name, name);
-    });
+    }
     return (MVMObject *)ref;
 }
 MVMObject * MVM_nativeref_attr_i(MVMThreadContext *tc, MVMObject *obj, MVMObject *class_handle, MVMString *name) {
@@ -416,11 +416,11 @@ MVMObject * MVM_nativeref_attr_s(MVMThreadContext *tc, MVMObject *obj, MVMObject
 /* Creation of native references for positionals. */
 static MVMObject * posref(MVMThreadContext *tc, MVMObject *type, MVMObject *obj, MVMint64 idx) {
     MVMNativeRef *ref;
-    MVMROOT(tc, obj, {
+    MVMROOT(tc, obj) {
         ref = (MVMNativeRef *)MVM_gc_allocate_object(tc, STABLE(type));
         MVM_ASSIGN_REF(tc, &(ref->common.header), ref->body.u.positional.obj, obj);
         ref->body.u.positional.idx = idx;
-    });
+    }
     return (MVMObject *)ref;
 }
 MVMObject * MVM_nativeref_pos_i(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) {
@@ -451,11 +451,11 @@ MVMObject * MVM_nativeref_pos_s(MVMThreadContext *tc, MVMObject *obj, MVMint64 i
 /* Creation of native references for multi-dimensional positionals. */
 static MVMObject * md_posref(MVMThreadContext *tc, MVMObject *type, MVMObject *obj, MVMObject *indices) {
     MVMNativeRef *ref;
-    MVMROOT2(tc, obj, indices, {
+    MVMROOT2(tc, obj, indices) {
         ref = (MVMNativeRef *)MVM_gc_allocate_object(tc, STABLE(type));
         MVM_ASSIGN_REF(tc, &(ref->common.header), ref->body.u.multidim.obj, obj);
         MVM_ASSIGN_REF(tc, &(ref->common.header), ref->body.u.multidim.indices, indices);
-    });
+    }
     return (MVMObject *)ref;
 }
 MVMObject * MVM_nativeref_multidim_i(MVMThreadContext *tc, MVMObject *obj, MVMObject *indices) {

--- a/src/6model/reprs/P6bigint.c
+++ b/src/6model/reprs/P6bigint.c
@@ -57,11 +57,11 @@ static const MVMREPROps P6bigint_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &P6bigint_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMP6bigint);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/P6int.c
+++ b/src/6model/reprs/P6int.c
@@ -27,7 +27,7 @@ static void mk_storage_spec(MVMThreadContext *tc, MVMuint16 bits, MVMuint16 is_u
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &P6int_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVMP6intREPRData *repr_data = (MVMP6intREPRData *)MVM_malloc(sizeof(MVMP6intREPRData));
 
@@ -38,7 +38,7 @@ static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
         st->size = sizeof(MVMP6int);
         st->REPR_data = repr_data;
 
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/P6num.c
+++ b/src/6model/reprs/P6num.c
@@ -21,7 +21,7 @@ static void mk_storage_spec(MVMThreadContext *tc, MVMuint16 bits, MVMStorageSpec
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &P6num_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVMP6numREPRData *repr_data = (MVMP6numREPRData *)MVM_malloc(sizeof(MVMP6numREPRData));
 
@@ -30,7 +30,7 @@ static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMP6num);
         st->REPR_data = repr_data;
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -52,11 +52,11 @@ static MVMint64 try_get_slot(MVMThreadContext *tc, MVMP6opaqueREPRData *repr_dat
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st = MVM_gc_allocate_stable(tc, &P6opaque_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = 0; /* Is updated later. */
-    });
+    }
 
     return st->WHAT;
 }
@@ -280,7 +280,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                         MVMObject *value = repr_data->auto_viv_values[slot];
                         if (value != NULL) {
                             if (IS_CONCRETE(value)) {
-                                MVMROOT2(tc, value, root, {
+                                MVMROOT2(tc, value, root) {
                                     MVMObject *cloned = REPR(value)->allocate(tc, STABLE(value));
                                     /* Ordering here matters. We write the object into the
                                     * register before calling copy_to. This is because
@@ -293,7 +293,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                                         cloned, OBJECT_BODY(cloned));
                                     set_obj_at_offset(tc, root, MVM_p6opaque_real_data(tc, OBJECT_BODY(root)),
                                         repr_data->attribute_offsets[slot], result_reg->o);
-                                });
+                                }
                             }
                             else {
                                 set_obj_at_offset(tc, root, data, repr_data->attribute_offsets[slot], value);
@@ -310,7 +310,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                 }
             }
             else {
-                MVMROOT2(tc, root, attr_st, {
+                MVMROOT2(tc, root, attr_st) {
                     /* Need to produce a boxed version of this attribute. */
                     MVMObject *cloned = attr_st->REPR->allocate(tc, attr_st);
 
@@ -319,7 +319,7 @@ static void get_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
                     attr_st->REPR->copy_to(tc, attr_st,
                         (char *)MVM_p6opaque_real_data(tc, OBJECT_BODY(root)) + repr_data->attribute_offsets[slot],
                         cloned, OBJECT_BODY(cloned));
-                });
+                }
             }
             break;
         }

--- a/src/6model/reprs/P6str.c
+++ b/src/6model/reprs/P6str.c
@@ -8,11 +8,11 @@ static const MVMREPROps P6str_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &P6str_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMP6str);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/ReentrantMutex.c
+++ b/src/6model/reprs/ReentrantMutex.c
@@ -19,11 +19,11 @@ static void initialize_mutex(MVMThreadContext *tc, MVMReentrantMutexBody *rm) {
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &ReentrantMutex_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMReentrantMutex);
-    });
+    }
 
     return st->WHAT;
 }
@@ -142,11 +142,11 @@ void MVM_reentrantmutex_lock(MVMThreadContext *tc, MVMReentrantMutex *rm) {
         /* Not holding the lock; obtain it. */
         /*interval_id = MVM_telemetry_interval_start(tc, "ReentrantMutex obtains lock");*/
         /*MVM_telemetry_interval_annotate(rm->body.mutex, interval_id, "lock in question");*/
-        MVMROOT(tc, rm, {
+        MVMROOT(tc, rm) {
             MVM_gc_mark_thread_blocked(tc);
             uv_mutex_lock(rm->body.mutex);
             MVM_gc_mark_thread_unblocked(tc);
-        });
+        }
         MVM_store(&rm->body.holder_id, tc->thread_id);
         MVM_store(&rm->body.lock_count, 1);
         tc->num_locks++;

--- a/src/6model/reprs/SCRef.c
+++ b/src/6model/reprs/SCRef.c
@@ -8,11 +8,11 @@ static const MVMREPROps SCRef_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &SCRef_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMSerializationContext);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/Semaphore.c
+++ b/src/6model/reprs/Semaphore.c
@@ -8,11 +8,11 @@ static const MVMREPROps Semaphore_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &Semaphore_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMSemaphore);
-    });
+    }
 
     return st->WHAT;
 }
@@ -123,11 +123,11 @@ MVMint64 MVM_semaphore_tryacquire(MVMThreadContext *tc, MVMSemaphore *sem) {
 void MVM_semaphore_acquire(MVMThreadContext *tc, MVMSemaphore *sem) {
     unsigned int interval_id;
     interval_id = MVM_telemetry_interval_start(tc, "Semaphore.acquire");
-    MVMROOT(tc, sem, {
+    MVMROOT(tc, sem) {
         MVM_gc_mark_thread_blocked(tc);
         uv_sem_wait(sem->body.sem);
         MVM_gc_mark_thread_unblocked(tc);
-    });
+    }
     MVM_telemetry_interval_stop(tc, interval_id, "Semaphore.acquire");
 }
 

--- a/src/6model/reprs/Uninstantiable.c
+++ b/src/6model/reprs/Uninstantiable.c
@@ -8,11 +8,11 @@ static const MVMREPROps Uninstantiable_this_repr;
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable *st  = MVM_gc_allocate_stable(tc, &Uninstantiable_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMUninstantiable);
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -26,7 +26,7 @@ static void exit_single_user(MVMThreadContext *tc, MVMArrayBody *arr) {
 static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
     MVMSTable        *st = MVM_gc_allocate_stable(tc, &VMArray_this_repr, HOW);
 
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         MVMObject *obj = MVM_gc_allocate_type_object(tc, st);
         MVMArrayREPRData *repr_data = (MVMArrayREPRData *)MVM_malloc(sizeof(MVMArrayREPRData));
 
@@ -37,7 +37,7 @@ static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
         MVM_ASSIGN_REF(tc, &(st->header), st->WHAT, obj);
         st->size = sizeof(MVMArray);
         st->REPR_data = repr_data;
-    });
+    }
 
     return st->WHAT;
 }

--- a/src/6model/sc.c
+++ b/src/6model/sc.c
@@ -13,9 +13,9 @@ MVMObject * MVM_sc_create(MVMThreadContext *tc, MVMString *handle) {
     }
 
     /* Allocate. */
-    MVMROOT(tc, handle, {
+    MVMROOT(tc, handle) {
         sc = (MVMSerializationContext *)REPR(tc->instance->SCRef)->allocate(tc, STABLE(tc->instance->SCRef));
-        MVMROOT(tc, sc, {
+        MVMROOT(tc, sc) {
             /* Add to weak lookup hash. */
             uv_mutex_lock(&tc->instance->mutex_sc_registry);
             struct MVMSerializationContextWeakHashEntry *entry
@@ -56,8 +56,8 @@ MVMObject * MVM_sc_create(MVMThreadContext *tc, MVMString *handle) {
                 }
             }
             uv_mutex_unlock(&tc->instance->mutex_sc_registry);
-        });
-    });
+        }
+    }
 
     return (MVMObject *)sc;
 }

--- a/src/core/args.c
+++ b/src/core/args.c
@@ -666,12 +666,12 @@ void MVM_args_set_result_obj(MVMThreadContext *tc, MVMObject *result, MVMint32 f
         target = tc->cur_frame;
     }
     else {
-        MVMROOT(tc, result, {
+        MVMROOT(tc, result) {
             if (MVM_spesh_log_is_caller_logging(tc))
                 MVM_spesh_log_return_type(tc, result);
             else if (MVM_spesh_log_is_logging(tc))
                 MVM_spesh_log_return_to_unlogged(tc);
-        });
+        }
         target = tc->cur_frame->caller;
     }
     if (target) {
@@ -936,14 +936,16 @@ void MVM_args_set_result_str(MVMThreadContext *tc, MVMString *result, MVMint32 f
         target = tc->cur_frame;
     }
     else {
-        if (MVM_spesh_log_is_caller_logging(tc))
-            MVMROOT(tc, result, {
+        if (MVM_spesh_log_is_caller_logging(tc)) {
+            MVMROOT(tc, result) {
                 MVM_spesh_log_return_type(tc, NULL);
-            });
-        else if (MVM_spesh_log_is_logging(tc))
-            MVMROOT(tc, result, {
+            }
+        }
+        else if (MVM_spesh_log_is_logging(tc)) {
+            MVMROOT(tc, result) {
                 MVM_spesh_log_return_to_unlogged(tc);
-            });
+            }
+        }
         target = tc->cur_frame->caller;
     }
     if (target) {

--- a/src/core/bytecode.c
+++ b/src/core/bytecode.c
@@ -607,9 +607,9 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
         return;
 
     /* Acquire the update mutex on the CompUnit. */
-    MVMROOT(tc, sf, {
+    MVMROOT(tc, sf) {
         MVM_reentrantmutex_lock(tc, (MVMReentrantMutex *)cu->body.deserialize_frame_mutex);
-    });
+    }
 
     /* Ensure no other thread has done this for us in the mean time. */
     if (sf->body.fully_deserialized) {
@@ -752,9 +752,9 @@ void MVM_bytecode_finish_frame(MVMThreadContext *tc, MVMCompUnit *cu,
                 MVM_exception_throw_adhoc(tc, "SC not yet resolved; lookup failed");
             }
             MVMObject *wval;
-            MVMROOT(tc, sf, {
+            MVMROOT(tc, sf) {
                 wval = MVM_sc_get_object(tc, sc, read_int32(pos, 8));
-            });
+            }
             MVM_ASSIGN_REF(tc, &(sf->common.header), sf->body.static_env[lex_idx].o, wval);
         }
         pos += FRAME_SLV_SIZE;

--- a/src/core/coerce.c
+++ b/src/core/coerce.c
@@ -808,17 +808,17 @@ MVMObject * MVM_radix(MVMThreadContext *tc, MVMint64 radix, MVMString *str, MVMi
 
     /* initialize the object */
     result = MVM_repr_alloc_init(tc, MVM_hll_current(tc)->slurpy_array_type);
-    MVMROOT(tc, result, {
+    MVMROOT(tc, result) {
         MVMObject *box_type = MVM_hll_current(tc)->int_box_type;
-        MVMROOT(tc, box_type, {
+        MVMROOT(tc, box_type) {
             MVMObject *boxed = MVM_repr_box_int(tc, box_type, value);
             MVM_repr_push_o(tc, result, boxed);
             boxed = MVM_repr_box_int(tc, box_type, chars_really_converted);
             MVM_repr_push_o(tc, result, boxed);
             boxed = MVM_repr_box_int(tc, box_type, pos);
             MVM_repr_push_o(tc, result, boxed);
-        });
-    });
+        }
+    }
 
     return result;
 }

--- a/src/core/continuation.c
+++ b/src/core/continuation.c
@@ -50,9 +50,9 @@ void MVM_continuation_control(MVMThreadContext *tc, MVMint64 protect,
      * allocation while we're slicing the stack frames off). */
     MVM_jit_code_trampoline(tc);
     MVMObject *cont;
-    MVMROOT2(tc, tag, code, {
+    MVMROOT2(tc, tag, code) {
         cont = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTContinuation);
-    });
+    }
 
     /* Find the tag and slice the required regions off the callstack. */
     MVMActiveHandler *active_handler_at_reset;
@@ -151,9 +151,9 @@ void MVM_continuation_invoke(MVMThreadContext *tc, MVMContinuation *cont,
     /* Force current frames to heap if there are heap frames in the continuation,
      * to maintain the no heap -> stack invariant. */
     if (have_heap_frame) {
-        MVMROOT3(tc, cont, code, bottom_frame, {
+        MVMROOT3(tc, cont, code, bottom_frame) {
             MVM_frame_force_to_heap(tc, tc->cur_frame);
-        });
+        }
     }
 
     /* Switch caller of the root to current invoker. */

--- a/src/core/dll.c
+++ b/src/core/dll.c
@@ -18,9 +18,9 @@ int MVM_dll_load(MVMThreadContext *tc, MVMString *name, MVMString *path) {
         return 0;
     }
 
-    MVMROOT2(tc, name, path, {
+    MVMROOT2(tc, name, path) {
         path = MVM_file_in_libpath(tc, path);
-    });
+    }
 
     cpath = MVM_string_utf8_c8_encode_C_string(tc, path);
     lib = MVM_nativecall_load_lib(cpath);

--- a/src/core/ext.c
+++ b/src/core/ext.c
@@ -5,12 +5,12 @@ int MVM_ext_load(MVMThreadContext *tc, MVMString *lib, MVMString *ext) {
     MVMDLLSym *sym;
     void (*init)(MVMThreadContext *);
 
-    MVMROOT2(tc, lib, ext, {
+    MVMROOT2(tc, lib, ext) {
         colon = MVM_string_ascii_decode_nt(
             tc, tc->instance->VMString, ":");
         prefix = MVM_string_concatenate(tc, lib, colon);
         name = MVM_string_concatenate(tc, prefix, ext);
-    });
+    }
 
     uv_mutex_lock(&tc->instance->mutex_ext_registry);
 
@@ -24,9 +24,9 @@ int MVM_ext_load(MVMThreadContext *tc, MVMString *lib, MVMString *ext) {
         return 0;
     }
 
-    MVMROOT(tc, name, {
+    MVMROOT(tc, name) {
         sym = (MVMDLLSym *)MVM_dll_find_symbol(tc, lib, ext);
-    });
+    }
     if (!sym) {
         char *c_name = MVM_string_utf8_encode_C_string(tc, name);
         char *waste[] = { c_name, NULL };

--- a/src/core/hll.c
+++ b/src/core/hll.c
@@ -100,12 +100,12 @@ MVMHLLConfig *MVM_hll_get_config_for(MVMThreadContext *tc, MVMString *name) {
     if (!MVM_is_null(tc, val)) (config)->member = MVM_repr_get_str(tc, val); \
 } while (0)
 static void set_max_inline_size(MVMThreadContext *tc, MVMObject *config_hash, MVMHLLConfig *config) {
-    MVMROOT(tc, config_hash, {
+    MVMROOT(tc, config_hash) {
         MVMString *key = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, "max_inline_size");
         MVMObject *size = MVM_repr_at_key_o(tc, config_hash, key);
         if (!MVM_is_null(tc, size))
             config->max_inline_size = MVM_repr_get_int(tc, size);
-    });
+    }
 }
 void MVM_hll_set_config_key(MVMThreadContext *tc, MVMHLLConfig *hll, MVMString *key, MVMObject *value) {
     hll->uint_box_type = value;
@@ -121,7 +121,7 @@ MVMObject * MVM_hll_set_config(MVMThreadContext *tc, MVMString *name, MVMObject 
     }
 
     /* MVM_string_utf8_decode() can potentially allocate, and hence gc. */
-    MVMROOT(tc, config_hash, {
+    MVMROOT(tc, config_hash) {
             check_config_key(tc, config_hash, "int_box", int_box_type, config);
             check_config_key(tc, config_hash, "uint_box", uint_box_type, config);
             check_config_key(tc, config_hash, "num_box", num_box_type, config);
@@ -192,7 +192,7 @@ MVMObject * MVM_hll_set_config(MVMThreadContext *tc, MVMString *name, MVMObject 
             MVM_gc_allocate_gen2_default_set(tc);
             MVM_intcache_for(tc, config->int_box_type);
             MVM_gc_allocate_gen2_default_clear(tc);
-        });
+        }
 
     return config_hash;
 }
@@ -222,9 +222,9 @@ MVMObject * MVM_hll_sym_get(MVMThreadContext *tc, MVMString *hll, MVMString *sym
     uv_mutex_lock(&tc->instance->mutex_hll_syms);
     hash = MVM_repr_at_key_o(tc, syms, hll);
     if (MVM_is_null(tc, hash)) {
-        MVMROOT2(tc, hll, syms, {
+        MVMROOT2(tc, hll, syms) {
             hash = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTHash);
-        });
+        }
         MVM_repr_bind_key_o(tc, syms, hll, hash);
         result = tc->instance->VMNull;
     }

--- a/src/core/intcache.c
+++ b/src/core/intcache.c
@@ -15,7 +15,7 @@ void MVM_intcache_for(MVMThreadContext *tc, MVMObject *type) {
         }
     }
     if (right_slot != -1) {
-        MVMROOT(tc, type, {
+        MVMROOT(tc, type) {
             int val;
             for (val = -1; val < 15; val++) {
                 MVMObject *obj;
@@ -26,7 +26,7 @@ void MVM_intcache_for(MVMThreadContext *tc, MVMObject *type) {
                     (MVMCollectable **)&tc->instance->int_const_cache->cache[type_index][val + 1],
                     "Boxed integer cache entry");
             }
-        });
+        }
         tc->instance->int_const_cache->types[type_index] = type;
         MVM_gc_root_add_permanent_desc(tc,
             (MVMCollectable **)&tc->instance->int_const_cache->types[type_index],

--- a/src/core/interp.c
+++ b/src/core/interp.c
@@ -1683,7 +1683,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
             OP(clone): {
                 MVMObject *value = GET_REG(cur_op, 2).o;
                 if (IS_CONCRETE(value)) {
-                    MVMROOT(tc, value, {
+                    MVMROOT(tc, value) {
                         MVMObject *cloned = REPR(value)->allocate(tc, STABLE(value));
                         /* Ordering here matters. We write the object into the
                         * register before calling copy_to. This is because
@@ -1693,7 +1693,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                         * in the register if it moved. */
                         GET_REG(cur_op, 0).o = cloned;
                         REPR(value)->copy_to(tc, STABLE(value), OBJECT_BODY(value), cloned, OBJECT_BODY(cloned));
-                    });
+                    }
                 }
                 else {
                     GET_REG(cur_op, 0).o = value;
@@ -2742,7 +2742,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (REPR(cr)->ID != MVM_REPR_ID_MVMCode)
                     MVM_exception_throw_adhoc(tc, "freshcoderef requires a coderef");
                 ncr = (MVMCode *)(GET_REG(cur_op, 0).o = MVM_repr_clone(tc, cr));
-                MVMROOT(tc, ncr, {
+                MVMROOT(tc, ncr) {
                     MVMStaticFrame *nsf;
                     if (!ncr->body.sf->body.fully_deserialized)
                         MVM_bytecode_finish_frame(tc, ncr->body.sf->body.cu, ncr->body.sf, 0);
@@ -2750,7 +2750,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                         (MVMObject *)ncr->body.sf);
                     MVM_ASSIGN_REF(tc, &(ncr->common.header), ncr->body.sf, nsf);
                     MVM_ASSIGN_REF(tc, &(ncr->common.header), ncr->body.sf->body.static_code, ncr);
-                });
+                }
                 cur_op += 4;
                 goto NEXT;
             }
@@ -3001,9 +3001,9 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 if (REPR(sc)->ID != MVM_REPR_ID_SCRef)
                     MVM_exception_throw_adhoc(tc, "Can only push an SCRef with pushcompsc");
                 if (MVM_is_null(tc, tc->compiling_scs)) {
-                    MVMROOT(tc, sc, {
+                    MVMROOT(tc, sc) {
                         tc->compiling_scs = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-                    });
+                    }
                 }
                 MVM_repr_unshift_o(tc, tc->compiling_scs, sc);
                 cur_op += 2;
@@ -4454,7 +4454,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                 cur_op += 2;
                 goto NEXT;
             OP(setthreadname):
-                MVM_thread_set_self_name(tc, GET_REG(cur_op, 0).s); 
+                MVM_thread_set_self_name(tc, GET_REG(cur_op, 0).s);
                 cur_op += 2;
                 goto NEXT;
             OP(atpos2d_i):
@@ -5214,12 +5214,12 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
 
                 MVM_platform_decodelocaltime(tc, GET_REG(cur_op, 2).i64, decoded);
 
-                MVMROOT(tc, result, {
+                MVMROOT(tc, result) {
                     REPR(result)->pos_funcs.set_elems(tc, STABLE(result), result, OBJECT_BODY(result), 9);
                     for (i = 0; i < 9; i++) {
                         MVM_repr_bind_pos_i(tc, result, i, decoded[i]);
                     }
-                });
+                }
 
                 cur_op += 4;
                 goto NEXT;
@@ -6972,7 +6972,7 @@ void MVM_interp_run(MVMThreadContext *tc, void (*initial_invoke)(MVMThreadContex
                     /* Returning 1 from breakpoint_check means we should rewind
                      * the cur_op so we hit the same breakpoint again after
                      * invoked code returned, for example. */
-                    
+
                 }
                 goto NEXT;
             }
@@ -7040,7 +7040,7 @@ void MVM_interp_run_nested(MVMThreadContext *tc, void (*initial_invoke)(MVMThrea
     __attribute__((unused))
 #endif
     MVMCallStackRecord *csrecord;
-    MVMROOT2(tc, backup_cur_frame, backup_thread_entry_frame, {
+    MVMROOT2(tc, backup_cur_frame, backup_thread_entry_frame) {
         MVMuint32 backup_mark                   = MVM_gc_root_temp_mark(tc);
         jmp_buf backup_interp_jump;
         memcpy(backup_interp_jump, tc->interp_jump, sizeof(jmp_buf));
@@ -7068,7 +7068,7 @@ void MVM_interp_run_nested(MVMThreadContext *tc, void (*initial_invoke)(MVMThrea
 
         memcpy(tc->interp_jump, backup_interp_jump, sizeof(jmp_buf));
         MVM_gc_root_temp_mark_reset(tc, backup_mark);
-    });
+    }
 }
 
 void MVM_interp_enable_tracing() {

--- a/src/core/loadbytecode.c
+++ b/src/core/loadbytecode.c
@@ -111,7 +111,7 @@ void MVM_load_bytecode(MVMThreadContext *tc, MVMString *filename) {
     }
 
     /* Otherwise, load from disk. */
-    MVMROOT(tc, filename, {
+    MVMROOT(tc, filename) {
         char *c_filename = MVM_string_utf8_c8_encode_C_string(tc, filename);
         MVMCompUnit *cu = MVM_cu_map_from_file(tc, c_filename, 1);
         cu->body.filename = filename;
@@ -122,7 +122,7 @@ void MVM_load_bytecode(MVMThreadContext *tc, MVMString *filename) {
         MVMString **key = MVM_fixkey_hash_insert_nocheck(tc, &tc->instance->loaded_compunits, filename);
         MVM_gc_root_add_permanent_desc(tc, (MVMCollectable **)key,
                                        "Loaded compilation unit filename");
-    });
+    }
 
 LEAVE:
     MVM_tc_clear_ex_release_mutex(tc);
@@ -134,14 +134,14 @@ void MVM_load_bytecode_fh(MVMThreadContext *tc, MVMObject *oshandle, MVMString *
     if (REPR(oshandle)->ID != MVM_REPR_ID_MVMOSHandle)
         MVM_exception_throw_adhoc(tc, "loadbytecodefh requires an object with REPR MVMOSHandle");
 
-    MVMROOT(tc, filename, {
+    MVMROOT(tc, filename) {
         MVMuint64 pos = MVM_io_tell(tc, oshandle);
         cu = MVM_cu_map_from_file_handle(tc, MVM_io_fileno(tc, oshandle), pos);
         cu->body.filename = filename;
         MVM_gc_write_barrier_hit(tc, (MVMCollectable *)cu);
 
         run_comp_unit(tc, cu);
-    });
+    }
 }
 
 /* Callback after running deserialize code to run the load code. */

--- a/src/core/nativecall.c
+++ b/src/core/nativecall.c
@@ -539,7 +539,7 @@ MVMint8 MVM_nativecall_build(MVMThreadContext *tc, MVMObject *site, MVMString *l
 static MVMObject * nativecall_cast(MVMThreadContext *tc, MVMObject *target_spec, MVMObject *target_type, void *cpointer_body) {
     MVMObject *result = NULL;
 
-    MVMROOT2(tc, target_spec, target_type, {
+    MVMROOT2(tc, target_spec, target_type) {
         switch (REPR(target_type)->ID) {
             case MVM_REPR_ID_P6opaque: {
                 const MVMStorageSpec *ss = REPR(target_spec)->get_storage_spec(tc, STABLE(target_spec));
@@ -677,7 +677,7 @@ static MVMObject * nativecall_cast(MVMThreadContext *tc, MVMObject *target_spec,
             default:
                 MVM_exception_throw_adhoc(tc, "Internal error: unhandled target type");
         }
-    });
+    }
 
     return result;
 }

--- a/src/core/nativecall_dyncall.c
+++ b/src/core/nativecall_dyncall.c
@@ -470,9 +470,9 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
      * shall need, since later we may allocate a result and and move it. */
     MVMNativeCallBody *body = MVM_nativecall_get_nc_body(tc, site);
     if (MVM_UNLIKELY(!body->lib_handle)) {
-        MVMROOT3(tc, site, args, res_type, {
+        MVMROOT3(tc, site, args, res_type) {
             MVM_nativecall_restore_library(tc, body, site);
-        });
+        }
         body = MVM_nativecall_get_nc_body(tc, site);
     }
     MVMint16  num_args    = body->num_args;
@@ -600,7 +600,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
         }
     }
 
-    MVMROOT3(tc, args, res_type, result, {
+    MVMROOT3(tc, args, res_type, result) {
         MVM_gc_mark_thread_blocked(tc);
         if (result) {
             /* We are calling a C++ constructor so we hand back the invocant (THIS) we recorded earlier. */
@@ -740,7 +740,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                     MVM_exception_throw_adhoc(tc, "Internal error: unhandled dyncall return type");
             }
         }
-    });
+    }
 
     num_rws = 0;
     for (i = 0; i < num_args; i++) {
@@ -887,9 +887,9 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
      * shall need, since later we may allocate a result and and move it. */
     MVMNativeCallBody *body = MVM_nativecall_get_nc_body(tc, site);
     if (MVM_UNLIKELY(!body->lib_handle)) {
-        MVMROOT2(tc, site, res_type, {
+        MVMROOT2(tc, site, res_type) {
             MVM_nativecall_restore_library(tc, body, site);
-        });
+        }
         body = MVM_nativecall_get_nc_body(tc, site);
     }
     MVMint16  num_args    = body->num_args;
@@ -1110,7 +1110,7 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
         }
     }
 
-    MVMROOT2(tc, res_type, result, {
+    MVMROOT2(tc, res_type, result) {
         MVM_gc_mark_thread_blocked(tc);
         if (result) {
             /* We are calling a C++ constructor so we hand back the invocant (THIS) we recorded earlier. */
@@ -1290,7 +1290,7 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                         "in MVM_nativecall_dispatch", ret_type & MVM_NATIVECALL_ARG_TYPE_MASK);
             }
         }
-    });
+    }
 
 
     /* Free any memory that we need to. */

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -486,9 +486,9 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
      * shall need, since later we may allocate a result and and move it. */
     MVMNativeCallBody *body = MVM_nativecall_get_nc_body(tc, site);
     if (MVM_UNLIKELY(!body->lib_handle)) {
-        MVMROOT3(tc, site, args, res_type, {
+        MVMROOT3(tc, site, args, res_type) {
             MVM_nativecall_restore_library(tc, body, site);
-        });
+        }
         body = MVM_nativecall_get_nc_body(tc, site);
     }
     MVMint16  num_args    = body->num_args;
@@ -616,7 +616,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
     }
 
 
-    MVMROOT3(tc, args, res_type, result, {
+    MVMROOT3(tc, args, res_type, result) {
         MVM_gc_mark_thread_blocked(tc);
         if (result) {
             /* We are calling a C++ constructor so we hand back the invocant (THIS) we recorded earlier. */
@@ -719,7 +719,7 @@ MVMObject * MVM_nativecall_invoke(MVMThreadContext *tc, MVMObject *res_type,
                     MVM_exception_throw_adhoc(tc, "Internal error: unhandled libffi return type");
             }
         }
-    });
+    }
 
     for (i = 0; i < num_args; i++) {
         MVMObject *value = MVM_repr_at_pos_o(tc, args, i);
@@ -859,9 +859,9 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
      * shall need, since later we may allocate a result and and move it. */
     MVMNativeCallBody *body = MVM_nativecall_get_nc_body(tc, site);
     if (MVM_UNLIKELY(!body->lib_handle)) {
-        MVMROOT2(tc, site, res_type, {
+        MVMROOT2(tc, site, res_type) {
             MVM_nativecall_restore_library(tc, body, site);
-        });
+        }
         body = MVM_nativecall_get_nc_body(tc, site);
     }
     MVMint16  num_args    = body->num_args;
@@ -1103,7 +1103,7 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
     }
 
 
-    MVMROOT2(tc, res_type, result, {
+    MVMROOT2(tc, res_type, result) {
         MVM_gc_mark_thread_blocked(tc);
         if (result) {
             /* We are calling a C++ constructor so we hand back the invocant (THIS) we recorded earlier. */
@@ -1242,7 +1242,7 @@ void MVM_nativecall_dispatch(MVMThreadContext *tc, MVMObject *res_type,
                         "in MVM_nativecall_dispatch", ret_type & MVM_NATIVECALL_ARG_TYPE_MASK);
             }
         }
-    });
+    }
 
     /* Free any memory that we need to. */
     if (free_strs)

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -19,18 +19,18 @@ MVMObject * MVM_thread_new(MVMThreadContext *tc, MVMObject *invokee, MVMint64 ap
     interval_id = MVM_telemetry_interval_start(tc, "spawning a new thread off of me");
 
     /* Create the Thread object and stash code to run and lifetime. */
-    MVMROOT(tc, invokee, {
+    MVMROOT(tc, invokee) {
         thread = (MVMThread *)MVM_repr_alloc_init(tc, tc->instance->Thread);
-    });
+    }
     thread->body.stage = MVM_thread_stage_unstarted;
     MVM_ASSIGN_REF(tc, &(thread->common.header), thread->body.invokee, invokee);
     thread->body.app_lifetime = app_lifetime;
 
     /* Try to create the new threadcontext. Can throw if libuv can't
      * create a loop for it for some reason (i.e. too many open files) */
-    MVMROOT(tc, thread, {
+    MVMROOT(tc, thread) {
         child_tc = MVM_tc_create(tc, tc->instance);
-    });
+    }
 
     /* Set up the new threadcontext a little. */
     child_tc->thread_obj = thread;
@@ -175,9 +175,9 @@ void MVM_thread_run(MVMThreadContext *tc, MVMObject *thread_obj) {
                 /* Another thread decided we'll GC now. Release mutex, and
                  * do the GC, making sure thread_obj and child are marked. */
                 uv_mutex_unlock(&tc->instance->mutex_threads);
-                MVMROOT2(tc, thread_obj, child, {
+                MVMROOT2(tc, thread_obj, child) {
                     GC_SYNC_POINT(tc);
-                });
+                }
             }
         }
 
@@ -363,7 +363,7 @@ void MVM_thread_set_self_name(MVMThreadContext *tc, MVMString *name) {
     MVMuint64 name_length = MVM_string_graphs(tc, name);
     MVMint16 acceptable_length = name_length > 15 ? 15 : name_length;
     MVMuint8 success = 0;
-    MVMROOT(tc, name, {
+    MVMROOT(tc, name) {
     while (acceptable_length > 0 && !success) {
             MVMString *substring = MVM_string_substring(tc, name, 0, acceptable_length);
             char *c_name = MVM_string_utf8_c8_encode_C_string(tc, substring);
@@ -377,6 +377,6 @@ void MVM_thread_set_self_name(MVMThreadContext *tc, MVMString *name) {
             MVM_free(c_name);
             acceptable_length--;
         }
-    });
+    }
     #endif
 }

--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -580,9 +580,9 @@ MVM_PUBLIC void MVM_debugserver_notify_unhandled_exception(MVMThreadContext *tc,
 
         uv_mutex_lock(&tc->instance->debugserver->mutex_network_send);
 
-        MVMROOT(tc, ex, {
+        MVMROOT(tc, ex) {
             request_all_threads_suspend(tc, ctx, NULL);
-        });
+        }
 
         event_id = tc->instance->debugserver->event_id;
         tc->instance->debugserver->event_id += 2;
@@ -784,7 +784,7 @@ static void request_all_threads_resume(MVMThreadContext *dtc, cmp_ctx_t *ctx, re
 
     uv_mutex_lock(&vm->mutex_threads);
     cur_thread = vm->threads;
-    MVMROOT(dtc, cur_thread, {
+    MVMROOT(dtc, cur_thread) {
         while (cur_thread) {
             if (cur_thread != dtc->thread_obj) {
                 AO_t current = MVM_load(&cur_thread->body.tc->gc_status);
@@ -802,7 +802,7 @@ static void request_all_threads_resume(MVMThreadContext *dtc, cmp_ctx_t *ctx, re
             }
             cur_thread = cur_thread->body.next;
         }
-    });
+    }
 
     uv_mutex_lock(&vm->debugserver->mutex_cond);
     uv_cond_broadcast(&vm->debugserver->tell_threads);
@@ -1331,7 +1331,7 @@ static MVMuint64 request_hll_symbol_data(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
 
     MVMString *hll_name_str = NULL;
     MVMString *key_str = NULL;
-    
+
     if (argument->fields_set & FS_hll) {
         hll_name_str = MVM_string_utf8_decode(dtc, vm->VMString, argument->hll, strlen(argument->hll));
     }
@@ -1345,7 +1345,7 @@ static MVMuint64 request_hll_symbol_data(MVMThreadContext *dtc, cmp_ctx_t *ctx, 
     if (!(vm->hll_syms) || !IS_CONCRETE(vm->hll_syms)) {
         if (dtc->instance->debugserver->debugspam_protocol)
             fprintf(stderr, "No HLL syms hash found in instance ?!?\n");
-        
+
         MVM_gc_root_temp_pop_n(dtc, 2);
         return 1;
     }
@@ -1777,12 +1777,12 @@ static MVMint32 create_context_or_code_obj_debug_handle(MVMThreadContext *dtc, c
     }
 
     if (argument->type == MT_ContextHandle) {
-        MVMROOT(dtc, cur_frame, {
+        MVMROOT(dtc, cur_frame) {
             if (MVM_FRAME_IS_ON_CALLSTACK(dtc, cur_frame)) {
                 cur_frame = MVM_frame_debugserver_move_to_heap(dtc, to_do->body.tc, cur_frame);
             }
             allocate_and_send_handle(dtc, ctx, argument, MVM_context_from_frame(dtc, cur_frame));
-        });
+        }
     } else if (argument->type == MT_CodeObjectHandle) {
         allocate_and_send_handle(dtc, ctx, argument, cur_frame->code_ref);
     } else {

--- a/src/disp/boot.c
+++ b/src/disp/boot.c
@@ -54,7 +54,7 @@ static void boot_code_constant(MVMThreadContext *tc, MVMArgs arg_info) {
     MVM_args_proc_setup(tc, &arg_ctx, arg_info);
     MVM_args_checkarity(tc, &arg_ctx, 1, 1);
     MVMObject *capture = MVM_args_get_required_pos_obj(tc, &arg_ctx, 0);
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         /* Get a capture dropping the first argument, which is the callee. */
         MVMObject *args_capture = MVM_disp_program_record_capture_drop_arg(tc, capture, 0);
 
@@ -70,7 +70,7 @@ static void boot_code_constant(MVMThreadContext *tc, MVMArgs arg_info) {
             MVM_exception_throw_adhoc(tc,
                     "boot-code-constant dispatcher only works with MVMCode or MVMCFunction");
         }
-    });
+    }
 
     MVM_args_set_result_obj(tc, tc->instance->VMNull, MVM_RETURN_CURRENT_FRAME);
 }
@@ -85,7 +85,7 @@ static void boot_foreign_code(MVMThreadContext *tc, MVMArgs arg_info) {
     MVM_args_proc_setup(tc, &arg_ctx, arg_info);
     MVM_args_checkarity(tc, &arg_ctx, 1, 1);
     MVMObject *capture = MVM_args_get_required_pos_obj(tc, &arg_ctx, 0);
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         /* Get a capture dropping the first argument, which is the callee. */
         MVMObject *args_capture = MVM_disp_program_record_capture_drop_arg(tc, capture, 0);
 
@@ -98,7 +98,7 @@ static void boot_foreign_code(MVMThreadContext *tc, MVMArgs arg_info) {
             MVM_exception_throw_adhoc(tc,
                     "boot-foreign-code dispatcher only works with MVMNativeCall, got %s", REPR(code)->name);
         }
-    });
+    }
 
     MVM_args_set_result_obj(tc, tc->instance->VMNull, MVM_RETURN_CURRENT_FRAME);
 }
@@ -116,14 +116,14 @@ static void boot_code(MVMThreadContext *tc, MVMArgs arg_info) {
     MVM_args_proc_setup(tc, &arg_ctx, arg_info);
     MVM_args_checkarity(tc, &arg_ctx, 1, 1);
     MVMObject *capture = MVM_args_get_required_pos_obj(tc, &arg_ctx, 0);
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         /* Get a capture dropping the first argument, which is the callee. */
         MVMObject *args_capture = MVM_disp_program_record_capture_drop_arg(tc, capture, 0);
 
-        MVMROOT(tc, args_capture, {
+        MVMROOT(tc, args_capture) {
             /* Work out what the callee is, and set us up to invoke it. */
             MVMObject *code = MVM_capture_arg_pos_o(tc, capture, 0);
-            MVMROOT(tc, code, {
+            MVMROOT(tc, code) {
                 MVMObject *tracked_code = MVM_disp_program_record_track_arg(tc, capture, 0);
                 if (REPR(code)->ID == MVM_REPR_ID_MVMCode && IS_CONCRETE(code)) {
                     MVM_disp_program_record_tracked_code(tc, tracked_code, args_capture);
@@ -135,9 +135,9 @@ static void boot_code(MVMThreadContext *tc, MVMArgs arg_info) {
                     MVM_exception_throw_adhoc(tc,
                             "boot-code dispatcher only works with MVMCode or MVMCFunction");
                 }
-            });
-        });
-    });
+            }
+        }
+    }
 
     MVM_args_set_result_obj(tc, tc->instance->VMNull, MVM_RETURN_CURRENT_FRAME);
 }
@@ -169,9 +169,9 @@ static void boot_syscall(MVMThreadContext *tc, MVMArgs arg_info) {
 
     /* Drop the name from the args capture, and then check them. */
     MVMObject *args_capture;
-    MVMROOT(tc, name, {
+    MVMROOT(tc, name) {
         args_capture = MVM_disp_program_record_capture_drop_arg(tc, capture, 0);
-    });
+    }
     MVMCallsite *cs = ((MVMCapture *)args_capture)->body.callsite;
     if (MVM_callsite_has_nameds(tc, cs)) {
         char *c_name = MVM_string_utf8_encode_C_string(tc, name);
@@ -212,10 +212,10 @@ static void boot_syscall(MVMThreadContext *tc, MVMArgs arg_info) {
                 MVMuint32 expected = syscall->expected_reprs[i];
                 MVMuint32 got = REPR(MVM_capture_arg_pos_o(tc, args_capture, i))->ID;
                 if (expected == got) {
-                    MVMROOT2(tc, name, args_capture, {
+                    MVMROOT2(tc, name, args_capture) {
                         MVM_disp_program_record_guard_type(tc,
                                 MVM_disp_program_record_track_arg(tc, args_capture, i));
-                    });
+                    }
                 }
                 else {
                     char *c_name = MVM_string_utf8_encode_C_string(tc, name);
@@ -229,10 +229,10 @@ static void boot_syscall(MVMThreadContext *tc, MVMArgs arg_info) {
             }
             if (syscall->expected_concrete[i]) {
                 if (IS_CONCRETE(MVM_capture_arg_pos_o(tc, args_capture, i))) {
-                    MVMROOT2(tc, name, args_capture, {
+                    MVMROOT2(tc, name, args_capture) {
                         MVM_disp_program_record_guard_concreteness(tc,
                                 MVM_disp_program_record_track_arg(tc, args_capture, i));
-                    });
+                    }
                 }
                 else {
                     char *c_name = MVM_string_utf8_encode_C_string(tc, name);
@@ -302,9 +302,9 @@ static void lang_call(MVMThreadContext *tc, MVMArgs arg_info) {
     /* Obtain and guard on the first argument of the capture, which is the
      * thing to invoke. */
     MVMObject *tracked_invokee;
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
          tracked_invokee = MVM_disp_program_record_track_arg(tc, capture, 0);
-    });
+    }
     MVM_disp_program_record_guard_type(tc, tracked_invokee);
 
     /* If it's a VM code object or a VM function, we'll delegate to the
@@ -364,9 +364,9 @@ static void lang_meth_call(MVMThreadContext *tc, MVMArgs arg_info) {
 
     /* If the invocant has an associated HLL and method dispatcher, delegate there. */
     MVMObject *tracked_invocant;
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
          tracked_invocant = MVM_disp_program_record_track_arg(tc, capture, 0);
-    });
+    }
     MVMObject *invocant = MVM_capture_arg_pos_o(tc, capture, 0);
     MVMHLLConfig *hll = STABLE(invocant)->hll_owner;
     if (hll && hll->method_call_dispatcher) {
@@ -380,15 +380,15 @@ static void lang_meth_call(MVMThreadContext *tc, MVMArgs arg_info) {
      * on the invocant, add a guard. */
     MVM_disp_program_record_guard_type(tc, tracked_invocant);
     MVMObject *HOW;
-    MVMROOT2(tc, capture, invocant, {
+    MVMROOT2(tc, capture, invocant) {
         HOW = MVM_6model_get_how(tc, STABLE(invocant));
-    });
+    }
     if (REPR(HOW)->ID == MVM_REPR_ID_KnowHOWREPR && IS_CONCRETE(HOW)) {
         MVMObject *methods = ((MVMKnowHOWREPR *)HOW)->body.methods;
         MVMString *method_name = MVM_capture_arg_pos_s(tc, capture, 1);
         MVMObject *method = MVM_repr_at_key_o(tc, methods, method_name);
         if (IS_CONCRETE(method)) {
-            MVMROOT2(tc, capture, method, {
+            MVMROOT2(tc, capture, method) {
                 /* Method found. Guard on the name. */
                 MVMObject *tracked_name = MVM_disp_program_record_track_arg(tc, capture, 1);
                 MVM_disp_program_record_guard_literal(tc, tracked_name);
@@ -403,7 +403,7 @@ static void lang_meth_call(MVMThreadContext *tc, MVMArgs arg_info) {
                         args_capture, 0, MVM_CALLSITE_ARG_OBJ, method_reg);
                 MVM_disp_program_record_delegate(tc, tc->instance->str_consts.lang_call,
                         del_capture);
-            });
+            }
         }
         else {
             MVM_disp_program_record_delegate(tc,
@@ -439,10 +439,10 @@ static void lang_find_meth(MVMThreadContext *tc, MVMArgs arg_info) {
     MVMObject *invocant = MVM_capture_arg_pos_o(tc, capture, 0);
     MVMHLLConfig *hll = STABLE(invocant)->hll_owner;
     if (hll && hll->find_method_dispatcher) {
-        MVMROOT(tc, capture, {
+        MVMROOT(tc, capture) {
             MVMObject *tracked_invocant = MVM_disp_program_record_track_arg(tc, capture, 0);
             MVM_disp_program_record_guard_hll(tc, tracked_invocant);
-        });
+        }
         MVM_disp_program_record_delegate(tc, hll->find_method_dispatcher, capture);
         return;
     }
@@ -450,23 +450,23 @@ static void lang_find_meth(MVMThreadContext *tc, MVMArgs arg_info) {
     /* Obtain and guard on the first argument of the capture, which is the
      * invocant of the method call, and then also on the name and the
      * exception flag. */
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         MVMObject *tracked_invocant = MVM_disp_program_record_track_arg(tc, capture, 0);
         MVM_disp_program_record_guard_type(tc, tracked_invocant);
         for (MVMuint8 i = 1; i <= 2; i++) {
             MVMObject *tracked_arg = MVM_disp_program_record_track_arg(tc, capture, i);
             MVM_disp_program_record_guard_literal(tc, tracked_arg);
         }
-    });
+    }
 
 
     /* Otherwise if it's a KnowHOW, then look in its method table (this is how
      * method dispatch bottoms out in the VM). */
     MVMint64 exceptional = MVM_capture_arg_pos_i(tc, capture, 2);
     MVMObject *HOW;
-    MVMROOT2(tc, capture, invocant, {
+    MVMROOT2(tc, capture, invocant) {
         HOW = MVM_6model_get_how(tc, STABLE(invocant));
-    });
+    }
     if (REPR(HOW)->ID == MVM_REPR_ID_KnowHOWREPR && IS_CONCRETE(HOW)) {
         MVMObject *methods = ((MVMKnowHOWREPR *)HOW)->body.methods;
         MVMString *method_name = MVM_capture_arg_pos_s(tc, capture, 1);
@@ -563,9 +563,9 @@ static void boot_boolify(MVMThreadContext *tc, MVMArgs arg_info) {
 
     /* Always guard on the type of the object being tested. */
     MVMObject *tracked_object;
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
          tracked_object = MVM_disp_program_record_track_arg(tc, capture, 0);
-    });
+    }
     MVM_disp_program_record_guard_type(tc, tracked_object);
 
     /* Now go on the boolification protocol value of the object. */
@@ -653,10 +653,10 @@ static void lang_hllize(MVMThreadContext *tc, MVMArgs arg_info) {
 
     /* Guard on the type's HLL (something later may strengthen it, if it is
      * doing a type mapping). */
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         MVM_disp_program_record_guard_hll(tc,
                 MVM_disp_program_record_track_arg(tc, capture, 0));
-    });
+    }
 
     MVMCallsite *cs = ((MVMCapture *)capture)->body.callsite;
 
@@ -665,10 +665,10 @@ static void lang_hllize(MVMThreadContext *tc, MVMArgs arg_info) {
         hll = MVM_disp_program_record_get_hll(tc);
     }
     else {
-        MVMROOT(tc, capture, {
+        MVMROOT(tc, capture) {
             MVM_disp_program_record_guard_literal(tc,
                 MVM_disp_program_record_track_arg(tc, capture, 1));
-        });
+        }
         MVMRegister name;
         MVMCallsiteFlags name_kind;
         MVM_capture_arg_pos(tc, capture, 1, &name, &name_kind);
@@ -711,10 +711,10 @@ static void lang_isinvokable(MVMThreadContext *tc, MVMArgs arg_info) {
 
     /* Guard on the type, as that's how we make our decision about either
      * the outcome or where to delegate. */
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         MVM_disp_program_record_guard_type(tc,
                 MVM_disp_program_record_track_arg(tc, capture, 0));
-    });
+    }
 
     /* Get the value, and ensure it's an object (natives are certainly not
      * invokable). */

--- a/src/disp/inline_cache.c
+++ b/src/disp/inline_cache.c
@@ -105,9 +105,9 @@ static void dispatch_monomorphic(MVMThreadContext *tc,
     record->arg_info.source = source;
     record->arg_info.map = arg_indices;
     MVMint64 outcome;
-    MVMROOT2(tc, id, sf, {
+    MVMROOT2(tc, id, sf) {
         outcome = MVM_disp_program_run(tc, dp, record, cid, bytecode_offset, 0);
-    });
+    }
     if (!outcome) {
         /* Dispatch program failed. Remove this record and then record a new
          * dispatch program. */
@@ -136,9 +136,9 @@ static void dispatch_monomorphic_flattening(MVMThreadContext *tc,
                 dp->num_temporaries);
         record->arg_info = flat_record->arg_info;
         MVMint64 outcome;
-        MVMROOT2(tc, id, sf, {
+        MVMROOT2(tc, id, sf) {
             outcome = MVM_disp_program_run(tc, dp, record, cid, bytecode_offset, 0);
-        });
+        }
         if (outcome) {
             /* It matches, so we're ready to continue. */
             return;
@@ -176,9 +176,9 @@ static void dispatch_polymorphic(MVMThreadContext *tc,
     MVMint32 i;
     for (i = entry->num_dps - 1; i >= 0; i--) {
         MVMint64 outcome;
-        MVMROOT2(tc, id, sf, {
+        MVMROOT2(tc, id, sf) {
             outcome = MVM_disp_program_run(tc, entry->dps[i], record, cid, bytecode_offset, i);
-        });
+        }
         if (outcome)
             return;
     }
@@ -212,9 +212,9 @@ static void dispatch_polymorphic_flattening(MVMThreadContext *tc,
     for (i = entry->num_dps - 1; i >= 0; i--) {
         if (flat_record->arg_info.callsite == entry->flattened_css[i]) {
             MVMint64 outcome;
-            MVMROOT2(tc, id, sf, {
+            MVMROOT2(tc, id, sf) {
                 outcome = MVM_disp_program_run(tc, entry->dps[i], record, cid, bytecode_offset, i);
-            });
+            }
             if (outcome)
                 return;
         }

--- a/src/disp/program.c
+++ b/src/disp/program.c
@@ -259,7 +259,7 @@ static void dump_program(MVMThreadContext *tc, MVMDispProgram *dp) {
                         STABLE(((MVMObject *)dp->gc_constants[op->arg_guard.checkee]))->debug_name);
                 break;
             case MVMDispOpcodeGuardArgLiteralStr: {
-                char *c_str = MVM_string_utf8_encode_C_string(tc, 
+                char *c_str = MVM_string_utf8_encode_C_string(tc,
                         ((MVMString *)dp->gc_constants[op->arg_guard.checkee]));
                 fprintf(stderr, "    Guard arg %d (literal string '%s')\n",
                         op->arg_guard.arg_idx, c_str);
@@ -320,7 +320,7 @@ static void dump_program(MVMThreadContext *tc, MVMDispProgram *dp) {
                         STABLE(((MVMObject *)dp->gc_constants[op->temp_guard.checkee]))->debug_name);
                 break;
             case MVMDispOpcodeGuardTempLiteralStr: {
-                char *c_str = MVM_string_utf8_encode_C_string(tc, 
+                char *c_str = MVM_string_utf8_encode_C_string(tc,
                         ((MVMString *)dp->gc_constants[op->temp_guard.checkee]));
                 fprintf(stderr, "    Guard temp %d (literal string '%s')\n",
                         op->temp_guard.temp, c_str);
@@ -576,9 +576,9 @@ void MVM_disp_program_run_dispatch(MVMThreadContext *tc, MVMDispDefinition *disp
 
     /* Form an argument capture. */
     MVMObject *capture;
-    MVMROOT(tc, update_sf, {
+    MVMROOT(tc, update_sf) {
         capture = MVM_capture_from_args(tc, arg_info);
-    });
+    }
 
     /* Push a dispatch recording frame onto the callstack; this is how we'll
      * keep track of the current recording state. */
@@ -1046,7 +1046,7 @@ MVMObject * MVM_disp_program_record_track_attr(MVMThreadContext *tc, MVMObject *
     /* Ensure the tracked value is an object type. */
     if (((MVMTracked *)tracked_in)->body.kind != MVM_CALLSITE_ARG_OBJ)
         MVM_exception_throw_adhoc(tc, "Can only use dispatcher-track-attr on a tracked object");
-    
+
     /* Resolve the tracked value. */
     MVMCallStackDispatchRecord *record = MVM_callstack_find_topmost_dispatch_recording(tc);
     MVMuint32 value_index = find_tracked_value_index(tc, &(record->rec), tracked_in);
@@ -1752,9 +1752,9 @@ static void record_resume(MVMThreadContext *tc, MVMObject *capture, MVMDispResum
     /* Set up the resumptions list and populate the initial entry (list as we
      * may fall back to resumptions of enclosing dispatchers). */
     MVM_VECTOR_INIT(record->rec.resumptions, 1);
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         push_resumption(tc, record, resume_data);
-    });
+    }
 
     /* Record the kind of dispatch resumption we're doing, and then delegate to
      * the appropriate `resume` dispatcher callback. */
@@ -3571,12 +3571,12 @@ MVMint64 MVM_disp_program_run(MVMThreadContext *tc, MVMDispProgram *dp,
                 record->chosen_dp = dp;
                 MVMCode *code = (MVMCode *)record->temps[op.res_code.temp_invokee].o;
                 if (spesh_cid) {
-                    MVMROOT(tc, code, {
+                    MVMROOT(tc, code) {
                         MVM_spesh_log_dispatch_resolution_for_correlation_id(tc, spesh_cid,
                             bytecode_offset, dp_index);
                         if (tc->spesh_log) /* Log may have filled from previous entry */
                             MVM_spesh_log_bytecode_target(tc, spesh_cid, bytecode_offset, code);
-                    });
+                    }
                 }
                 MVM_frame_dispatch(tc, code, invoke_args, -1);
                 goto accept;

--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -751,14 +751,14 @@ static void capture_pos_args_impl(MVMThreadContext *tc, MVMArgs arg_info) {
 
     /* Set up an args processing context and use the standard slurpy args
      * handler to extract all positionals. */
-    MVMROOT(tc, capture, {
+    MVMROOT(tc, capture) {
         MVMArgs capture_args = MVM_capture_to_args(tc, capture);
         MVMArgProcContext capture_ctx;
         MVM_args_proc_setup(tc, &capture_ctx, capture_args);
         MVMObject *result = MVM_args_slurpy_positional(tc, &capture_ctx, 0);
         MVM_args_proc_cleanup(tc, &capture_ctx);
         MVM_args_set_result_obj(tc, result, MVM_RETURN_CURRENT_FRAME);
-    });
+    }
 }
 static MVMDispSysCall capture_pos_args = {
     .c_name = "capture-pos-args",
@@ -1061,17 +1061,17 @@ static MVMDispSysCall try_capture_lex = {
 static void try_capture_lex_callers_impl(MVMThreadContext *tc, MVMArgs arg_info) {
     MVMObject *code = get_obj_arg(arg_info, 0);
     MVMFrame *find;
-    MVMROOT(tc, code, {
+    MVMROOT(tc, code) {
         find = MVM_frame_force_to_heap(tc, tc->cur_frame);
-    });
+    }
     while (find) {
         if (((MVMCode *)code)->body.sf->body.outer == find->static_info) {
             MVMFrame *orig = tc->cur_frame;
             tc->cur_frame = find;
-            MVMROOT(tc, orig, {
+            MVMROOT(tc, orig) {
                 MVM_frame_capturelex(tc, code);
                 tc->cur_frame = orig;
-            });
+            }
             break;
         }
         find = find->caller;

--- a/src/gc/allocation.c
+++ b/src/gc/allocation.c
@@ -54,7 +54,7 @@ void * MVM_gc_allocate_nursery(MVMThreadContext *tc, size_t size) {
  * and meta-object. */
 MVMSTable * MVM_gc_allocate_stable(MVMThreadContext *tc, const MVMREPROps *repr, MVMObject *how) {
     MVMSTable *st;
-    MVMROOT(tc, how, {
+    MVMROOT(tc, how) {
         st                = MVM_gc_allocate_zeroed(tc, sizeof(MVMSTable));
         st->header.flags1 = MVM_CF_STABLE;
         st->header.size   = sizeof(MVMSTable);
@@ -63,34 +63,34 @@ MVMSTable * MVM_gc_allocate_stable(MVMThreadContext *tc, const MVMREPROps *repr,
         st->type_cache_id = MVM_6model_next_type_cache_id(tc);
         st->debug_name    = NULL;
         MVM_ASSIGN_REF(tc, &(st->header), st->HOW, how);
-    });
+    }
     return st;
 }
 
 /* Allocates a new type object. */
 MVMObject * MVM_gc_allocate_type_object(MVMThreadContext *tc, MVMSTable *st) {
     MVMObject *obj;
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         obj                = MVM_gc_allocate_zeroed(tc, sizeof(MVMObject));
         obj->header.flags1 = MVM_CF_TYPE_OBJECT;
         obj->header.size   = sizeof(MVMObject);
         obj->header.owner  = tc->thread_id;
         MVM_ASSIGN_REF(tc, &(obj->header), obj->st, st);
-    });
+    }
     return obj;
 }
 
 /* Allocates a new object, and points it at the specified STable. */
 MVMObject * MVM_gc_allocate_object(MVMThreadContext *tc, MVMSTable *st) {
     MVMObject *obj;
-    MVMROOT(tc, st, {
+    MVMROOT(tc, st) {
         obj               = MVM_gc_allocate_zeroed(tc, st->size);
         obj->header.size  = (MVMuint16)st->size;
         obj->header.owner = tc->thread_id;
         MVM_ASSIGN_REF(tc, &(obj->header), obj->st, st);
         if (st->mode_flags & MVM_FINALIZE_TYPE)
             MVM_gc_finalize_add_to_queue(tc, obj);
-    });
+    }
     return obj;
 }
 

--- a/src/gc/finalize.c
+++ b/src/gc/finalize.c
@@ -98,11 +98,11 @@ void MVM_gc_finalize_run_handler(MVMThreadContext *tc) {
     if (handler) {
         /* Drain the finalizing queue to an array. */
         MVMObject *drain;
-        MVMROOT(tc, handler, {
+        MVMROOT(tc, handler) {
             drain = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
             while (tc->num_finalizing > 0)
                 MVM_repr_push_o(tc, drain, tc->finalizing[--tc->num_finalizing]);
-        });
+        }
 
         /* If there is a last exception handler result stored, put something
          * in place to restore it, otherwise it may be overwritten during the

--- a/src/gc/roots.h
+++ b/src/gc/roots.h
@@ -17,7 +17,7 @@ MVM_STATIC_INLINE void MVM_gc_root_temp_push(MVMThreadContext *tc, MVMCollectabl
 #endif
 
     /* If less than the number of always-allocated roots, just add. */
-    if (tc->num_temproots < MVM_TEMP_ROOT_BASE_ALLOC) {
+    if (MVM_LIKELY(tc->num_temproots < MVM_TEMP_ROOT_BASE_ALLOC)) {
         tc->temproots[tc->num_temproots] = obj_ref;
         tc->num_temproots++;
     }
@@ -26,6 +26,46 @@ MVM_STATIC_INLINE void MVM_gc_root_temp_push(MVMThreadContext *tc, MVMCollectabl
     else {
         MVM_gc_root_temp_push_slow(tc, obj_ref);
     }
+}
+
+/* Special forms of root pushing only needed for the MVMROOT macros */
+static MVMuint8 __MVM_gc_root_temp_push_ensure_space_slow(MVMThreadContext *tc, MVMuint8 amount) {
+    if (tc->num_temproots + amount > tc->alloc_temproots) {
+        tc->alloc_temproots *= 2;
+        tc->temproots = MVM_realloc(tc->temproots,
+            sizeof(MVMCollectable **) * tc->alloc_temproots);
+    }
+    return 1;
+}
+MVM_STATIC_INLINE MVMuint8 __MVM_gc_root_temp_push_ensure_space(MVMThreadContext *tc, MVMuint8 amount) {
+    /* If less than the number of always-allocated roots, we are happy */
+    if (MVM_LIKELY(tc->num_temproots + amount < MVM_TEMP_ROOT_BASE_ALLOC)) {
+        return 1;
+    }
+    else {
+        /* Make a call into the slow path, we don't ask for this one
+         * to be inlined. */
+        __MVM_gc_root_temp_push_ensure_space_slow(tc, amount);
+        return 1;
+    }
+}
+/* We only use this after having manually assured that there is space. */
+MVM_STATIC_INLINE MVMuint8 __MVM_gc_root_temp_push_nonvoid_noslow(MVMThreadContext *tc, MVMCollectable **obj_ref, MVMuint8 chain_in) {
+    /* If debugging, ensure the root is not null. */
+#if MVM_TEMP_ROOT_DEBUG
+    if (obj_ref == NULL)
+        MVM_panic(MVM_exitcode_gcroots, "Illegal attempt to add null object address as a temporary root");
+#endif
+
+    tc->temproots[tc->num_temproots] = obj_ref;
+    tc->num_temproots++;
+    return 1;
+}
+/* Special version of gc_root_temp_push that returns a value so it is
+ * allowed to be chained together without the compiler complaining. */
+MVM_STATIC_INLINE MVMuint8 __MVM_gc_root_temp_push_nonvoid(MVMThreadContext *tc, MVMCollectable **obj_ref, MVMuint8 chain_in) {
+    MVM_gc_root_temp_push(tc, obj_ref);
+    return 1;
 }
 
 /* Pop top root from the per-thread temporary roots stack. */
@@ -63,50 +103,91 @@ void MVM_gc_root_gen2_cleanup(MVMThreadContext *tc);
 void MVM_gc_root_add_frame_roots_to_worklist(MVMThreadContext *tc, MVMGCWorklist *worklist, MVMFrame *start_frame);
 void MVM_gc_root_add_frame_registers_to_worklist(MVMThreadContext *tc, MVMGCWorklist *worklist, MVMFrame *frame);
 
-/* Macros related to rooting objects into the temporaries list, and
- * unrooting them afterwards. */
-#define MVMROOT(tc, obj_ref, block) do {\
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref)); \
-    block \
-    MVM_gc_root_temp_pop(tc); \
- } while (0)
-#define MVMROOT2(tc, obj_ref1, obj_ref2, block) do {\
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref1)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref2)); \
-    block \
-    MVM_gc_root_temp_pop_n(tc, 2); \
- } while (0)
-#define MVMROOT3(tc, obj_ref1, obj_ref2, obj_ref3, block) do {\
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref1)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref2)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref3)); \
-    block \
-    MVM_gc_root_temp_pop_n(tc, 3); \
- } while (0)
-#define MVMROOT4(tc, obj_ref1, obj_ref2, obj_ref3, obj_ref4, block) do {\
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref1)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref2)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref3)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref4)); \
-    block \
-    MVM_gc_root_temp_pop_n(tc, 4); \
- } while (0)
-#define MVMROOT5(tc, obj_ref1, obj_ref2, obj_ref3, obj_ref4, obj_ref5, block) do {\
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref1)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref2)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref3)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref4)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref5)); \
-    block \
-    MVM_gc_root_temp_pop_n(tc, 5); \
- } while (0)
-#define MVMROOT6(tc, obj_ref1, obj_ref2, obj_ref3, obj_ref4, obj_ref5, obj_ref6, block) do {\
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref1)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref2)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref3)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref4)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref5)); \
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&(obj_ref6)); \
-    block \
-    MVM_gc_root_temp_pop_n(tc, 6); \
- } while (0)
+/* C preprocessor macros are basically the worst thing ever.
+ * So here's an explanation of the cool new MVMROOT macro:
+ *
+ * We want the whole macro to expand to a "for ( ...; ...; ...)"
+ * line, so that
+ * 1. we can put a block afterwards as if our root macro were control flow
+ * 2. we can put code in the initialization part of the for loop body that
+ *    pushes the temp roots
+ * 3. we can put code in the step part of the for loop to pop the roots again
+ * 4. we can put code in the check part that makes sure the block only
+ *    runs the first time around.
+ *
+ * This is achieved by chaining __MVM_gc_root_temp_push_nonvoid calls into a
+ * single expression that we use to initialize the "loop counter" variable to
+ * 1, which at the end of the "loop" is set to 0.
+ */
+
+/* The specific rules of concatenation with ## force us to put one macro in
+ * between what we want to concat and the ## operator.
+ */
+#define __MVM__CONCAT_IMPL( x, y ) x##y
+#define __MVM__MACRO_CONCAT( x, y ) __MVM__CONCAT_IMPL( x, y )
+
+// The variable that we set to 0 after the for loop runs so it terminates
+#define __MVMROOT_VAR_NAME __MVM__MACRO_CONCAT(__MVMROOT_runned_, __LINE__)
+
+#define __MVMROOT_PUSH(tc, obj_ref, chain) __MVM_gc_root_temp_push_nonvoid_noslow(tc, (MVMCollectable **)&(obj_ref), chain)
+
+#define MVMROOT(tc, obj_ref1)  /* If you get "passed 3 arguments, but takes just 2" error, if you want to keep compatibility with older moar versions, write explicit MVM_gc_root_temp_push and _pop calls, otherwise move the curly braces outside the MVMROOT parenthesis. */ \
+    for (MVMuint8 __MVMROOT_VAR_NAME = __MVM_gc_root_temp_push_nonvoid(tc, (MVMCollectable **)&(obj_ref1), 0); \
+        __MVMROOT_VAR_NAME != 0; \
+        MVM_gc_root_temp_pop(tc), \
+            __MVMROOT_VAR_NAME = 0)
+
+#define MVMROOT2(tc, obj_ref1, obj_ref2)  /* If you get "passed 4 arguments, but takes just 3" error, if you want to keep compatibility with older moar versions, write explicit MVM_gc_root_temp_push and _pop calls, otherwise move the curly braces outside the MVMROOT parenthesis. */ \
+    for (MVMuint8 __MVMROOT_VAR_NAME = \
+            __MVMROOT_PUSH(tc, obj_ref1, \
+            __MVMROOT_PUSH(tc, obj_ref2, \
+            __MVM_gc_root_temp_push_ensure_space(tc, 2))); \
+        __MVMROOT_VAR_NAME != 0 \
+        ; \
+    MVM_gc_root_temp_pop_n(tc, 2), __MVMROOT_VAR_NAME = 0)
+
+#define MVMROOT3(tc, obj_ref1, obj_ref2, obj_ref3)  /* If you get "passed 5 arguments, but takes just 4" error, if you want to keep compatibility with older moar versions, write explicit MVM_gc_root_temp_push and _pop calls, otherwise move the curly braces outside the MVMROOT parenthesis. */ \
+    for (MVMuint8 __MVMROOT_VAR_NAME = \
+            __MVMROOT_PUSH(tc, obj_ref1, \
+            __MVMROOT_PUSH(tc, obj_ref2, \
+            __MVMROOT_PUSH(tc, obj_ref3, \
+            __MVM_gc_root_temp_push_ensure_space(tc, 3)))); \
+        __MVMROOT_VAR_NAME != 0 \
+        ; \
+    MVM_gc_root_temp_pop_n(tc, 3), __MVMROOT_VAR_NAME = 0)
+
+#define MVMROOT4(tc, obj_ref1, obj_ref2, obj_ref3, obj_ref4)  /* If you get "passed 6 arguments, but takes just 5" error, if you want to keep compatibility with older moar versions, write explicit MVM_gc_root_temp_push and _pop calls, otherwise move the curly braces outside the MVMROOT parenthesis. */ \
+    for (MVMuint8 __MVMROOT_VAR_NAME = \
+            __MVMROOT_PUSH(tc, obj_ref1, \
+            __MVMROOT_PUSH(tc, obj_ref2, \
+            __MVMROOT_PUSH(tc, obj_ref3, \
+            __MVMROOT_PUSH(tc, obj_ref4, \
+            __MVM_gc_root_temp_push_ensure_space(tc, 4))))); \
+        __MVMROOT_VAR_NAME != 0 \
+        ; \
+    MVM_gc_root_temp_pop_n(tc, 4), __MVMROOT_VAR_NAME = 0)
+
+#define MVMROOT5(tc, obj_ref1, obj_ref2, obj_ref3, obj_ref4, obj_ref5)  /* If you get "passed 7 arguments, but takes just 6" error, if you want to keep compatibility with older moar versions, write explicit MVM_gc_root_temp_push and _pop calls, otherwise move the curly braces outside the MVMROOT parenthesis. */ \
+    for (MVMuint8 __MVMROOT_VAR_NAME = \
+            __MVMROOT_PUSH(tc, obj_ref1, \
+            __MVMROOT_PUSH(tc, obj_ref2, \
+            __MVMROOT_PUSH(tc, obj_ref3, \
+            __MVMROOT_PUSH(tc, obj_ref4, \
+            __MVMROOT_PUSH(tc, obj_ref5, \
+            __MVM_gc_root_temp_push_ensure_space(tc, 5)))))); \
+        __MVMROOT_VAR_NAME != 0 \
+        ; \
+    MVM_gc_root_temp_pop_n(tc, 5), __MVMROOT_VAR_NAME = 0)
+
+#define MVMROOT6(tc, obj_ref1, obj_ref2, obj_ref3, obj_ref4, obj_ref5, obj_ref6)  /* If you get "passed 8 arguments, but takes just 7" error, if you want to keep compatibility with older moar versions, write explicit MVM_gc_root_temp_push and _pop calls, otherwise move the curly braces outside the MVMROOT parenthesis. */ \
+    for (MVMuint8 __MVMROOT_VAR_NAME = \
+            __MVMROOT_PUSH(tc, obj_ref1, \
+            __MVMROOT_PUSH(tc, obj_ref2, \
+            __MVMROOT_PUSH(tc, obj_ref3, \
+            __MVMROOT_PUSH(tc, obj_ref4, \
+            __MVMROOT_PUSH(tc, obj_ref5, \
+            __MVMROOT_PUSH(tc, obj_ref6, \
+            __MVM_gc_root_temp_push_ensure_space(tc, 6))))))); \
+        __MVMROOT_VAR_NAME != 0 \
+        ; \
+    MVM_gc_root_temp_pop_n(tc, 6), __MVMROOT_VAR_NAME = 0)

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -57,13 +57,13 @@ static void push_name_and_port(MVMThreadContext *tc, struct sockaddr_storage *na
                 return;
                 break;
         }
-        MVMROOT(tc, arr, {
+        MVMROOT(tc, arr) {
             port_o = MVM_repr_box_int(tc, tc->instance->boot_types.BOOTInt, port);
-            MVMROOT(tc, port_o, {
+            MVMROOT(tc, port_o) {
                 host_o = (MVMObject *)MVM_repr_box_str(tc, tc->instance->boot_types.BOOTStr,
                         MVM_string_ascii_decode_nt(tc, tc->instance->VMString, addrstr));
-            });
-        });
+            }
+        }
     } else {
         host_o = tc->instance->boot_types.BOOTStr;
         port_o = tc->instance->boot_types.BOOTInt;
@@ -92,7 +92,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
 
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (nread >= 0) {
-        MVMROOT2(tc, t, arr, {
+        MVMROOT2(tc, t, arr) {
             MVMArray *res_buf;
 
             /* Push the sequence number. */
@@ -113,10 +113,10 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
 
             /* and finally, address and port */
             push_name_and_port(tc, (struct sockaddr_storage *)addr, arr);
-        });
+        }
     }
     else if (nread == UV_EOF) {
-        MVMROOT2(tc, t, arr, {
+        MVMROOT2(tc, t, arr) {
             MVMObject *final = MVM_repr_box_int(tc,
                 tc->instance->boot_types.BOOTInt, ri->seq_number);
             MVM_repr_push_o(tc, arr, final);
@@ -124,7 +124,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
-        });
+        }
         if (buf->base)
             MVM_free(buf->base);
         uv_udp_recv_stop(handle);
@@ -133,7 +133,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
     else {
         MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
         MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
-        MVMROOT2(tc, t, arr, {
+        MVMROOT2(tc, t, arr) {
             MVMString *msg_str = MVM_string_ascii_decode_nt(tc,
                 tc->instance->VMString, uv_strerror(nread));
             MVMObject *msg_box = MVM_repr_box_str(tc,
@@ -141,7 +141,7 @@ static void on_read(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const 
             MVM_repr_push_o(tc, arr, msg_box);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
-        });
+        }
         if (buf->base)
             MVM_free(buf->base);
         uv_udp_recv_stop(handle);
@@ -165,20 +165,20 @@ static void read_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_t
     handle_data->handle->data = data;
     if ((r = uv_udp_recv_start(handle_data->handle, on_alloc, on_read)) < 0) {
         /* Error; need to notify. */
-        MVMROOT(tc, async_task, {
+        MVMROOT(tc, async_task) {
             MVMObject    *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
             MVM_repr_push_o(tc, arr, ((MVMAsyncTask *)async_task)->body.schedulee);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
-            MVMROOT(tc, arr, {
+            MVMROOT(tc, arr) {
                 MVMString *msg_str = MVM_string_ascii_decode_nt(tc,
                     tc->instance->VMString, uv_strerror(r));
                 MVMObject *msg_box = MVM_repr_box_str(tc,
                     tc->instance->boot_types.BOOTStr, msg_str);
                 MVM_repr_push_o(tc, arr, msg_box);
-            });
+            }
             MVM_repr_push_o(tc, ((MVMAsyncTask *)async_task)->body.queue, arr);
-        });
+        }
     }
 }
 
@@ -227,9 +227,9 @@ static MVMAsyncTask * read_bytes(MVMThreadContext *tc, MVMOSHandle *h, MVMObject
     }
 
     /* Create async task handle. */
-    MVMROOT4(tc, queue, schedulee, h, buf_type, {
+    MVMROOT4(tc, queue, schedulee, h, buf_type) {
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc, async_type);
-    });
+    }
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.queue, queue);
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.schedulee, schedulee);
     task->body.ops  = &read_op_table;
@@ -239,9 +239,9 @@ static MVMAsyncTask * read_bytes(MVMThreadContext *tc, MVMOSHandle *h, MVMObject
     task->body.data = ri;
 
     /* Hand the task off to the event loop. */
-    MVMROOT(tc, task, {
+    MVMROOT(tc, task) {
         MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
-    });
+    }
 
     return task;
 }
@@ -265,23 +265,23 @@ static void on_write(uv_udp_send_t *req, int status) {
     MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, wi->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
     if (status >= 0) {
-        MVMROOT2(tc, arr, t, {
+        MVMROOT2(tc, arr, t) {
             MVMObject *bytes_box = MVM_repr_box_int(tc,
                 tc->instance->boot_types.BOOTInt,
                 wi->buf.len);
             MVM_repr_push_o(tc, arr, bytes_box);
-        });
+        }
         MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
     }
     else {
         MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
-        MVMROOT2(tc, arr, t, {
+        MVMROOT2(tc, arr, t) {
             MVMString *msg_str = MVM_string_ascii_decode_nt(tc,
                 tc->instance->VMString, uv_strerror(status));
             MVMObject *msg_box = MVM_repr_box_str(tc,
                 tc->instance->boot_types.BOOTStr, msg_str);
             MVM_repr_push_o(tc, arr, msg_box);
-        });
+        }
     }
     MVM_repr_push_o(tc, t->body.queue, arr);
     MVM_free(wi->req);
@@ -318,19 +318,19 @@ static void write_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
 
     if ((r = uv_udp_send(wi->req, handle_data->handle, &(wi->buf), 1, wi->dest_addr, on_write)) < 0) {
         /* Error; need to notify. */
-        MVMROOT(tc, async_task, {
+        MVMROOT(tc, async_task) {
             MVMObject    *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
             MVM_repr_push_o(tc, arr, ((MVMAsyncTask *)async_task)->body.schedulee);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
-            MVMROOT(tc, arr, {
+            MVMROOT(tc, arr) {
                 MVMString *msg_str = MVM_string_ascii_decode_nt(tc,
                     tc->instance->VMString, uv_strerror(r));
                 MVMObject *msg_box = MVM_repr_box_str(tc,
                     tc->instance->boot_types.BOOTStr, msg_str);
                 MVM_repr_push_o(tc, arr, msg_box);
-            });
+            }
             MVM_repr_push_o(tc, ((MVMAsyncTask *)async_task)->body.queue, arr);
-        });
+        }
 
         /* Cleanup handle. */
         MVM_free_null(wi->req);
@@ -385,12 +385,12 @@ static MVMAsyncTask * write_bytes_to(MVMThreadContext *tc, MVMOSHandle *h, MVMOb
         MVM_exception_throw_adhoc(tc, "asyncwritebytesto requires a native array of uint8 or int8");
 
     /* Resolve destination and create async task handle. */
-    MVMROOT4(tc, queue, schedulee, h, buffer, {
-        MVMROOT(tc, async_type, {
+    MVMROOT4(tc, queue, schedulee, h, buffer) {
+        MVMROOT(tc, async_type) {
             dest_addr = MVM_io_resolve_host_name(tc, host, port, MVM_SOCKET_FAMILY_UNSPEC, MVM_SOCKET_TYPE_DGRAM, MVM_SOCKET_PROTOCOL_ANY, 0);
-        });
+        }
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc, async_type);
-    });
+    }
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.queue, queue);
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.schedulee, schedulee);
     task->body.ops  = &write_op_table;
@@ -401,9 +401,9 @@ static MVMAsyncTask * write_bytes_to(MVMThreadContext *tc, MVMOSHandle *h, MVMOb
     task->body.data = wi;
 
     /* Hand the task off to the event loop. */
-    MVMROOT(tc, task, {
+    MVMROOT(tc, task) {
         MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
-    });
+    }
 
     return task;
 }
@@ -431,10 +431,10 @@ static MVMint64 close_socket(MVMThreadContext *tc, MVMOSHandle *h) {
     MVMIOAsyncUDPSocketData *data = (MVMIOAsyncUDPSocketData *)h->body.data;
     MVMAsyncTask *task;
 
-    MVMROOT(tc, h, {
+    MVMROOT(tc, h) {
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc,
             tc->instance->boot_types.BOOTAsync);
-    });
+    }
     task->body.ops  = &close_op_table;
     task->body.data = data->handle;
     MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
@@ -505,38 +505,38 @@ static void setup_setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_
         /* UDP handle initialized; wrap it up in an I/O handle and send. */
         MVMAsyncTask *t   = (MVMAsyncTask *)async_task;
         MVMObject    *arr;
-        MVMROOT(tc, t, {
+        MVMROOT(tc, t) {
             arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
             MVM_repr_push_o(tc, arr, t->body.schedulee);
-            MVMROOT(tc, arr, {
+            MVMROOT(tc, arr) {
                 MVMOSHandle          *result = (MVMOSHandle *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTIO);
                 MVMIOAsyncUDPSocketData *data   = MVM_calloc(1, sizeof(MVMIOAsyncUDPSocketData));
                 data->handle                 = udp_handle;
                 result->body.ops             = &op_table;
                 result->body.data            = data;
                 MVM_repr_push_o(tc, arr, (MVMObject *)result);
-            });
+            }
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
-        });
+        }
         MVM_repr_push_o(tc, t->body.queue, arr);
     }
     else {
         /* Something failed; need to notify. */
-        MVMROOT(tc, async_task, {
+        MVMROOT(tc, async_task) {
             MVMObject    *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
             MVMAsyncTask *t   = (MVMAsyncTask *)async_task;
             MVM_repr_push_o(tc, arr, t->body.schedulee);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTIO);
-            MVMROOT2(tc, arr, t, {
+            MVMROOT2(tc, arr, t) {
                 MVMString *msg_str = MVM_string_ascii_decode_nt(tc,
                     tc->instance->VMString, uv_strerror(r));
                 MVMObject *msg_box = MVM_repr_box_str(tc,
                     tc->instance->boot_types.BOOTStr, msg_str);
                 MVM_repr_push_o(tc, arr, msg_box);
-            });
+            }
             MVM_repr_push_o(tc, t->body.queue, arr);
             uv_close((uv_handle_t *)udp_handle, free_on_close_cb);
-        });
+        }
     }
 }
 
@@ -578,15 +578,15 @@ MVMObject * MVM_io_socket_udp_async(MVMThreadContext *tc, MVMObject *queue,
 
     /* Resolve hostname. (Could be done asynchronously too.) */
     if (host && IS_CONCRETE(host)) {
-        MVMROOT3(tc, queue, schedulee, async_type, {
+        MVMROOT3(tc, queue, schedulee, async_type) {
             bind_addr = MVM_io_resolve_host_name(tc, host, port, MVM_SOCKET_FAMILY_UNSPEC, MVM_SOCKET_TYPE_DGRAM, MVM_SOCKET_PROTOCOL_ANY, 1);
-        });
+        }
     }
 
     /* Create async task handle. */
-    MVMROOT2(tc, queue, schedulee, {
+    MVMROOT2(tc, queue, schedulee) {
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc, async_type);
-    });
+    }
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.queue, queue);
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.schedulee, schedulee);
     task->body.ops  = &setup_op_table;
@@ -596,9 +596,9 @@ MVMObject * MVM_io_socket_udp_async(MVMThreadContext *tc, MVMObject *queue,
     task->body.data = ssi;
 
     /* Hand the task off to the event loop. */
-    MVMROOT(tc, task, {
+    MVMROOT(tc, task) {
         MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
-    });
+    }
 
     return (MVMObject *)task;
 }

--- a/src/io/dirops.c
+++ b/src/io/dirops.c
@@ -211,9 +211,9 @@ static const MVMIOOps op_table = {
 MVMObject * MVM_dir_open(MVMThreadContext *tc, MVMString *dirname) {
     MVMOSHandle  * result;
     MVMIODirIter * const data   = MVM_calloc(1, sizeof(MVMIODirIter));
-    MVMROOT(tc, dirname, {
+    MVMROOT(tc, dirname) {
         result = (MVMOSHandle *)MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTIO);
-    });
+    }
 #ifdef _WIN32
     {
         char *name;

--- a/src/io/filewatchers.c
+++ b/src/io/filewatchers.c
@@ -14,7 +14,7 @@ static void on_changed(uv_fs_event_t *handle, const char *filename, int events, 
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
     MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, wi->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
-    MVMROOT2(tc, t, arr, {
+    MVMROOT2(tc, t, arr) {
         MVMObject *filename_boxed;
         MVMObject *rename_boxed;
         if (filename) {
@@ -33,7 +33,7 @@ static void on_changed(uv_fs_event_t *handle, const char *filename, int events, 
             events == UV_RENAME ? 1 : 0);
         MVM_repr_push_o(tc, arr, rename_boxed);
         MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
-    });
+    }
     MVM_repr_push_o(tc, t->body.queue, arr);
 }
 
@@ -51,20 +51,20 @@ static void setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task, 
     uv_fs_event_init(loop, &wi->handle);
     if ((r = uv_fs_event_start(&wi->handle, on_changed, wi->path, 0)) != 0) {
         /* Error; need to notify. */
-        MVMROOT(tc, async_task, {
+        MVMROOT(tc, async_task) {
             MVMObject    *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
             MVM_repr_push_o(tc, arr, ((MVMAsyncTask *)async_task)->body.schedulee);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTStr);
             MVM_repr_push_o(tc, arr, tc->instance->boot_types.BOOTInt);
-            MVMROOT(tc, arr, {
+            MVMROOT(tc, arr) {
                 MVMString *msg_str = MVM_string_ascii_decode_nt(tc,
                     tc->instance->VMString, uv_strerror(r));
                 MVMObject *msg_box = MVM_repr_box_str(tc,
                     tc->instance->boot_types.BOOTStr, msg_str);
                 MVM_repr_push_o(tc, arr, msg_box);
-            });
+            }
             MVM_repr_push_o(tc, ((MVMAsyncTask *)async_task)->body.queue, arr);
-        });
+        }
     }
 }
 
@@ -110,9 +110,9 @@ MVMObject * MVM_io_file_watch(MVMThreadContext *tc, MVMObject *queue,
     }
 
     /* Create async task handle. */
-    MVMROOT2(tc, queue, schedulee, {
+    MVMROOT2(tc, queue, schedulee) {
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc, async_type);
-    });
+    }
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.queue, queue);
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.schedulee, schedulee);
     task->body.ops   = &op_table;
@@ -121,9 +121,9 @@ MVMObject * MVM_io_file_watch(MVMThreadContext *tc, MVMObject *queue,
     task->body.data  = watch_info;
 
     /* Hand the task off to the event loop. */
-    MVMROOT(tc, task, {
+    MVMROOT(tc, task) {
         MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
-    });
+    }
 
     return (MVMObject *)task;
 }

--- a/src/io/io.c
+++ b/src/io/io.c
@@ -29,11 +29,11 @@ MVMint64 MVM_io_close(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "close");
     if (handle->body.ops->closable) {
         MVMint64 ret;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             ret = handle->body.ops->closable->close(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return ret;
     }
     else
@@ -45,11 +45,11 @@ MVMint64 MVM_io_is_tty(MVMThreadContext *tc, MVMObject *oshandle) {
     /* We need the extra check on is_tty because it is NULL for pipes. */
     if (handle->body.ops->introspection && handle->body.ops->introspection->is_tty) {
         MVMint64 ret;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             ret = handle->body.ops->introspection->is_tty(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return ret;
     }
     else {
@@ -61,11 +61,11 @@ MVMint64 MVM_io_fileno(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "get native descriptor");
     if (handle->body.ops->introspection) {
         MVMint64 ret;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             ret = handle->body.ops->introspection->native_descriptor(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return ret;
     }
     else {
@@ -76,11 +76,11 @@ MVMint64 MVM_io_fileno(MVMThreadContext *tc, MVMObject *oshandle) {
 void MVM_io_seek(MVMThreadContext *tc, MVMObject *oshandle, MVMint64 offset, MVMint64 flag) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "seek");
     if (handle->body.ops->seekable) {
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->seekable->seek(tc, handle, offset, flag);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot seek this kind of handle");
@@ -90,11 +90,11 @@ MVMint64 MVM_io_tell(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "tell");
     if (handle->body.ops->seekable) {
         MVMint64 result;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = handle->body.ops->seekable->tell(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -117,11 +117,11 @@ void MVM_io_read_bytes(MVMThreadContext *tc, MVMObject *oshandle, MVMObject *res
         MVM_exception_throw_adhoc(tc, "Out of range: attempted to read %"PRId64" bytes from filehandle", length);
 
     if (handle->body.ops->sync_readable) {
-        MVMROOT2(tc, handle, result, {
+        MVMROOT2(tc, handle, result) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             bytes_read = handle->body.ops->sync_readable->read_bytes(tc, handle, &buf, length);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot read characters from this kind of handle");
@@ -155,11 +155,11 @@ void MVM_io_write_bytes(MVMThreadContext *tc, MVMObject *oshandle, MVMObject *bu
         MVM_exception_throw_adhoc(tc, "write_fhb requires a native array of uint8, int8, uint16 or int16");
 
     if (handle->body.ops->sync_writable) {
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->sync_writable->write_bytes(tc, handle, output, output_size);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot write bytes to this kind of handle");
@@ -169,11 +169,11 @@ void MVM_io_write_bytes_c(MVMThreadContext *tc, MVMObject *oshandle, char *outpu
                           MVMuint64 output_size) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "write bytes");
     if (handle->body.ops->sync_writable) {
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->sync_writable->write_bytes(tc, handle, output, output_size);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot write bytes to this kind of handle");
@@ -184,12 +184,12 @@ MVMObject * MVM_io_read_bytes_async(MVMThreadContext *tc, MVMObject *oshandle, M
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "read bytes asynchronously");
     if (handle->body.ops->async_readable) {
         MVMObject *result;
-        MVMROOT5(tc, queue, schedulee, buf_type, async_type, handle, {
+        MVMROOT5(tc, queue, schedulee, buf_type, async_type, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = (MVMObject *)handle->body.ops->async_readable->read_bytes(tc,
                 handle, queue, schedulee, buf_type, async_type);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -203,12 +203,12 @@ MVMObject * MVM_io_write_bytes_async(MVMThreadContext *tc, MVMObject *oshandle, 
         MVM_exception_throw_adhoc(tc, "Failed to write to filehandle: NULL buffer given");
     if (handle->body.ops->async_writable) {
         MVMObject *result;
-        MVMROOT5(tc, queue, schedulee, buffer, async_type, handle, {
+        MVMROOT5(tc, queue, schedulee, buffer, async_type, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = (MVMObject *)handle->body.ops->async_writable->write_bytes(tc,
                 handle, queue, schedulee, buffer, async_type);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -223,12 +223,12 @@ MVMObject * MVM_io_write_bytes_to_async(MVMThreadContext *tc, MVMObject *oshandl
         MVM_exception_throw_adhoc(tc, "Failed to write to filehandle: NULL buffer given");
     if (handle->body.ops->async_writable_to) {
         MVMObject *result;
-        MVMROOT6(tc, host, queue, schedulee, buffer, async_type, handle, {
+        MVMROOT6(tc, host, queue, schedulee, buffer, async_type, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = (MVMObject *)handle->body.ops->async_writable_to->write_bytes_to(tc,
                 handle, queue, schedulee, buffer, async_type, host, port);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -239,11 +239,11 @@ MVMint64 MVM_io_eof(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "eof");
     if (handle->body.ops->sync_readable) {
         MVMint64 result;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = handle->body.ops->sync_readable->eof(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -254,11 +254,11 @@ MVMint64 MVM_io_lock(MVMThreadContext *tc, MVMObject *oshandle, MVMint64 flag) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "lock");
     if (handle->body.ops->lockable) {
         MVMint64 result;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = handle->body.ops->lockable->lock(tc, handle, flag);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -268,11 +268,11 @@ MVMint64 MVM_io_lock(MVMThreadContext *tc, MVMObject *oshandle, MVMint64 flag) {
 void MVM_io_unlock(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "unlock");
     if (handle->body.ops->lockable) {
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->lockable->unlock(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot unlock this kind of handle");
@@ -281,11 +281,11 @@ void MVM_io_unlock(MVMThreadContext *tc, MVMObject *oshandle) {
 void MVM_io_flush(MVMThreadContext *tc, MVMObject *oshandle, MVMint32 sync) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "flush");
     if (handle->body.ops->sync_writable) {
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->sync_writable->flush(tc, handle, sync);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot flush this kind of handle");
@@ -294,11 +294,11 @@ void MVM_io_flush(MVMThreadContext *tc, MVMObject *oshandle, MVMint32 sync) {
 void MVM_io_truncate(MVMThreadContext *tc, MVMObject *oshandle, MVMint64 offset) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "truncate");
     if (handle->body.ops->sync_writable) {
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->sync_writable->truncate(tc, handle, offset);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot truncate this kind of handle");
@@ -307,11 +307,11 @@ void MVM_io_truncate(MVMThreadContext *tc, MVMObject *oshandle, MVMint64 offset)
 void MVM_io_connect(MVMThreadContext *tc, MVMObject *oshandle, MVMString *host, MVMint64 port, MVMuint16 family) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "connect");
     if (handle->body.ops->sockety) {
-        MVMROOT2(tc, host, handle, {
+        MVMROOT2(tc, host, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->sockety->connect(tc, handle, host, port, family);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot connect this kind of handle");
@@ -320,11 +320,11 @@ void MVM_io_connect(MVMThreadContext *tc, MVMObject *oshandle, MVMString *host, 
 void MVM_io_bind(MVMThreadContext *tc, MVMObject *oshandle, MVMString *host, MVMint64 port, MVMuint16 family, MVMint32 backlog) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "bind");
     if (handle->body.ops->sockety) {
-        MVMROOT2(tc, host, handle, {
+        MVMROOT2(tc, host, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->sockety->bind(tc, handle, host, port, family, backlog);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot bind this kind of handle");
@@ -334,11 +334,11 @@ MVMint64 MVM_io_getport(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "getport");
     if (handle->body.ops->sockety) {
         MVMint64 result;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = handle->body.ops->sockety->getport(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -349,11 +349,11 @@ MVMObject * MVM_io_accept(MVMThreadContext *tc, MVMObject *oshandle) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "accept");
     if (handle->body.ops->sockety) {
         MVMObject *result;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             result = handle->body.ops->sockety->accept(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return result;
     }
     else
@@ -363,11 +363,11 @@ MVMObject * MVM_io_accept(MVMThreadContext *tc, MVMObject *oshandle) {
 void MVM_io_set_buffer_size(MVMThreadContext *tc, MVMObject *oshandle, MVMint64 size) {
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "set buffer size");
     if (handle->body.ops->set_buffer_size) {
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             handle->body.ops->set_buffer_size(tc, handle, size);
             release_mutex(tc, mutex);
-        });
+        }
     }
     else
         MVM_exception_throw_adhoc(tc, "Cannot set buffer size on this kind of handle");
@@ -377,11 +377,11 @@ MVMObject * MVM_io_get_async_task_handle(MVMThreadContext *tc, MVMObject *oshand
     MVMOSHandle *handle = verify_is_handle(tc, oshandle, "get async task handle");
     if (handle->body.ops->get_async_task_handle) {
         MVMObject *ath;
-        MVMROOT(tc, handle, {
+        MVMROOT(tc, handle) {
             uv_mutex_t *mutex = acquire_mutex(tc, handle);
             ath = handle->body.ops->get_async_task_handle(tc, handle);
             release_mutex(tc, mutex);
-        });
+        }
         return ath;
     }
     else

--- a/src/io/signals.c
+++ b/src/io/signals.c
@@ -26,11 +26,11 @@ static void signal_cb(uv_signal_t *handle, int sig_num) {
     MVMObject        *arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
     MVMAsyncTask     *t   = MVM_io_eventloop_get_active_work(tc, si->work_idx);
     MVM_repr_push_o(tc, arr, t->body.schedulee);
-    MVMROOT2(tc, t, arr, {
+    MVMROOT2(tc, t, arr) {
         MVMObject *sig_num_boxed = MVM_repr_box_int(tc,
             tc->instance->boot_types.BOOTInt, sig_num);
         MVM_repr_push_o(tc, arr, sig_num_boxed);
-    });
+    }
     MVM_repr_push_o(tc, t->body.queue, arr);
 }
 
@@ -45,9 +45,9 @@ static void setup(MVMThreadContext *tc, uv_loop_t *loop, MVMObject *async_task, 
 
     if (si->setup_notify_queue && si->setup_notify_schedulee) {
         MVMObject *arr;
-        MVMROOT(tc, async_task, {
+        MVMROOT(tc, async_task) {
             arr = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTArray);
-        });
+        }
         MVM_repr_push_o(tc, arr, si->setup_notify_schedulee);
         MVM_repr_push_o(tc, si->setup_notify_queue, arr);
     }
@@ -285,14 +285,14 @@ MVMObject * MVM_io_get_signals(MVMThreadContext *tc) {
     }
 
     sig_arr = MVM_repr_alloc_init(tc, hll->slurpy_array_type);
-    MVMROOT(tc, sig_arr, {
+    MVMROOT(tc, sig_arr) {
         MVMint8 i;
         for (i = 0; i < NUM_SIG_WANTED; i++) {
             MVMObject *key      = NULL;
             MVMString *full_key = NULL;
             MVMObject *val      = NULL;
 
-            MVMROOT3(tc, key, full_key, val, {
+            MVMROOT3(tc, key, full_key, val) {
                 full_key = MVM_string_utf8_c8_decode(
                     tc, instance->VMString, SIG_WANTED[i], strlen(SIG_WANTED[i])
                 );
@@ -304,12 +304,12 @@ MVMObject * MVM_io_get_signals(MVMThreadContext *tc) {
 
                 MVM_repr_push_o(tc, sig_arr, key);
                 MVM_repr_push_o(tc, sig_arr, val);
-            });
+            }
         }
 
         populate_instance_valid_sigs(tc, sig_wanted_vals);
         instance->sig_arr = sig_arr;
-    });
+    }
 
     return sig_arr;
 }
@@ -348,9 +348,9 @@ MVMObject * MVM_io_signal_handle(
             "signal result type must have REPR AsyncTask");
 
     /* Create async task handle. */
-    MVMROOT4(tc, queue, schedulee, setup_notify_queue, setup_notify_schedulee, {
+    MVMROOT4(tc, queue, schedulee, setup_notify_queue, setup_notify_schedulee) {
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc, async_type);
-    });
+    }
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.queue, queue);
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.schedulee, schedulee);
     task->body.ops      = &op_table;
@@ -361,9 +361,9 @@ MVMObject * MVM_io_signal_handle(
     task->body.data     = signal_info;
 
     /* Hand the task off to the event loop. */
-    MVMROOT(tc, task, {
+    MVMROOT(tc, task) {
         MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
-    });
+    }
 
     return (MVMObject *)task;
 }

--- a/src/io/timers.c
+++ b/src/io/timers.c
@@ -84,9 +84,9 @@ MVMObject * MVM_io_timer_create(MVMThreadContext *tc, MVMObject *queue,
             "timer result type must have REPR AsyncTask");
 
     /* Create async task handle. */
-    MVMROOT2(tc, queue, schedulee, {
+    MVMROOT2(tc, queue, schedulee) {
         task = (MVMAsyncTask *)MVM_repr_alloc_init(tc, async_type);
-    });
+    }
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.queue, queue);
     MVM_ASSIGN_REF(tc, &(task->common.header), task->body.schedulee, schedulee);
     task->body.ops      = &op_table;
@@ -97,9 +97,9 @@ MVMObject * MVM_io_timer_create(MVMThreadContext *tc, MVMObject *queue,
 
     /* Hand the task off to the event loop, which will set up the timer on the
      * event loop. */
-    MVMROOT(tc, task, {
+    MVMROOT(tc, task) {
         MVM_io_eventloop_queue_work(tc, (MVMObject *)task);
-    });
+    }
 
     return (MVMObject *)task;
 }

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -251,9 +251,9 @@ static void two_complement_shl(MVMThreadContext *tc, mp_int *result, mp_int *val
 MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MVMObject *source) { \
     MVMP6bigintBody *bb; \
     MVMObject *result; \
-    MVMROOT(tc, source, { \
+    MVMROOT(tc, source) { \
         result = MVM_repr_alloc_init(tc, result_type);\
-    }); \
+    } \
     bb = get_bigint_body(tc, result); \
     if (!IS_CONCRETE(source)) { \
         store_int64_result(tc, bb, 0); \
@@ -292,9 +292,9 @@ MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MV
     MVMObject *result; \
     mp_err err; \
     mp_int *ia, *ib, *ic; \
-    MVMROOT2(tc, a, b, { \
+    MVMROOT2(tc, a, b) { \
         result = MVM_repr_alloc_init(tc, result_type);\
-    }); \
+    } \
     ba = get_bigint_body(tc, a); \
     bb = get_bigint_body(tc, b); \
     bc = get_bigint_body(tc, result); \
@@ -343,9 +343,9 @@ MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MV
     if (MVM_BIGINT_IS_BIG(ba) || MVM_BIGINT_IS_BIG(bb)) { \
         mp_err err; \
         mp_int *ia, *ib, *ic; \
-        MVMROOT2(tc, a, b, { \
+        MVMROOT2(tc, a, b) { \
             result = MVM_repr_alloc_init(tc, result_type);\
-        }); \
+        } \
         ba = get_bigint_body(tc, a); \
         bb = get_bigint_body(tc, b); \
         bc = get_bigint_body(tc, result); \
@@ -382,9 +382,9 @@ MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MV
 #define MVM_BIGINT_BINARY_OP_2(opname, SMALLINT_OP) \
 MVMObject * MVM_bigint_##opname(MVMThreadContext *tc, MVMObject *result_type, MVMObject *a, MVMObject *b) { \
     MVMObject *result; \
-    MVMROOT2(tc, a, b, { \
+    MVMROOT2(tc, a, b) { \
         result = MVM_repr_alloc_init(tc, result_type);\
-    }); \
+    } \
     {\
         MVMP6bigintBody *ba = get_bigint_body(tc, a); \
         MVMP6bigintBody *bb = get_bigint_body(tc, b); \
@@ -427,9 +427,9 @@ MVM_BIGINT_BINARY_OP(lcm)
 MVMObject *MVM_bigint_gcd(MVMThreadContext *tc, MVMObject *result_type, MVMObject *a, MVMObject *b) {
     MVMObject       *result;
 
-    MVMROOT2(tc, a, b, {
+    MVMROOT2(tc, a, b) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     {
         MVMP6bigintBody *ba = get_bigint_body(tc, a);
@@ -494,9 +494,9 @@ MVMObject * MVM_bigint_mod(MVMThreadContext *tc, MVMObject *result_type, MVMObje
 
     MVMObject *result;
 
-    MVMROOT2(tc, a, b, {
+    MVMROOT2(tc, a, b) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     {
         MVMP6bigintBody *ba = get_bigint_body(tc, a);
@@ -549,9 +549,9 @@ MVMObject *MVM_bigint_div(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
         return a;
     }
 
-    MVMROOT2(tc, a, b, {
+    MVMROOT2(tc, a, b) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     ba = get_bigint_body(tc, a);
     bb = get_bigint_body(tc, b);
@@ -707,9 +707,9 @@ MVMObject *MVM_bigint_shl(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
     MVMP6bigintBody *bb;
     MVMObject       *result;
 
-    MVMROOT(tc, a, {
+    MVMROOT(tc, a) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     ba = get_bigint_body(tc, a);
     bb = get_bigint_body(tc, result);
@@ -752,9 +752,9 @@ MVMObject *MVM_bigint_shr(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
     MVMP6bigintBody *bb;
     MVMObject       *result;
 
-    MVMROOT(tc, a, {
+    MVMROOT(tc, a) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     ba = get_bigint_body(tc, a);
     bb = get_bigint_body(tc, result);
@@ -786,9 +786,9 @@ MVMObject *MVM_bigint_not(MVMThreadContext *tc, MVMObject *result_type, MVMObjec
     MVMP6bigintBody *bb;
     MVMObject       *result;
 
-    MVMROOT(tc, a, {
+    MVMROOT(tc, a) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     ba = get_bigint_body(tc, a);
     bb = get_bigint_body(tc, result);
@@ -840,9 +840,9 @@ MVMObject *MVM_bigint_expmod(MVMThreadContext *tc, MVMObject *result_type, MVMOb
         MVM_exception_throw_adhoc(tc, "Error creating a big integer: %s", mp_error_to_string(err));
     }
 
-    MVMROOT3(tc, a, b, c, {
+    MVMROOT3(tc, a, b, c) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     bd = get_bigint_body(tc, result);
 
@@ -886,9 +886,9 @@ MVMObject * MVM_coerce_sI(MVMThreadContext *tc, MVMString *s, MVMObject *type) {
     int is_malloced = 0;
     MVMStringIndex i;
     MVMObject *a;
-    MVMROOT(tc, s, {
+    MVMROOT(tc, s) {
         a = MVM_repr_alloc_init(tc, type);
-    });
+    }
     if (s->body.num_graphs < 120) {
         buf = alloca(s->body.num_graphs + 1);
     }
@@ -945,9 +945,9 @@ MVMObject * MVM_bigint_from_bigint(MVMThreadContext *tc, MVMObject *result_type,
     MVMP6bigintBody *r_body;
     MVMObject       *result;
 
-    MVMROOT(tc, a, {
+    MVMROOT(tc, a) {
         result = MVM_repr_alloc_init(tc, result_type);
-    });
+    }
 
     a_body = get_bigint_body(tc, a);
     r_body = get_bigint_body(tc, result);
@@ -1474,7 +1474,7 @@ mp_err MVM_mp_rand(MVMThreadContext *tc, mp_int *a, int digits)
 }
 
 
-/* 
+/*
     The old version of LibTomMath has it publically defined the new one not,
     so we can take the (non)existance as a marker.
  */
@@ -1510,9 +1510,9 @@ MVMObject * MVM_bigint_rand(MVMThreadContext *tc, MVMObject *type, MVMObject *b)
             if (have_to_negate)
                 result_int *= -1;
 
-            MVMROOT2(tc, type, b, {
+            MVMROOT2(tc, type, b) {
                 result = MVM_repr_alloc_init(tc, type);
-            });
+            }
 
             ba = get_bigint_body(tc, result);
             store_int64_result(tc, ba, result_int);
@@ -1526,9 +1526,9 @@ MVMObject * MVM_bigint_rand(MVMThreadContext *tc, MVMObject *type, MVMObject *b)
         mp_int *rnd = MVM_malloc(sizeof(mp_int));
         mp_int *max = force_bigint(tc, bb, 0);
 
-        MVMROOT2(tc, type, b, {
+        MVMROOT2(tc, type, b) {
             result = MVM_repr_alloc_init(tc, type);
-        });
+        }
 
         ba = get_bigint_body(tc, result);
 

--- a/src/moar.c
+++ b/src/moar.c
@@ -781,7 +781,7 @@ void MVM_vm_event_subscription_configure(MVMThreadContext *tc, MVMObject *queue,
     MVMString *speshoverviewevent;
     MVMString *startup_time;
 
-    MVMROOT2(tc, queue, config, {
+    MVMROOT2(tc, queue, config) {
         if (!IS_CONCRETE(config)) {
             MVM_exception_throw_adhoc(tc, "vmeventsubscribe requires a concrete configuration hash (got a %s type object)", MVM_6model_get_debug_name(tc, config));
         }
@@ -797,12 +797,12 @@ void MVM_vm_event_subscription_configure(MVMThreadContext *tc, MVMObject *queue,
         }
 
         gcevent = MVM_string_utf8_decode(tc, tc->instance->VMString, "gcevent", 7);
-        MVMROOT(tc, gcevent, {
+        MVMROOT(tc, gcevent) {
             speshoverviewevent = MVM_string_utf8_decode(tc, tc->instance->VMString, "speshoverviewevent", 18);
-            MVMROOT(tc, speshoverviewevent, {
+            MVMROOT(tc, speshoverviewevent) {
                 startup_time = MVM_string_utf8_decode(tc, tc->instance->VMString, "startup_time", 12);
-            });
-        });
+            }
+        }
 
         if (MVM_repr_exists_key(tc, config, gcevent)) {
             MVMObject *value = MVM_repr_at_key_o(tc, config, gcevent);
@@ -836,10 +836,10 @@ void MVM_vm_event_subscription_configure(MVMThreadContext *tc, MVMObject *queue,
 
         if (MVM_repr_exists_key(tc, config, startup_time)) {
             /* Value is ignored, it will just be overwritten. */
-            MVMObject *value = NULL; 
-            MVMROOT3(tc, gcevent, speshoverviewevent, startup_time, {
+            MVMObject *value = NULL;
+            MVMROOT3(tc, gcevent, speshoverviewevent, startup_time) {
                     value = MVM_repr_box_num(tc, tc->instance->boot_types.BOOTNum, tc->instance->subscriptions.vm_startup_now);
-            });
+            }
 
             if (MVM_is_null(tc, value)) {
                 uv_mutex_unlock(&tc->instance->subscriptions.mutex_event_subscription);
@@ -847,7 +847,7 @@ void MVM_vm_event_subscription_configure(MVMThreadContext *tc, MVMObject *queue,
             }
             MVM_repr_bind_key_o(tc, config, startup_time, value);
         }
-    });
+    }
 
     uv_mutex_unlock(&tc->instance->subscriptions.mutex_event_subscription);
 }

--- a/src/platform/sys.c
+++ b/src/platform/sys.c
@@ -28,7 +28,7 @@ MVMObject * MVM_platform_uname(MVMThreadContext *tc) {
     if ((error = uv_os_uname(&uname)) != 0)
         MVM_exception_throw_adhoc(tc, "Unable to uname: %s", uv_strerror(error));
 
-    MVMROOT(tc, result, {
+    MVMROOT(tc, result) {
         result = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTStrArray);
 
         MVM_repr_push_s(
@@ -54,7 +54,7 @@ MVMObject * MVM_platform_uname(MVMThreadContext *tc) {
             result,
             MVM_string_utf8_decode(tc, tc->instance->VMString, uname.machine, strlen((char *)uname.machine))
         );
-    });
+    }
 
     return result;
 }

--- a/src/spesh/deopt.c
+++ b/src/spesh/deopt.c
@@ -170,7 +170,7 @@ static void materialize_object(MVMThreadContext *tc, MVMFrame *f, MVMuint16 **ma
         MVMSpeshPEAMaterializeInfo *mi = &(cand->body.deopt_pea.materialize_info[info_idx]);
         MVMSTable *st = (MVMSTable *)cand->body.spesh_slots[mi->stable_sslot];
         MVMP6opaqueREPRData *repr_data = (MVMP6opaqueREPRData *)st->REPR_data;
-        MVMROOT2(tc, f, cand, {
+        MVMROOT2(tc, f, cand) {
             obj = MVM_gc_allocate_object(tc, st);
 
             char *data = (char *)OBJECT_BODY(obj);
@@ -205,7 +205,7 @@ static void materialize_object(MVMThreadContext *tc, MVMFrame *f, MVMuint16 **ma
             }
             /* Store register index offset by 1, so 0 can indicate "uninitialized" */
             (*materialized)[info_idx] = target_reg + 1;
-        });
+        }
 #if MVM_LOG_DEOPTS
         fprintf(stderr, "    Materialized a %s\n", st->debug_name);
 #endif
@@ -220,13 +220,13 @@ static void materialize_replaced_objects(MVMThreadContext *tc, MVMFrame *f, MVMi
     MVMSpeshCandidate *cand = f->spesh_cand;
     MVMuint32 num_deopt_points = MVM_VECTOR_ELEMS(cand->body.deopt_pea.deopt_point);
     MVMuint16 *materialized = NULL;
-    MVMROOT2(tc, f, cand, {
+    MVMROOT2(tc, f, cand) {
         for (i = 0; i < num_deopt_points; i++) {
             MVMSpeshPEADeoptPoint *dp = &(cand->body.deopt_pea.deopt_point[i]);
             if (dp->deopt_point_idx == deopt_index)
                 materialize_object(tc, f, &materialized, dp->materialize_info_idx, dp->target_reg);
         }
-    });
+    }
     MVM_free(materialized);
 }
 
@@ -270,8 +270,8 @@ void MVM_spesh_deopt_one(MVMThreadContext *tc, MVMuint32 deopt_idx) {
 #if MVM_LOG_DEOPTS
         fprintf(stderr, "    Will deopt %u -> %u\n", deopt_offset, deopt_target);
 #endif
-        MVMFrame *top_frame; 
-        MVMROOT(tc, f, {
+        MVMFrame *top_frame;
+        MVMROOT(tc, f) {
             begin_frame_deopt(tc, f, deopt_idx);
 
             /* Perform any uninlining. */
@@ -288,7 +288,7 @@ void MVM_spesh_deopt_one(MVMThreadContext *tc, MVMuint32 deopt_idx) {
                 /* No uninlining, so we know the top frame didn't change. */
                 top_frame = f;
             }
-        });
+        }
 
         /* Move the program counter of the interpreter. */
         *(tc->interp_cur_op)         = top_frame->static_info->body.bytecode + deopt_target;
@@ -410,7 +410,7 @@ void MVM_spesh_deopt_during_unwind(MVMThreadContext *tc) {
         MVMuint32 deopt_offset = MVM_spesh_deopt_bytecode_pos(spesh_cand->body.deopts[deopt_idx * 2 + 1]);
 
         MVMFrame *top_frame;
-        MVMROOT(tc, frame, {
+        MVMROOT(tc, frame) {
             begin_frame_deopt(tc, frame, deopt_idx);
 
             /* Potentially need to uninline. This leaves the top frame being the
@@ -423,7 +423,7 @@ void MVM_spesh_deopt_during_unwind(MVMThreadContext *tc) {
             else {
                 top_frame = frame;
             }
-        });
+        }
 
         /* Rewrite return address in the current top frame and sync current
          * frame. */

--- a/src/spesh/frame_walker.c
+++ b/src/spesh/frame_walker.c
@@ -236,9 +236,9 @@ MVMuint32 MVM_spesh_frame_walker_get_lex(MVMThreadContext *tc, MVMSpeshFrameWalk
         *found_out = result;
         *found_kind_out = kind;
         if (vivify && kind == MVM_reg_obj && !result->o) {
-            MVMROOT(tc, cur_frame, {
+            MVMROOT(tc, cur_frame) {
                     MVM_frame_vivify_lexical(tc, cur_frame, index);
-                });
+                }
         }
         if (found_frame)
             *found_frame = cur_frame;
@@ -327,7 +327,7 @@ MVMObject * MVM_spesh_frame_walker_get_lexicals_hash(MVMThreadContext *tc, MVMSp
     MVMHLLConfig *hll = MVM_hll_current(tc);
     MVMObject *ctx_hash = MVM_repr_alloc_init(tc, hll->slurpy_hash_type);
     find_lex_info(tc, fw, &frame, &sf, &base_index);
-    MVMROOT3(tc, ctx_hash, frame, sf, {
+    MVMROOT3(tc, ctx_hash, frame, sf) {
         MVMString **lexnames = sf->body.lexical_names_list;
         MVMuint32 i;
         for (i = 0; i < sf->body.num_lexicals; i++) {
@@ -413,7 +413,7 @@ MVMObject * MVM_spesh_frame_walker_get_lexicals_hash(MVMThreadContext *tc, MVMSp
                             MVM_reg_get_debug_name(tc, type));
             }
         }
-    });
+    }
     return ctx_hash;
 }
 

--- a/src/spesh/inline.c
+++ b/src/spesh/inline.c
@@ -326,10 +326,10 @@ MVMSpeshGraph * MVM_spesh_inline_try_get_graph_from_unspecialized(MVMThreadConte
      * the args specialization). */
     MVMSpeshGraph *ig = MVM_spesh_graph_create(tc, target_sf, 0, 1);
     MVM_spesh_args(tc, ig, cs, type_tuple);
-    MVMROOT(tc, target_sf, {
+    MVMROOT(tc, target_sf) {
         MVM_spesh_facts_discover(tc, ig, NULL, 0);
         MVM_spesh_optimize(tc, ig, NULL);
-    });
+    }
 
     /* See if it's inlineable; clean up if not. */
     if (is_graph_inlineable(tc, inliner, target_sf, runbytecode_ins, ig,

--- a/src/spesh/stats.c
+++ b/src/spesh/stats.c
@@ -636,7 +636,7 @@ void MVM_spesh_stats_cleanup(MVMThreadContext *tc, MVMObject *check_frames) {
     MVMint64 elems = MVM_repr_elems(tc, check_frames);
     MVMSTable *check_frames_st = STABLE(check_frames);
     void *check_frames_data = OBJECT_BODY(check_frames);
-    MVMROOT(tc, check_frames, {
+    MVMROOT(tc, check_frames) {
         MVMint64 insert_pos = 0;
         MVMint64 i;
         for (i = 0; i < elems; i++) {
@@ -644,7 +644,7 @@ void MVM_spesh_stats_cleanup(MVMThreadContext *tc, MVMObject *check_frames) {
             MVM_VMArray_at_pos(tc, check_frames_st, check_frames, check_frames_data,
                     i, &sf_reg, MVM_reg_obj);
             MVMStaticFrame *sf = (MVMStaticFrame *)sf_reg.o;
-            MVMROOT(tc, sf, {
+            MVMROOT(tc, sf) {
                 MVMStaticFrameSpesh *spesh = sf->body.spesh;
                 MVMSpeshStats *ss = spesh->body.spesh_stats;
                 MVMuint32 removed = 0;
@@ -691,10 +691,10 @@ void MVM_spesh_stats_cleanup(MVMThreadContext *tc, MVMObject *check_frames) {
                     MVM_VMArray_bind_pos(tc, check_frames_st, check_frames,
                             check_frames_data, insert_pos++, sf_reg, MVM_reg_obj);
                 }
-            });
+            }
         }
         MVM_repr_pos_set_elems(tc, check_frames, insert_pos);
-    });
+    }
 }
 
 void MVM_spesh_stats_gc_mark(MVMThreadContext *tc, MVMSpeshStats *ss, MVMGCWorklist *worklist) {

--- a/src/spesh/worker.c
+++ b/src/spesh/worker.c
@@ -10,15 +10,15 @@ static void worker(MVMThreadContext *tc, MVMArgs arg_info) {
     MVMObject *updated_static_frames = MVM_repr_alloc_init(tc,
         tc->instance->boot_types.BOOTArray);
     MVMObject *newly_seen_static_frames;
-    MVMROOT(tc, updated_static_frames, {
+    MVMROOT(tc, updated_static_frames) {
         newly_seen_static_frames = MVM_repr_alloc_init(tc,
             tc->instance->boot_types.BOOTArray);
-    });
+    }
     MVMObject *previous_static_frames;
-    MVMROOT2(tc, updated_static_frames, newly_seen_static_frames, {
+    MVMROOT2(tc, updated_static_frames, newly_seen_static_frames) {
         previous_static_frames = MVM_repr_alloc_init(tc,
             tc->instance->boot_types.BOOTArray);
-    });
+    }
 
 #ifdef MVM_HAS_PTHREAD_SETNAME_NP
     pthread_setname_np(pthread_self(), "spesh optimizer");
@@ -26,7 +26,7 @@ static void worker(MVMThreadContext *tc, MVMArgs arg_info) {
 
     tc->instance->speshworker_thread_id = tc->thread_obj->body.thread_id;
 
-    MVMROOT3(tc, updated_static_frames, newly_seen_static_frames, previous_static_frames, {
+    MVMROOT3(tc, updated_static_frames, newly_seen_static_frames, previous_static_frames) {
         size_t log_tell_before = 0;
         while (1) {
             MVMObject *log_obj;
@@ -53,9 +53,9 @@ static void worker(MVMThreadContext *tc, MVMArgs arg_info) {
                 if (spesh_overview_event) {
                     MVMuint64 now_time = uv_hrtime();
 
-                    MVMROOT(tc, log_obj, {
+                    MVMROOT(tc, log_obj) {
                         overview_subscription_packet = MVM_repr_alloc(tc, spesh_overview_event);
-                    });
+                    }
                     MVM_gc_root_temp_push(tc, (MVMCollectable **)&overview_subscription_packet);
 
                     MVM_repr_pos_set_elems(tc, overview_subscription_packet, 15);
@@ -85,7 +85,7 @@ static void worker(MVMThreadContext *tc, MVMArgs arg_info) {
                 if (overview_data) {
                     overview_data[4] = sl->body.thread->body.tc->thread_id;
                 }
-                MVMROOT(tc, sl, {
+                MVMROOT(tc, sl) {
                     MVMThreadContext *stc;
                     MVMuint32 i;
                     MVMuint32 n;
@@ -224,7 +224,7 @@ static void worker(MVMThreadContext *tc, MVMArgs arg_info) {
                         sl->body.entries = NULL;
                         MVM_free(entries);
                     }
-                });
+                }
 
             }
             else if (MVM_is_null(tc, log_obj)) {
@@ -260,7 +260,7 @@ static void worker(MVMThreadContext *tc, MVMArgs arg_info) {
 
             work_sequence_number++;
         }
-    });
+    }
 }
 
 /* Not thread safe per instance, but normally only used when instance is still


### PR DESCRIPTION
This is good for working with tools that do something with lines, such as stepping through code line by line, or measuring profiling data per line, but also anything that outputs C-level stack traces with line numbers.

Due to how macros are compiled, the entire expansion of the macro gets assigned a single line number.

The solution I present in this pull request creates a `for (...; ...; ...)` from the macro, which means the block of code doesn't have to go on the inside of the macro.

Here's descriptive text I've written in roots.h:

```C
/* C preprocessor macros are basically the worst thing ever.
 * So here's an explanation of the cool new root macro:
 *
 * We want the whole macro to expand to a "for ( ...; ...; ...)"
 * line, so that
 * 1. we can put a block afterwards as if our root macro were control flow
 * 2. we can put code in the initialization part of the for loop body that
 *    pushes the temp roots
 * 3. we can put code in the step part of the for loop to pop the roots again
 * 4. we can put code in the check part that makes sure the block only
 *    runs the first time around.
 *
 * In order to have multiple statements in the initialization part of the for
 * arguments list, we have to have a single statement that declares multiple
 * variables and assigns values to them.
 *
 * We use a thin wrapper around the temp root push function that returns a
 * value, since otherwise we get errors for not ignoring a void value.
 *
 * We have to make sure these variables we initialize for the sole purpose
 * of calling MVM_gc_root_temp_push have unique names, so we combine __LINE__
 * which has the line the macro was parsed at in it, and a manually provided
 * index for each of the variables.
 *
 * Another thing we have to do is make sure these variables are not completely
 * unused, since otherwise the compiler would also be unhappy.
 */
```

Concerns:

* Any user of the MVMROOT macros will have to change their code to match the new spelling (block outside instead of inside)
* Code that doesn't target an exact version of moarvm can't easily use MVMROOT in a way that is correct for the old and new version of MVMROOT

The only code we've identified is one mention in rakudo's extops, as well as Inline::Perl6. Fortunately, the code in question is mostly controlled by us. We should consider if some users can get into the situation where their moarvm updates but their inline::perl6 doesn't?

For any further users, we can put a loooong comment on the #define line which at least gcc spits out when you try to use MVMROOT with a code block:

![image](https://github.com/user-attachments/assets/21d6f7c7-2c98-485a-a452-34b515e1c5c4)
