### PR TITLE
Fix a compile warning on cl / Windows

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -466,7 +466,7 @@ $config{lddebugflags} = sprintf $config{lddebugflags}, defined_or $args{debug}, 
 # generate CFLAGS
 my @cflags;
 push @cflags, '-std=c99' if $defaults{os} eq 'mingw32';
-push @cflags, $args{os} eq 'MSWin32' ? '-d2UndefIntOverflow-' : '-fwrapv';
+push @cflags, '-fwrapv'             if $config{cc} ne 'cl';
 push @cflags, $config{ccmiscflags};
 push @cflags, $config{ccoptiflags}  if $args{optimize};
 push @cflags, $config{ccdebugflags} if $args{debug};


### PR DESCRIPTION
The previous check was wrong, adding "-fwrapv" whenever you did not specify "--os" on the command line. That option is unknown to `cl`. It seems `cl` doesn't recognize "-d2UndefIntOverflow-" (nor some variants I have tried) either. So the best we can do is just not adding any option of the like.

I do wonder if this has negative stability consequences.