### PR TITLE
Add MVM_string_decodestream_get_up_to_chars

### DIFF
--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -252,7 +252,7 @@ MVMString * MVM_decoder_take_chars(MVMThreadContext *tc, MVMDecoder *decoder, MV
     MVMString *result = NULL;
     enter_single_user(tc, decoder);
     MVMROOT(tc, decoder, {
-        result = MVM_string_decodestream_get_chars(tc, get_ds(tc, decoder), (MVMint32)chars, eof);
+        result = MVM_string_decodestream_get_up_to_chars(tc, get_ds(tc, decoder), (MVMint32)chars);
     });
     exit_single_user(tc, decoder);
     return result;

--- a/src/strings/decode_stream.h
+++ b/src/strings/decode_stream.h
@@ -107,6 +107,7 @@ void MVM_string_decodestream_add_bytes(MVMThreadContext *tc, MVMDecodeStream *ds
 void MVM_string_decodestream_add_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMGrapheme32 *chars, MVMint32 length);
 void MVM_string_decodestream_discard_to(MVMThreadContext *tc, MVMDecodeStream *ds, const MVMDecodeStreamBytes *bytes, MVMint32 pos);
 MVMString * MVM_string_decodestream_get_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint32 chars, MVMint64 eof);
+MVMString * MVM_string_decodestream_get_up_to_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint32 chars);
 MVMString * MVM_string_decodestream_get_until_sep(MVMThreadContext *tc, MVMDecodeStream *ds, MVMDecodeStreamSeparators *seps, MVMint32 chomp);
 MVMString * MVM_string_decodestream_get_until_sep_eof(MVMThreadContext *tc, MVMDecodeStream *ds, MVMDecodeStreamSeparators *sep_spec, MVMint32 chomp);
 MVMString * MVM_string_decodestream_get_all(MVMThreadContext *tc, MVMDecodeStream *ds);


### PR DESCRIPTION
Allows us to ask for an amount of characters, and get something out of the decodestream even when there's not as much to get as we ask for.

IO::Handle's readchars method by default tries to
get $*DEFAULT-READ-ELEMS from the decoder and won't return anything until that amount of chars has become available from repeated reads.

This change brings MVM_decoder_take_chars behaviour in line with the comment in front of it ("or all if there is not enough") and fixes both the readchars and Supply methods on $*IN with an encoding blocking until a lot of input has been read.

IO::Handle.lines.Supply already did what you wanted, and if you unset the encoding on $*IN first, .Supply.lines also works. Now both work.

resolves https://github.com/rakudo/rakudo/issues/5189