### PR TITLE
Dedicated nursery memory area

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -569,6 +569,17 @@ struct MVMInstance {
     MVMuint64 hashSecrets[2];
 
     /************************************************************************
+     * Memory Management Stuff
+     ************************************************************************/
+#ifdef MVM_USE_MIMALLOC
+    mi_arena_id_t nursery_arena;
+    mi_heap_t *nursery_heap;
+#else
+    int nursery_arena;
+    int *nursery_heap;
+#endif
+
+    /************************************************************************
      * VM Event subscription
      ************************************************************************/
 

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -17,13 +17,13 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
     #if MVM_USE_NURSERY_ARENA
     if (parent && parent->nursery_heap) {
         tc->nursery_tospace     = mi_heap_calloc(parent->nursery_heap, 1, tc->nursery_tospace_size);
-        fprintf(stderr, "created nursery for new tc with parent's nursery_heap\n");
+        // fprintf(stderr, "created nursery for new tc with parent's nursery_heap\n");
     }
     else if (instance->nursery_heap) {
         tc->nursery_tospace     = mi_heap_calloc(instance->nursery_heap, 1, tc->nursery_tospace_size);
-        fprintf(stderr, "created nursery for new tc with instance's nursery_heap\n");
+        // fprintf(stderr, "created nursery for new tc with instance's nursery_heap\n");
     } else {
-        fprintf(stderr, "created nursery for new tc with normal calloc\n");
+        // fprintf(stderr, "created nursery for new tc with normal calloc\n");
         tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
     }
     /*if (!((uintptr_t)(tc->nursery_tospace) >= (uintptr_t)MVM_NURSERY_ARENA_POS && (uintptr_t)(tc->nursery_tospace) < (uintptr_t)MVM_NURSERY_ARENA_LIMIT)) {

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -14,7 +14,16 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
     /* Set up GC nursery. We only allocate tospace initially, and allocate
      * fromspace the first time this thread GCs, provided it ever does. */
     tc->nursery_tospace_size = MVM_gc_new_thread_nursery_size(instance);
+    #ifdef MVM_USE_MIMALLOC
+    if (parent && parent->nursery_heap)
+        tc->nursery_tospace     = mi_heap_calloc(parent->nursery_heap, 1, tc->nursery_tospace_size);
+    else if (instance->nursery_heap)
+        tc->nursery_tospace     = mi_heap_calloc(instance->nursery_heap, 1, tc->nursery_tospace_size);
+    else
+        tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
+    #else
     tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
+    #endif
     tc->nursery_alloc       = tc->nursery_tospace;
     tc->nursery_alloc_limit = (char *)tc->nursery_alloc + tc->nursery_tospace_size;
 

--- a/src/core/threadcontext.c
+++ b/src/core/threadcontext.c
@@ -14,13 +14,21 @@ MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance
     /* Set up GC nursery. We only allocate tospace initially, and allocate
      * fromspace the first time this thread GCs, provided it ever does. */
     tc->nursery_tospace_size = MVM_gc_new_thread_nursery_size(instance);
-    #ifdef MVM_USE_MIMALLOC
-    if (parent && parent->nursery_heap)
+    #if MVM_USE_NURSERY_ARENA
+    if (parent && parent->nursery_heap) {
         tc->nursery_tospace     = mi_heap_calloc(parent->nursery_heap, 1, tc->nursery_tospace_size);
-    else if (instance->nursery_heap)
+        fprintf(stderr, "created nursery for new tc with parent's nursery_heap\n");
+    }
+    else if (instance->nursery_heap) {
         tc->nursery_tospace     = mi_heap_calloc(instance->nursery_heap, 1, tc->nursery_tospace_size);
-    else
+        fprintf(stderr, "created nursery for new tc with instance's nursery_heap\n");
+    } else {
+        fprintf(stderr, "created nursery for new tc with normal calloc\n");
         tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
+    }
+    /*if (!((uintptr_t)(tc->nursery_tospace) >= (uintptr_t)MVM_NURSERY_ARENA_POS && (uintptr_t)(tc->nursery_tospace) < (uintptr_t)MVM_NURSERY_ARENA_LIMIT)) {
+        MVM_oops(parent, "nursery tospace in tc_create was out of bounds??");
+    }*/
     #else
     tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
     #endif

--- a/src/core/threadcontext.h
+++ b/src/core/threadcontext.h
@@ -4,6 +4,14 @@
 #define MVM_NUM_TEMP_BIGINTS 3
 #include "tommath.h"
 
+/* If we can get the memory management to grant us this wish,
+ * only nurseries will ever live in the memory area starting
+ * at this position, ending at twice its position. */
+#define MVM_NURSERY_ARENA_SIZE 0x10000000
+#define MVM_NURSERY_ARENA_POS ((void *)MVM_NURSERY_ARENA_SIZE)
+#define MVM_NURSERY_ARENA_LIMIT (void *)((char *)MVM_NURSERY_ARENA_POS + MVM_NURSERY_ARENA_SIZE)
+
+
 /* Possible values for the thread execution interrupt flag. */
 typedef enum {
     /* Indicates that the thread is currently executing, and should
@@ -316,6 +324,11 @@ struct MVMThreadContext {
     int nested_interpreter;
 
     MVMArgs *mark_args;
+
+    /* Memory Management bits */
+#ifdef MVM_USE_MIMALLOC
+    mi_heap_t *nursery_heap;
+#endif
 };
 
 MVMThreadContext * MVM_tc_create(MVMThreadContext *parent, MVMInstance *instance);

--- a/src/core/threadcontext.h
+++ b/src/core/threadcontext.h
@@ -6,9 +6,17 @@
 
 /* If we can get the memory management to grant us this wish,
  * only nurseries will ever live in the memory area starting
- * at this position, ending at twice its position. */
-#define MVM_NURSERY_ARENA_SIZE 0x10000000
-#define MVM_NURSERY_ARENA_POS ((void *)MVM_NURSERY_ARENA_SIZE)
+ * at this position up to _LIMIT */
+#ifndef MVM_USE_NURSERY_ARENA
+#ifdef MVM_USE_MIMALLOC
+#define MVM_USE_NURSERY_ARENA 1
+#else
+#define MVM_USE_NURSERY_ARENA 0
+#endif
+#endif
+
+#define MVM_NURSERY_ARENA_SIZE 0x40000000
+#define MVM_NURSERY_ARENA_POS ((void *)0x400000000)
 #define MVM_NURSERY_ARENA_LIMIT (void *)((char *)MVM_NURSERY_ARENA_POS + MVM_NURSERY_ARENA_SIZE)
 
 

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -56,22 +56,11 @@ static void thread_initial_invoke(MVMThreadContext *tc, void *data) {
     MVMObject *invokee = thread->body.invokee;
     thread->body.invokee = NULL;
 
-    /* Set up GC nursery. We only allocate tospace initially, and allocate
-     * fromspace the first time this thread GCs, provided it ever does. */
-    tc->nursery_tospace_size = MVM_gc_new_thread_nursery_size(tc->instance);
-    #ifdef MVM_USE_MIMALLOC
-    tc->nursery_heap = mi_heap_new_in_arena(tc->instance->nursery_arena);
-    if (tc->nursery_heap != NULL) {
-        tc->nursery_tospace     = mi_heap_calloc(tc->nursery_heap, 1, tc->nursery_tospace_size);
+    /* create mimalloc heap for this tc */
+    if (tc->instance->nursery_arena) {
+        fprintf(stderr, "initial thread invoke creates a nursery_heap!\n");
+        tc->nursery_heap = mi_heap_new_in_arena(tc->instance->nursery_arena);
     }
-    else {
-        tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
-    }
-    #else
-    tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
-    #endif
-    tc->nursery_alloc       = tc->nursery_tospace;
-    tc->nursery_alloc_limit = (char *)tc->nursery_alloc + tc->nursery_tospace_size;
 
     /* Create initial frame, which sets up all of the interpreter state also. */
     MVMArgs args = {

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -58,7 +58,7 @@ static void thread_initial_invoke(MVMThreadContext *tc, void *data) {
 
     /* create mimalloc heap for this tc */
     if (tc->instance->nursery_arena) {
-        fprintf(stderr, "initial thread invoke creates a nursery_heap!\n");
+        // fprintf(stderr, "initial thread invoke creates a nursery_heap!\n");
         tc->nursery_heap = mi_heap_new_in_arena(tc->instance->nursery_arena);
     }
 

--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -56,6 +56,23 @@ static void thread_initial_invoke(MVMThreadContext *tc, void *data) {
     MVMObject *invokee = thread->body.invokee;
     thread->body.invokee = NULL;
 
+    /* Set up GC nursery. We only allocate tospace initially, and allocate
+     * fromspace the first time this thread GCs, provided it ever does. */
+    tc->nursery_tospace_size = MVM_gc_new_thread_nursery_size(tc->instance);
+    #ifdef MVM_USE_MIMALLOC
+    tc->nursery_heap = mi_heap_new_in_arena(tc->instance->nursery_arena);
+    if (tc->nursery_heap != NULL) {
+        tc->nursery_tospace     = mi_heap_calloc(tc->nursery_heap, 1, tc->nursery_tospace_size);
+    }
+    else {
+        tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
+    }
+    #else
+    tc->nursery_tospace     = MVM_calloc(1, tc->nursery_tospace_size);
+    #endif
+    tc->nursery_alloc       = tc->nursery_tospace;
+    tc->nursery_alloc_limit = (char *)tc->nursery_alloc + tc->nursery_tospace_size;
+
     /* Create initial frame, which sets up all of the interpreter state also. */
     MVMArgs args = {
         .callsite = MVM_callsite_get_common(tc, MVM_CALLSITE_ID_ZERO_ARITY),

--- a/src/gc/allocation.c
+++ b/src/gc/allocation.c
@@ -42,6 +42,9 @@ void * MVM_gc_allocate_nursery(MVMThreadContext *tc, size_t size) {
         /* Allocate (just bump the pointer). */
         allocated = tc->nursery_alloc;
         tc->nursery_alloc = (char *)tc->nursery_alloc + size;
+        /*if (!((uintptr_t)(tc->nursery_alloc) >= (uintptr_t)MVM_NURSERY_ARENA_POS && (uintptr_t)(tc->nursery_alloc) < (uintptr_t)MVM_NURSERY_ARENA_LIMIT)) {
+            MVM_oops(tc, "nursery alloc went outside of nursery memory area???");
+        }*/
     }
     else {
         MVM_panic(MVM_exitcode_gcalloc, "Cannot allocate 0 bytes of memory in the nursery");

--- a/src/gc/worklist.c
+++ b/src/gc/worklist.c
@@ -8,7 +8,7 @@ MVMGCWorklist * MVM_gc_worklist_create(MVMThreadContext *tc, MVMuint8 include_ge
     worklist->list  = MVM_malloc(worklist->alloc * sizeof(MVMCollectable **));
     worklist->include_gen2 = !!include_gen2;
     worklist->nursery_address_hack_active = 0;
-    #ifdef MVM_USE_MIMALLOC
+    #if MVM_USE_NURSERY_ARENA
     worklist->nursery_address_hack_active = tc->nursery_heap != NULL;
     #endif
     return worklist;

--- a/src/gc/worklist.c
+++ b/src/gc/worklist.c
@@ -6,7 +6,11 @@ MVMGCWorklist * MVM_gc_worklist_create(MVMThreadContext *tc, MVMuint8 include_ge
     worklist->items = 0;
     worklist->alloc = MVM_GC_WORKLIST_START_SIZE;
     worklist->list  = MVM_malloc(worklist->alloc * sizeof(MVMCollectable **));
-    worklist->include_gen2 = include_gen2;
+    worklist->include_gen2 = !!include_gen2;
+    worklist->nursery_address_hack_active = 0;
+    #ifdef MVM_USE_MIMALLOC
+    worklist->nursery_address_hack_active = tc->nursery_heap != NULL;
+    #endif
     return worklist;
 }
 

--- a/src/gc/worklist.h
+++ b/src/gc/worklist.h
@@ -70,7 +70,7 @@ struct MVMGCWorklist {
 #define MVM_gc_worklist_add_object_no_include_gen2_nocheck(tc, worklist, item) \
     MVM_gc_worklist_add(tc, worklist, item)
 #else
-#ifdef MVM_USE_MIMALLOC
+#if MVM_USE_NURSERY_ARENA
 #define MVM_ITEM_IS_SECOND_GEN(worklist, item) \
     (worklist->nursery_address_hack_active \
         ? !((uintptr_t)(*item) >= (uintptr_t)MVM_NURSERY_ARENA_POS && (uintptr_t)(*item) < (uintptr_t)MVM_NURSERY_ARENA_LIMIT) \

--- a/src/moar.c
+++ b/src/moar.c
@@ -110,8 +110,8 @@ MVMInstance * MVM_vm_create_instance(void) {
     char *dynvar_log;
     int init_stat;
 
-    fprintf(stderr, "test allocation gives %p\n", mi_calloc(1, 64));
-    fprintf(stderr, "test allocation gives %p\n", mi_calloc(1, 64));
+    // fprintf(stderr, "test allocation gives %p\n", mi_calloc(1, 64));
+    // fprintf(stderr, "test allocation gives %p\n", mi_calloc(1, 64));
 
 #if MVM_USE_NURSERY_ARENA
     mi_arena_id_t nursery_arena = 0;
@@ -121,12 +121,12 @@ MVMInstance * MVM_vm_create_instance(void) {
             MVM_platform_unmap_file(nursery_location, NULL, MVM_NURSERY_ARENA_SIZE);
         }
         else if (nursery_location != NULL) {
-            fprintf(stderr, "going to manage memory at %p with mimalloc\n", nursery_location);
+            // fprintf(stderr, "going to manage memory at %p with mimalloc\n", nursery_location);
             if (!mi_manage_os_memory_ex(
                 MVM_NURSERY_ARENA_POS, MVM_NURSERY_ARENA_SIZE,
                 0, 0, 0, -1,
                 true, &nursery_arena)) {
-                fprintf(stderr, "that didn't work...\n");
+                // fprintf(stderr, "that didn't work...\n");
                 MVM_platform_unmap_file(nursery_location, NULL, MVM_NURSERY_ARENA_SIZE);
             }
         }
@@ -146,7 +146,7 @@ MVMInstance * MVM_vm_create_instance(void) {
     instance->nursery_arena = nursery_arena;
     if (nursery_arena) {
         instance->nursery_heap = mi_heap_new_in_arena(nursery_arena);
-        fprintf(stderr, "took arena %d, made a heap %p\n", nursery_arena, instance->nursery_heap);
+        // fprintf(stderr, "took arena %d, made a heap %p\n", nursery_arena, instance->nursery_heap);
 
         /* create mimalloc heap for this tc */
         /*instance->main_thread->nursery_heap = instance->nursery_heap;*/

--- a/src/moar.c
+++ b/src/moar.c
@@ -115,7 +115,7 @@ MVMInstance * MVM_vm_create_instance(void) {
 
 #if MVM_USE_NURSERY_ARENA
     mi_arena_id_t nursery_arena = 0;
-    if (getenv("MVM_NO_NURSERY_RANGE") == 0) {
+    if (getenv("MVM_NO_NURSERY_RANGE")) {
         void *nursery_location = MVM_platform_try_alloc_page_at_exactly(MVM_NURSERY_ARENA_POS, MVM_NURSERY_ARENA_SIZE, MVM_PAGE_READ | MVM_PAGE_WRITE);
         if (nursery_location != MVM_NURSERY_ARENA_POS) {
             MVM_platform_unmap_file(nursery_location, NULL, MVM_NURSERY_ARENA_SIZE);

--- a/src/platform/mmap.h
+++ b/src/platform/mmap.h
@@ -3,6 +3,7 @@
 #define MVM_PAGE_EXEC    4
 
 void *MVM_platform_alloc_pages(size_t size, int mode);
+void *MVM_platform_try_alloc_page_at_exactly(void *addr, size_t size, int mode);
 int MVM_platform_set_page_mode(void * block, size_t size, int mode);
 int MVM_platform_free_pages(void *block, size_t size);
 void *MVM_platform_map_file(int fd, void **handle, size_t size, int writable);

--- a/src/platform/posix/mmap.c
+++ b/src/platform/posix/mmap.c
@@ -50,6 +50,18 @@ void *MVM_platform_alloc_pages(size_t size, int page_mode)
     return block;
 }
 
+void *MVM_platform_try_alloc_page_at_exactly(void *addr, size_t size, int page_mode)
+{
+    int prot_mode = page_mode_to_prot_mode(page_mode);
+    void *block = mmap(addr, size, prot_mode, MVM_MAP_ANON | MAP_FIXED_NOREPLACE | MAP_PRIVATE, -1, 0);
+
+    if (block == MAP_FAILED)
+        return NULL;
+
+    return block;
+}
+
+
 int MVM_platform_set_page_mode(void * block, size_t size, int page_mode) {
     int prot_mode = page_mode_to_prot_mode(page_mode);
     return mprotect(block, size, prot_mode) == 0;

--- a/src/platform/posix/mmap.c
+++ b/src/platform/posix/mmap.c
@@ -53,7 +53,7 @@ void *MVM_platform_alloc_pages(size_t size, int page_mode)
 void *MVM_platform_try_alloc_page_at_exactly(void *addr, size_t size, int page_mode)
 {
     int prot_mode = page_mode_to_prot_mode(page_mode);
-    void *block = mmap(addr, size, prot_mode, MVM_MAP_ANON | MAP_FIXED_NOREPLACE | MAP_PRIVATE, -1, 0);
+    void *block = mmap(addr, size, prot_mode, MVM_MAP_ANON | MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
 
     if (block == MAP_FAILED)
         return NULL;

--- a/src/platform/win32/mmap.c
+++ b/src/platform/win32/mmap.c
@@ -32,6 +32,15 @@ void *MVM_platform_alloc_pages(size_t size, int page_mode) {
     return allocd;
 }
 
+void *MVM_platform_try_alloc_page_at_exactly(void *addr, size_t size, int page_mode) {
+    int prot_mode = page_mode_to_prot_mode(page_mode);
+    void * allocd = VirtualAlloc(addr, size, MEM_COMMIT | MEM_RESERVE, prot_mode);
+    if (!allocd)
+        return NULL;
+    return allocd;
+}
+
+
 int MVM_platform_set_page_mode(void * pages, size_t size, int page_mode) {
     int prot_mode = page_mode_to_prot_mode(page_mode);
     DWORD oldMode;


### PR DESCRIPTION
This feature reserves a big virtual memory area during startup (0x40000000 bytes, so 1 gigabyte. this should maybe be more, since virtual memory is essentially free) and gives it to mimalloc for use to allocate nurseries in.

This lets us check very cheaply if a pointer points into a nursery, or somewhere else. Most importantly, checking if an object is in generation two now becomes a simple bounds check on the pointer (plus check if the feature is currently in use, since the virtual memory reservation at the start can fail) instead of having to follow the pointer which is not guaranteed to hit the processor cache (especially in a minor gc collection run).