### PR TITLE
Add fast path when difference for 8-bit strings

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2519,6 +2519,13 @@ MVMint64 MVM_string_compare(MVMThreadContext *tc, MVMString *a, MVMString *b) {
         while (i < scanlen && a_blob8[i] == b_blob8[i]) {
             i++;
         }
+        if (i < scanlen){
+            MVMGrapheme8 g_a = a_blob8[i];
+            MVMGrapheme8 g_b = b_blob8[i];
+            return g_a < g_b ? -1 :
+                   g_b < g_a ?  1 :
+                                0 ;
+        }
     }
     else if (!a_is_eight && !b_is_eight) {
         MVMGrapheme32  *a_blob32 = a_is_in_situ ? a->body.storage.in_situ_32 : a->body.storage.blob_32;


### PR DESCRIPTION
If we're comparing 8-bit strings and there's a difference, we don't need to go through the generic grapheme-iterator path, since we know there won't be combining synthetics.

A micro-benchmark of `raku -e 'my @a = (^100_000).map(~*).pick(*).sort; say @a[now % 100_000]'` drops from ~336ms and ~2.6b instructions to ~316ms and ~2.4b instructions.