### PR TITLE
when a hash oopses, heap snapshot and look for refs

### DIFF
--- a/src/6model/reprs/HashAttrStore.c
+++ b/src/6model/reprs/HashAttrStore.c
@@ -92,7 +92,7 @@ static void bind_attribute(MVMThreadContext *tc, MVMSTable *st, MVMObject *root,
         MVM_exception_throw_adhoc(tc,
             "HashAttrStore representation does not support native attribute storage");
 
-    if (!MVM_str_hash_entry_size(tc, hashtable)) {
+    if (!MVM_str_hash_entry_size_blame(tc, hashtable, root)) {
         MVM_str_hash_build(tc, hashtable, sizeof(MVMHashEntry), 0);
     }
 

--- a/src/6model/reprs/MVMHash.c
+++ b/src/6model/reprs/MVMHash.c
@@ -95,7 +95,7 @@ void MVMHash_at_key(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *
         MVM_exception_throw_adhoc(tc,
             "MVMHash representation does not support native type storage");
 
-    MVMHashEntry *entry = MVM_str_hash_fetch(tc, hashtable, (MVMString *)key_obj);
+    MVMHashEntry *entry = MVM_str_hash_fetch_blame(tc, hashtable, (MVMString *)key_obj, root);
     result->o = entry != NULL ? entry->value : tc->instance->VMNull;
 }
 
@@ -111,11 +111,11 @@ void MVMHash_bind_key(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void
         MVM_exception_throw_adhoc(tc,
             "MVMHash representation does not support native type storage");
 
-    if (!MVM_str_hash_entry_size(tc, hashtable)) {
+    if (!MVM_str_hash_entry_size_blame(tc, hashtable, root)) {
         MVM_str_hash_build(tc, hashtable, sizeof(MVMHashEntry), 0);
     }
 
-    MVMHashEntry *entry = MVM_str_hash_lvalue_fetch_nocheck(tc, hashtable, key);
+    MVMHashEntry *entry = MVM_str_hash_lvalue_fetch_nocheck_blame(tc, hashtable, key, root);
     MVM_ASSIGN_REF(tc, &(root->header), entry->value, value.o);
     if (!entry->hash_handle.key) {
         entry->hash_handle.key = key;

--- a/src/core/exceptions.h
+++ b/src/core/exceptions.h
@@ -90,6 +90,7 @@ void MVM_exception_resume(MVMThreadContext *tc, MVMObject *exObj);
 MVM_PUBLIC MVM_NO_RETURN void MVM_panic_allocation_failed(size_t len) MVM_NO_RETURN_ATTRIBUTE;
 MVM_PUBLIC MVM_NO_RETURN void MVM_panic(MVMint32 exitCode, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
 MVM_PUBLIC MVM_NO_RETURN void MVM_oops(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
+MVM_PUBLIC MVM_NO_RETURN void MVM_oops_with_blame(MVMThreadContext *tc, MVMObject *blame, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 3, 4);
 MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc(MVMThreadContext *tc, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 2, 3);
 MVM_NO_RETURN void MVM_exception_throw_adhoc_va(MVMThreadContext *tc, const char *messageFormat, va_list args) MVM_NO_RETURN_ATTRIBUTE;
 MVM_PUBLIC MVM_NO_RETURN void MVM_exception_throw_adhoc_free(MVMThreadContext *tc, char **waste, const char *messageFormat, ...) MVM_NO_RETURN_ATTRIBUTE MVM_FORMAT(printf, 3, 4);

--- a/src/profiler/heapsnapshot.h
+++ b/src/profiler/heapsnapshot.h
@@ -213,7 +213,7 @@ struct MVMHeapSnapshotState {
     MVMuint64 ref_from;
 
     /* The seen hash of collectables (including frames). */
-    MVMPtrHashTable seen;
+    MVMPtrHashTable *seen;
 
     /* We sometimes use GC mark functions to find references. Keep a worklist
      * around for those times (much cheaper than allocating it whenever we
@@ -246,10 +246,11 @@ struct MVMHeapSnapshotWorkItem {
     void *target;
 };
 
-MVMint32 MVM_profile_heap_profiling(MVMThreadContext *tc);
-void MVM_profile_heap_start(MVMThreadContext *tc, MVMObject *config);
-void MVM_profile_heap_take_snapshot(MVMThreadContext *tc);
-MVMObject * MVM_profile_heap_end(MVMThreadContext *tc);
+MVM_PUBLIC MVMint32 MVM_profile_heap_profiling(MVMThreadContext *tc);
+MVM_PUBLIC void MVM_profile_heap_start(MVMThreadContext *tc, MVMObject *config);
+MVM_PUBLIC void MVM_profile_heap_take_snapshot(MVMThreadContext *tc);
+MVM_PUBLIC MVMHeapSnapshotCollection *MVM_profile_heap_make_in_memory_snapshot(MVMThreadContext *tc, MVMPtrHashTable **out_seen_hash);
+MVM_PUBLIC MVMObject * MVM_profile_heap_end(MVMThreadContext *tc);
 
 /* API for things that want to contribute more detailed data to the heap
  * profile. */


### PR DESCRIPTION
PR Status: **Draft / Experiment / Research**

Currently this isn't working very well.

The idea is that if a hash was concurrently changed without proper locking, then we may still find a reference to the hash that exploded in other thread's memory, in particular the registers and lexicals of its frames.

However, outputting this information completely unfiltered is not helpful: it is a huge amount, and any thread that has any frame on its stack that has an outer frame that has a lexical pointing at our object will show up here, which is a very low strength signal for whether the thread is manipulating the hash, or even looking at it.

The graphviz output from this code is not much better than the terminal output, thanks to long labels on the edges as well as far too many incident edges on some of the nodes, especially close to our object.