### PR TITLE
Do not persist tokens in CI artifacts

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: 'true'
+          persist-credentials: false
           ref: ${{ github.event.ref }}
 
       - name: Run "perl Configure.pl"
@@ -57,6 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: 'true'
+          persist-credentials: false
           ref: ${{ github.event.ref }}
         
       - name: Setup VS Dev Environment


### PR DESCRIPTION
zizmor reports that the MoarVM will persistent credentials through GitHub Actions artifacts:
```
zizmor .github/workflows/build_release.yml
2024-12-17T01:34:17.812372Z  WARN zizmor: skipping impostor-commit: can't run without a GitHub API token
2024-12-17T01:34:17.812388Z  WARN zizmor: skipping ref-confusion: can't run without a GitHub API token
2024-12-17T01:34:17.812397Z  WARN zizmor: skipping known-vulnerable-actions: can't run without a GitHub API token
2024-12-17T01:34:17.813247Z  INFO audit: zizmor: 🌈 completed /Users/nlogan/.rakubrew/versions/moar-blead/nqp/MoarVM/.github/workflows/build_release.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/nlogan/.rakubrew/versions/moar-blead/nqp/MoarVM/.github/workflows/build_release.yml:21:9
   |
21 |         - name: Checkout repository
   |  _________-
22 | |         uses: actions/checkout@v4
23 | |         with:
24 | |           fetch-tags: 'true'
25 | |           ref: ${{ github.event.ref }}
   | |______________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/nlogan/.rakubrew/versions/moar-blead/nqp/MoarVM/.github/workflows/build_release.yml:56:9
   |
56 |         - name: Checkout repository
   |  _________-
57 | |         uses: actions/checkout@v4
58 | |         with:
59 | |           fetch-tags: 'true'
60 | |           ref: ${{ github.event.ref }}
   | |______________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

9 findings (7 suppressed): 0 unknown, 0 informational, 0 low, 2 medium, 0 high
```

See https://github.com/actions/checkout/issues/485 and its comments for more information on setting `persist-credentials` to false.

This explicitly sets `persist-credentials: false` to opt out of the potential credential persistence.