### PR TITLE
Add telemetry log output to more pieces of moar: queues, semaphores, async processes, compunit loading, plus syscall interface for user code

### DIFF
--- a/src/6model/reprs/Semaphore.c
+++ b/src/6model/reprs/Semaphore.c
@@ -115,8 +115,9 @@ static const MVMREPROps Semaphore_this_repr = {
 
 MVMint64 MVM_semaphore_tryacquire(MVMThreadContext *tc, MVMSemaphore *sem) {
     int r;
-    MVM_telemetry_timestamp(tc, "Semaphore.tryAcquire");
+    unsigned int interval_id = MVM_telemetry_interval_start(tc, "Semaphore.tryAcquire");
     r = uv_sem_trywait(sem->body.sem);
+    MVM_telemetry_interval_stop((MVMThreadContext*)(uintptr_t)r, interval_id, "tryAcquire result");
     return !r;
 }
 

--- a/src/core/exceptions.c
+++ b/src/core/exceptions.c
@@ -857,6 +857,9 @@ MVM_NO_RETURN void MVM_panic(MVMint32 exitCode, const char *messageFormat, ...) 
     vfprintf(stderr, messageFormat, args);
     va_end(args);
     fputc('\n', stderr);
+    /* Make sure we flush the telemetry buffer before exiting. */
+    MVM_telemetry_timestamp(NULL, "moarvm paniced.");
+    MVM_telemetry_finish();
     if (crash_on_error)
         abort();
     else
@@ -881,6 +884,9 @@ MVM_NO_RETURN void MVM_oops(MVMThreadContext *tc, const char *messageFormat, ...
     vfprintf(stderr, messageFormat, args);
     va_end(args);
     fputc('\n', stderr);
+
+    MVM_telemetry_timestamp(tc, "moarvm oopsed.");
+    MVM_telemetry_finish();
 
     /* Our caller is seriously buggy if tc is NULL */
     if (!tc)

--- a/src/core/loadbytecode.c
+++ b/src/core/loadbytecode.c
@@ -50,12 +50,20 @@ void MVM_load_bytecode_buffer(MVMThreadContext *tc, MVMObject *buf) {
     )
         MVM_exception_throw_adhoc(tc, "loadbytecodebuffer requires a native int8 or uint8 array to read from");
 
+    unsigned long interval_id = MVM_telemetry_interval_start(tc, "loadbytecodebuffer");
+
     /* MVMCompUnit expects the data to be non-GC managed as it usually comes straight from a file */
     data_size = ((MVMArray *)buf)->body.elems;
+
+    MVM_telemetry_interval_annotate((uintptr_t)data_size, interval_id, "this size");
+
     data_start = MVM_malloc(data_size);
     memcpy(data_start, (MVMuint8 *)(((MVMArray *)buf)->body.slots.i8 + ((MVMArray *)buf)->body.start), data_size);
 
     cu = MVM_cu_from_bytes(tc, data_start, data_size);
+
+    MVM_telemetry_interval_stop(tc, interval_id, "done mapping");
+
     run_comp_unit(tc, cu);
 }
 void MVM_load_bytecode_buffer_to_cu(MVMThreadContext *tc, MVMObject *buf, MVMRegister *res) {
@@ -74,12 +82,20 @@ void MVM_load_bytecode_buffer_to_cu(MVMThreadContext *tc, MVMObject *buf, MVMReg
     )
         MVM_exception_throw_adhoc(tc, "loadbytecodebuffer requires a native int8 or uint8 array to read from");
 
+    unsigned long interval_id = MVM_telemetry_interval_start(tc, "buffertocu");
+
     /* MVMCompUnit expects the data to be non-GC managed as it usually comes straight from a file */
     data_size = ((MVMArray *)buf)->body.elems;
+
+    MVM_telemetry_interval_annotate((uintptr_t)data_size, interval_id, "this size");
+
     data_start = MVM_malloc(data_size);
     memcpy(data_start, (MVMuint8 *)(((MVMArray *)buf)->body.slots.i8 + ((MVMArray *)buf)->body.start), data_size);
 
     cu = MVM_cu_from_bytes(tc, data_start, data_size);
+
+    MVM_telemetry_interval_stop(tc, interval_id, "done mapping");
+
     cu->body.deallocate = MVM_DEALLOCATE_FREE;
     res->o = (MVMObject *)cu;
 

--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -1582,6 +1582,52 @@ static MVMDispSysCall stat_is_executable = {
     .expected_concrete = { 1 },
 };
 
+/* telemetry-interval-start */
+static void telemetry_interval_start_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+    unsigned long interval_id = MVM_telemetry_interval_start(tc, (const char *)(get_int_arg(arg_info, 0) % 4096));
+    MVM_args_set_result_int(tc, interval_id, MVM_RETURN_CURRENT_FRAME);
+}
+static MVMDispSysCall telemetry_interval_start = {
+    .c_name = "telemetry-interval-start",
+    .implementation = telemetry_interval_start_impl,
+    .min_args = 1,
+    .max_args = 1,
+    .expected_kinds = { MVM_CALLSITE_ARG_INT },
+    .expected_reprs = { 0 },
+    .expected_concrete = { 1 },
+};
+
+/* telemetry-interval-start */
+static void telemetry_interval_stop_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+    MVM_telemetry_interval_stop(tc, get_int_arg(arg_info, 0), (const char *)(get_int_arg(arg_info, 1) % 4096));
+    MVM_args_set_result_obj(tc, tc->instance->VMNull, MVM_RETURN_CURRENT_FRAME);
+}
+static MVMDispSysCall telemetry_interval_stop = {
+    .c_name = "telemetry-interval-stop",
+    .implementation = telemetry_interval_stop_impl,
+    .min_args = 2,
+    .max_args = 2,
+    .expected_kinds = { MVM_CALLSITE_ARG_INT, MVM_CALLSITE_ARG_INT },
+    .expected_reprs = { 0, 0 },
+    .expected_concrete = { 1, 1 },
+};
+
+/* telemetry-interval-annotate */
+static void telemetry_interval_annotate_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+    char *dyn_str = MVM_string_utf8_encode_C_string(tc, get_str_arg(arg_info, 2));
+    MVM_telemetry_interval_annotate_dynamic(get_int_arg(arg_info, 1), get_int_arg(arg_info, 0), dyn_str);
+    MVM_args_set_result_obj(tc, tc->instance->VMNull, MVM_RETURN_CURRENT_FRAME);
+}
+static MVMDispSysCall telemetry_interval_annotate = {
+    .c_name = "telemetry-interval-annotate",
+    .implementation = telemetry_interval_annotate_impl,
+    .min_args = 3,
+    .max_args = 3,
+    .expected_kinds = { MVM_CALLSITE_ARG_INT, MVM_CALLSITE_ARG_INT, MVM_CALLSITE_ARG_STR },
+    .expected_reprs = { 0, 0, 0 },
+    .expected_concrete = { 1, 1, 1 },
+};
+
 /* Add all of the syscalls into the hash. */
 MVM_STATIC_INLINE void add_to_hash(MVMThreadContext *tc, MVMDispSysCall *syscall) {
     MVMString *name = MVM_string_ascii_decode_nt(tc, tc->instance->VMString, syscall->c_name);
@@ -1680,6 +1726,9 @@ void MVM_disp_syscall_setup(MVMThreadContext *tc) {
     add_to_hash(tc, &stat_is_writable);
     add_to_hash(tc, &stat_is_executable);
     add_to_hash(tc, &all_thread_bt);
+    add_to_hash(tc, &telemetry_interval_start);
+    add_to_hash(tc, &telemetry_interval_stop);
+    add_to_hash(tc, &telemetry_interval_annotate);
     MVM_gc_allocate_gen2_default_clear(tc);
 }
 

--- a/src/io/syncfile.c
+++ b/src/io/syncfile.c
@@ -72,6 +72,8 @@ static MVMint64 mvm_fileno(MVMThreadContext *tc, MVMOSHandle *h) {
 /* Performs a write, either because a buffer filled or because we are not
  * buffering output. */
 static void perform_write(MVMThreadContext *tc, MVMIOFileData *data, char *buf, MVMint64 bytes) {
+    unsigned int interval_id = MVM_telemetry_interval_start(tc, "syncfile.perform_write");
+    MVMuint64 loops = 0;
     MVMint64 bytes_written = 0;
     MVM_gc_mark_thread_blocked(tc);
     while (bytes > 0) {
@@ -88,10 +90,15 @@ static void perform_write(MVMThreadContext *tc, MVMIOFileData *data, char *buf, 
         bytes_written += r;
         buf += r;
         bytes -= r;
+        loops++;
     }
     MVM_gc_mark_thread_unblocked(tc);
     data->byte_position += bytes_written;
     data->known_writable = 1;
+    if (loops > 1)
+        MVM_telemetry_interval_annotate(loops, interval_id, "looped this many times");
+    MVM_telemetry_interval_annotate(bytes_written, interval_id, "this many bytes written");
+    MVM_telemetry_interval_stop((MVMThreadContext*)(uintptr_t)data->fd, interval_id, "syncfile.perform_write FD");
 }
 
 /* Flushes any existing output buffer and clears use back to 0. */

--- a/src/main.c
+++ b/src/main.c
@@ -250,26 +250,6 @@ int wmain(int argc, wchar_t *wargv[])
         }
     }
 
-#ifdef HAVE_TELEMEH
-    if (getenv("MVM_TELEMETRY_LOG")) {
-        char path[256];
-        FILE *fp;
-        snprintf(path, 255, "%s.%d", getenv("MVM_TELEMETRY_LOG"),
-#ifdef _WIN32
-             _getpid()
-#else
-             getpid()
-#endif
-             );
-        fp = MVM_platform_fopen(path, "w");
-        if (fp) {
-            MVM_telemetry_init(fp);
-            telemeh_inited = 1;
-            interval_id = MVM_telemetry_interval_start(0, "moarvm startup");
-        }
-    }
-#endif
-
     lib_path[lib_path_i] = NULL;
 
     if (argi >= argc) {
@@ -305,13 +285,6 @@ int wmain(int argc, wchar_t *wargv[])
 
     if (dump) MVM_vm_dump_file(instance, input_file);
     else MVM_vm_run_file(instance, input_file);
-
-#ifdef HAVE_TELEMEH
-    if (getenv("MVM_TELEMETRY_LOG") && telemeh_inited) {
-        MVM_telemetry_interval_stop(0, interval_id, "moarvm teardown");
-        MVM_telemetry_finish();
-    }
-#endif
 
     if (full_cleanup) {
         MVM_vm_destroy_instance(instance);

--- a/src/profiler/telemeh.c
+++ b/src/profiler/telemeh.c
@@ -248,16 +248,28 @@ static void serializeTelemetryBufferRange(FILE *outfile, unsigned int serializat
                 fprintf(outfile, "Epoch counter: %lld\n", record->u.epoch.time);
                 break;
             case TimeStamp:
-                fprintf(outfile, "%15lld -|-  \"%s\"\n", record->u.timeStamp.time - beginningEpoch, record->u.timeStamp.description);
+                if ((uintptr_t)record->u.timeStamp.description < 4096)
+                    fprintf(outfile, "%15lld -|-  \"custom #%lu\"\n", record->u.timeStamp.time - beginningEpoch, (MVMuint64)record->u.timeStamp.description);
+                else
+                    fprintf(outfile, "%15lld -|-  \"%s\"\n", record->u.timeStamp.time - beginningEpoch, record->u.timeStamp.description);
                 break;
             case IntervalStart:
-                fprintf(outfile, "%15lld (-   \"%s\" (%d)\n", record->u.interval.time - beginningEpoch, record->u.interval.description, record->u.interval.intervalID);
+                if ((uintptr_t)record->u.interval.description < 4096)
+                    fprintf(outfile, "%15lld (-   \"custom #%lu\" (%d)\n", record->u.interval.time - beginningEpoch, (MVMuint64)record->u.interval.description, record->u.interval.intervalID);
+                else
+                    fprintf(outfile, "%15lld (-   \"%s\" (%d)\n", record->u.interval.time - beginningEpoch, record->u.interval.description, record->u.interval.intervalID);
                 break;
             case IntervalEnd:
-                fprintf(outfile, "%15lld  -)  \"%s\" (%d)\n", record->u.interval.time - beginningEpoch, record->u.interval.description, record->u.interval.intervalID);
+                if ((uintptr_t)record->u.interval.description < 4096)
+                    fprintf(outfile, "%15lld  -)  \"custom #%lu\" (%d)\n", record->u.interval.time - beginningEpoch, (MVMuint64)record->u.interval.description, record->u.interval.intervalID);
+                else
+                    fprintf(outfile, "%15lld  -)  \"%s\" (%d)\n", record->u.interval.time - beginningEpoch, record->u.interval.description, record->u.interval.intervalID);
                 break;
             case IntervalAnnotation:
-                fprintf(outfile,  "%15s ???  \"%s\" (%d)\n", " ", record->u.annotation.description, record->u.annotation.intervalID);
+                if ((uintptr_t)record->u.annotation.description < 4096)
+                    fprintf(outfile,  "%15s ???  \"custom #%lu\" (%d)\n", " ", (MVMuint64)record->u.annotation.description, record->u.annotation.intervalID);
+                else
+                    fprintf(outfile,  "%15s ???  \"%s\" (%d)\n", " ", record->u.annotation.description, record->u.annotation.intervalID);
                 break;
             case DynamicString:
                 fprintf(outfile,  "%15s ???  \"%s\" (%d)\n", " ", record->u.annotation_dynamic.description, record->u.annotation_dynamic.intervalID);
@@ -285,10 +297,16 @@ static void serializeTelemetryBuffer(FILE *outfile)
 
 static void backgroundSerialization(void *outfile)
 {
-        struct TelemetryRecord *calibrationRecord;
+    struct TelemetryRecord *calibrationRecord;
     struct TelemetryRecord *epochRecord;
 
     pthread_setname_np(pthread_self(), "telemetrylog");
+
+    epochRecord = newRecord();
+    READ_TSC(epochRecord->u.epoch.time)
+    epochRecord->recordType = Epoch;
+
+    beginningEpoch = epochRecord->u.epoch.time;
 
     calibrateTSC(outfile);
 
@@ -299,8 +317,6 @@ static void backgroundSerialization(void *outfile)
     epochRecord = newRecord();
     READ_TSC(epochRecord->u.epoch.time)
     epochRecord->recordType = Epoch;
-
-    beginningEpoch = epochRecord->u.epoch.time;
 
     while(continueBackgroundSerialization) {
         MVM_sleep(100);
@@ -327,7 +343,8 @@ MVM_PUBLIC void MVM_telemetry_init(FILE *outfile)
 MVM_PUBLIC void MVM_telemetry_finish()
 {
     continueBackgroundSerialization = 0;
-    uv_thread_join(&backgroundSerializationThread);
+    if (backgroundSerializationThread)
+        uv_thread_join(&backgroundSerializationThread);
 }
 
 #else

--- a/src/profiler/telemeh.c
+++ b/src/profiler/telemeh.c
@@ -318,9 +318,11 @@ static void backgroundSerialization(void *outfile)
     READ_TSC(epochRecord->u.epoch.time)
     epochRecord->recordType = Epoch;
 
-    while(continueBackgroundSerialization) {
-        MVM_sleep(100);
+    MVMuint8 has_serialized_one = 0;
+    while(continueBackgroundSerialization || has_serialized_one == 0) {
+        MVM_sleep(500);
         serializeTelemetryBuffer((FILE *)outfile);
+        has_serialized_one = 1;
     }
 
     fclose((FILE *)outfile);


### PR DESCRIPTION
* Make sure that MVM_TELEMETRY_LOG is respected in nqp and rakudo runner binaries
* output some information when queues and semaphores do something
* output some information when an async process is spawned
* output some information when a compunit is loaded from a file, or from a bucket of bytes
* allow putting output in the telemetry log using `nqp::syscall` from nqp/raku internals