### PR TITLE
Add missing mode initializers to socket function pointer structs

### DIFF
--- a/src/io/asyncsocket.c
+++ b/src/io/asyncsocket.c
@@ -458,8 +458,7 @@ static MVMint64 socket_handle(MVMThreadContext *tc, MVMOSHandle *h) {
 static const MVMIOClosable      closable       = { close_socket };
 static const MVMIOAsyncReadable async_readable = { read_bytes };
 static const MVMIOAsyncWritable async_writable = { write_bytes };
-static const MVMIOIntrospection introspection  = { socket_is_tty,
-                                                   socket_handle };
+static const MVMIOIntrospection introspection  = { socket_is_tty, socket_handle, NULL };
 static const MVMIOOps op_table = {
     &closable,
     NULL,

--- a/src/io/asyncsocketudp.c
+++ b/src/io/asyncsocketudp.c
@@ -463,8 +463,7 @@ static MVMint64 socket_handle(MVMThreadContext *tc, MVMOSHandle *h) {
 static const MVMIOClosable        closable          = { close_socket };
 static const MVMIOAsyncReadable   async_readable    = { read_bytes };
 static const MVMIOAsyncWritableTo async_writable_to = { write_bytes_to };
-static const MVMIOIntrospection   introspection     = { socket_is_tty,
-                                                        socket_handle };
+static const MVMIOIntrospection   introspection     = { socket_is_tty, socket_handle, NULL };
 static const MVMIOOps op_table = {
     &closable,
     NULL,

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -511,7 +511,8 @@ static const MVMIOSockety             sockety = { socket_connect,
                                                   socket_accept,
                                                   socket_getport };
 static const MVMIOIntrospection introspection = { socket_is_tty,
-                                                  socket_handle };
+                                                  socket_handle,
+                                                  NULL };
 
 static const MVMIOOps op_table = {
     &closable,


### PR DESCRIPTION
I think these were missed in #1803.

This fixes the three compiler warnings like the example below:
```
src/io/asyncsocketudp.c:467:57: warning: missing initializer for field ‘mvm_open_mode’ of ‘MVMIOIntrospection’ [-Wmissing-field-initializers]
  467 |                                                         socket_handle };
      |                                                         ^~~~~~~~~~~~~
In file included from src/moar.h:279,
                 from src/io/asyncsocketudp.c:1:
src/io/io.h:86:16: note: ‘mvm_open_mode’ declared here
   86 |     MVMint64 (*mvm_open_mode) (MVMThreadContext *tc, MVMOSHandle *h);
      |                ^~~~~~~~~~~~~
```

I believe putting NULL is safe because of the check here https://github.com/MoarVM/MoarVM/blob/main/src/disp/syscall.c#L1277.