### PR TITLE
Difference fast path when comparing 8-bit strings

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2519,6 +2519,15 @@ MVMint64 MVM_string_compare(MVMThreadContext *tc, MVMString *a, MVMString *b) {
         while (i < scanlen && a_blob8[i] == b_blob8[i]) {
             i++;
         }
+        if (i < scanlen){
+            MVMGrapheme8 g_a = a_blob8[i];
+            MVMGrapheme8 g_b = b_blob8[i];
+            /* synthetics can't be trivially compared */
+            if (g_a >= 0 && g_b >= 0)
+                return g_a < g_b ? -1 :
+                       g_b < g_a ?  1 :
+                                    0 ;
+        }
     }
     else if (!a_is_eight && !b_is_eight) {
         MVMGrapheme32  *a_blob32 = a_is_in_situ ? a->body.storage.in_situ_32 : a->body.storage.blob_32;


### PR DESCRIPTION
If we're comparing 8-bit strings and there's a difference, but no synthetics involved, we don't need to go through the generic grapheme iterator path.

A micro-benchmark of `raku -e 'my @a = (^100_000).map(~*).pick(*).sort; say @a[now % 100_000]'` drops from ~336ms and ~2.6b instructions to ~316ms and ~2.4b instructions.

With this version, 
`my $with_a = buf8.new(0x41, 0xCD, 0x99, 0xE2, 0x83, 0xB0); my $with_b = buf8.new(0x42, 0xCD, 0x99, 0xE2, 0x83, 0xB0); $with_b.decode; $with_a.decode; say $with_a.decode cmp $with_b.decode`
and
`my $with_a = buf8.new(0x41, 0xCD, 0x99, 0xE2, 0x83, 0xB0); my $with_b = buf8.new(0x42, 0xCD, 0x99, 0xE2, 0x83, 0xB0); $with_a.decode; $with_b.decode; say $with_a.decode cmp $with_b.decode`
both print `Less`.