### PR TITLE
Add example scripts using the Zulip API

### DIFF
--- a/tools/zulip-file-upload.sh
+++ b/tools/zulip-file-upload.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Docs https://zulip.com/api/upload-file
+#
+# Must set env vars:
+#
+#   * ZULIP_EMAIL
+#   * ZULIP_API_KEY
+#
+# Optionally set env vars:
+#
+#   * ZULIP_DOMAIN - default: raku.zulipchat.com
+#
+# Pass argument:
+#
+#   * path to file
+#
+# Example usage uploading a file, extracting the path component
+# from the response, and posting a message with the fully-qualified
+# URL to download the file
+#
+#     $ url_path_component=$(./tools/zulip-file-upload.sh Artistic2.txt | jq -r '.url')
+#
+#     $ echo $url_path_component
+#     /user_uploads/56534/N8QnWz2lDP8-1daEkLDKpXSh/Artistic2.txt
+#
+#     $ ./tools/zulip-message-post.sh "check out this file: https://raku.zulipchat.com${url_path_component}"
+#     {"result":"success","msg":"","id":470682252}
+#
+
+
+if [ -z $ZULIP_DOMAIN ]; then
+  ZULIP_DOMAIN="raku.zulipchat.com"
+fi
+
+set -eu
+
+UPLOAD_FILE=$1
+
+curl -sSX POST "https://${ZULIP_DOMAIN}/api/v1/user_uploads" \
+    -u "${ZULIP_EMAIL}:${ZULIP_API_KEY}" \
+    -F "filename=@${UPLOAD_FILE}"
+

--- a/tools/zulip-message-post.sh
+++ b/tools/zulip-message-post.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# See api docs: https://zulip.com/api/send-message
+#
+# Must set env vars:
+#
+#   * ZULIP_EMAIL
+#   * ZULIP_API_KEY
+#
+# Optionally set env vars:
+#
+#   * ZULIP_DOMAIN - default: raku.zulipchat.com
+#   * ZULIP_TO - default: dev
+#   * ZULIP_TOPIC - default: "API Test"
+#
+# Pass argument:
+#
+#   * string content to post into the message
+#
+
+
+if [ -z $ZULIP_DOMAIN ]; then
+  ZULIP_DOMAIN="raku.zulipchat.com"
+fi
+
+if [ -z $ZULIP_TO ]; then
+  ZULIP_TO="dev"
+fi
+
+if [ -z $ZULIP_TOPIC ]; then
+  ZULIP_TOPIC="API Test"
+fi
+
+set -eu
+
+message_content=$1
+
+
+curl -sSX POST "https://${ZULIP_DOMAIN}/api/v1/messages" \
+    -u "${ZULIP_EMAIL}:${ZULIP_API_KEY}" \
+    --data-urlencode type=stream \
+    --data-urlencode "to=${ZULIP_TO}" \
+    --data-urlencode "topic=${ZULIP_TOPIC}" \
+    --data-urlencode content="${message_content}"
+


### PR DESCRIPTION
The Raku community has a Zulip instance at raku.zulipchat.com with a 50GB file storage drive.

Individual files can be up to 25MB.

We could use Zulip as an automation target for sharing test results, deploys, releases, etc.