### PR TITLE
all-thread-bt syscall: dump backtraces, optionally exit

### DIFF
--- a/src/debug/debugserver.h
+++ b/src/debug/debugserver.h
@@ -145,12 +145,15 @@ struct MVMDebugServerData {
 };
 
 MVM_PUBLIC void MVM_debugserver_init(MVMThreadContext *tc, MVMuint32 port);
+MVM_PUBLIC void MVM_debugserver_partial_init(MVMThreadContext *tc);
 MVM_PUBLIC void MVM_debugserver_mark_handles(MVMThreadContext *tc, MVMGCWorklist *worklist, MVMHeapSnapshotState *snapshot);
 
 MVM_PUBLIC void MVM_debugserver_notify_thread_creation(MVMThreadContext *tc);
 MVM_PUBLIC void MVM_debugserver_notify_thread_destruction(MVMThreadContext *tc);
 
 MVM_PUBLIC void MVM_debugserver_notify_unhandled_exception(MVMThreadContext *tc, MVMException *ex);
+
+MVM_PUBLIC MVMuint64 MVM_dump_all_backtraces(MVMThreadContext *dtc, MVMuint64 is_harmless);
 
 MVM_PUBLIC void MVM_debugserver_register_line(MVMThreadContext *tc, char *filename, MVMuint32 filename_len, MVMuint32 line_no,  MVMuint32 *file_idx);
 MVM_PUBLIC MVMint32 MVM_debugserver_breakpoint_check(MVMThreadContext *tc, MVMuint32 file_idx, MVMuint32 line_no);

--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -1506,6 +1506,30 @@ static MVMDispSysCall stat_is_writable = {
     .expected_concrete = { 1 },
 };
 
+/* all-thread-bt */
+static void all_thread_bt_impl(MVMThreadContext *tc, MVMArgs arg_info) {
+    MVMint64 is_harmless = arg_info.callsite->num_pos == 0 || get_int_arg(arg_info, 0) == 0;
+
+    if (!tc->instance->debugserver) {
+        MVM_debugserver_partial_init(tc);
+    }
+    MVM_dump_all_backtraces(tc, is_harmless);
+
+    if (!is_harmless)
+        exit(2);
+
+    MVM_args_set_result_int(tc, 0, MVM_RETURN_CURRENT_FRAME);
+}
+static MVMDispSysCall all_thread_bt = {
+    .c_name = "all-thread-bt",
+    .implementation = all_thread_bt_impl,
+    .min_args = 0,
+    .max_args = 1,
+    .expected_kinds = { MVM_CALLSITE_ARG_INT },
+    .expected_reprs = { 0 },
+    .expected_concrete = { 1 },
+};
+
 /* stat-is-executable */
 static void stat_is_executable_impl(MVMThreadContext *tc, MVMArgs arg_info) {
     MVMStat    *stat_obj = (MVMStat *)get_obj_arg(arg_info, 0);
@@ -1655,6 +1679,7 @@ void MVM_disp_syscall_setup(MVMThreadContext *tc) {
     add_to_hash(tc, &stat_is_readable);
     add_to_hash(tc, &stat_is_writable);
     add_to_hash(tc, &stat_is_executable);
+    add_to_hash(tc, &all_thread_bt);
     MVM_gc_allocate_gen2_default_clear(tc);
 }
 


### PR DESCRIPTION
This is how you can use it:

```
rakudo -e 'use nqp; Thread.start({ sleep 60 }, :app-lifetime); sleep 1; nqp::syscall("all-thread-bt", 1)'

==========
Thread 1 (rakudo) requested orderly crash


Thread 4 (0x7fe8e92006c0) (4: <anon>): Backtrace
   at SETTING::src/core.c/Date.rakumod:445  (/var/home/timo/raku/prefix/share/perl6/runtime/CORE.c.setting.moarvm:sleep)
 from -e:1  (<ephemeral file>:)
 from SETTING::src/core.c/Thread.rakumod:72  (/var/home/timo/raku/prefix/share/perl6/runtime/CORE.c.setting.moarvm:THREAD-ENTRY)

Thread 1 (0x7fe8ebf8cf40) (rakudo): Backtrace
   at -e:1  (<ephemeral file>:<unit>)
 from -e:1  (<ephemeral file>:<unit-outer>)
 from NQP::src/HLL/Compiler.nqp:196  (/var/home/timo/raku/prefix/share/nqp/lib/NQPHLL.moarvm:eval)
 from NQP::src/HLL/Compiler.nqp:288  (/var/home/timo/raku/prefix/share/nqp/lib/NQPHLL.moarvm:)
 from NQP::src/HLL/Compiler.nqp:285  (/var/home/timo/raku/prefix/share/nqp/lib/NQPHLL.moarvm:command_eval)
 from src/Perl6/Compiler.nqp:234  (/var/home/timo/raku/prefix/share/perl6/lib/Perl6/Compiler.moarvm:command_eval)
 from NQP::src/HLL/Compiler.nqp:268  (/var/home/timo/raku/prefix/share/nqp/lib/NQPHLL.moarvm:command_line)
 from src/main.nqp:81  (/var/home/timo/raku/prefix/share/perl6/runtime/perl6.moarvm:MAIN)
 from src/main.nqp:63  (/var/home/timo/raku/prefix/share/perl6/runtime/perl6.moarvm:<mainline>)
 from <unknown>:1  (/var/home/timo/raku/prefix/share/perl6/runtime/perl6.moarvm:<main>)
 from <unknown>:1  (/var/home/timo/raku/prefix/share/perl6/runtime/perl6.moarvm:<entry>)
```