### PR TITLE
Use 64 bit ints in decoder

### DIFF
--- a/src/6model/reprs/Decoder.c
+++ b/src/6model/reprs/Decoder.c
@@ -252,7 +252,7 @@ MVMString * MVM_decoder_take_chars(MVMThreadContext *tc, MVMDecoder *decoder, MV
     MVMString *result = NULL;
     enter_single_user(tc, decoder);
     MVMROOT(tc, decoder) {
-        result = MVM_string_decodestream_get_chars(tc, get_ds(tc, decoder), (MVMint32)chars, eof);
+        result = MVM_string_decodestream_get_chars(tc, get_ds(tc, decoder), chars, eof);
     }
     exit_single_user(tc, decoder);
     return result;

--- a/src/strings/decode_stream.c
+++ b/src/strings/decode_stream.c
@@ -27,7 +27,7 @@ MVMDecodeStream * MVM_string_decodestream_create(MVMThreadContext *tc, MVMint32 
 }
 
 /* Adds another byte buffer into the decoding stream. */
-void MVM_string_decodestream_add_bytes(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 *bytes, MVMint32 length) {
+void MVM_string_decodestream_add_bytes(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 *bytes, MVMint64 length) {
     if (length > 0) {
         MVMDecodeStreamBytes *new_bytes = MVM_calloc(1, sizeof(MVMDecodeStreamBytes));
         new_bytes->bytes  = bytes;
@@ -45,7 +45,7 @@ void MVM_string_decodestream_add_bytes(MVMThreadContext *tc, MVMDecodeStream *ds
 }
 
 /* Adds another char result buffer into the decoding stream. */
-void MVM_string_decodestream_add_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMGrapheme32 *chars, MVMint32 length) {
+void MVM_string_decodestream_add_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMGrapheme32 *chars, MVMint64 length) {
     MVMDecodeStreamChars *new_chars;
     if (ds->chars_reuse) {
         new_chars = ds->chars_reuse;
@@ -74,7 +74,7 @@ static void free_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMDecodeStrea
 }
 
 /* Throws away byte buffers no longer needed. */
-void MVM_string_decodestream_discard_to(MVMThreadContext *tc, MVMDecodeStream *ds, const MVMDecodeStreamBytes *bytes, MVMint32 pos) {
+void MVM_string_decodestream_discard_to(MVMThreadContext *tc, MVMDecodeStream *ds, const MVMDecodeStreamBytes *bytes, MVMint64 pos) {
     while (ds->bytes_head != bytes) {
         MVMDecodeStreamBytes *discard = ds->bytes_head;
         ds->abs_byte_pos += discard->length - ds->bytes_head_pos;
@@ -306,7 +306,7 @@ static MVMString * take_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint3
     return result;
 }
 MVMString * MVM_string_decodestream_get_chars(MVMThreadContext *tc, MVMDecodeStream *ds,
-                                              MVMint32 chars, MVMint64 eof) {
+                                              MVMint64 chars, MVMint64 eof) {
     MVMuint32 missing;
 
     /* If we request nothing, give empty string. */
@@ -497,7 +497,7 @@ static MVMString * get_all_in_buffer(MVMThreadContext *tc, MVMDecodeStream *ds) 
     /* Otherwise, need to assemble all the things. */
     else {
         /* Calculate length. */
-        MVMint32 length = 0, pos = 0;
+        MVMint64 length = 0, pos = 0;
         MVMDecodeStreamChars *cur_chars = ds->chars_head;
         while (cur_chars) {
             if (cur_chars == ds->chars_head)
@@ -516,7 +516,7 @@ static MVMString * get_all_in_buffer(MVMThreadContext *tc, MVMDecodeStream *ds) 
         while (cur_chars) {
             MVMDecodeStreamChars *next_chars = cur_chars->next;
             if (cur_chars == ds->chars_head) {
-                MVMint32 to_copy = ds->chars_head->length - ds->chars_head_pos;
+                MVMint64 to_copy = ds->chars_head->length - ds->chars_head_pos;
                 memcpy(result->body.storage.blob_32 + pos, cur_chars->chars + ds->chars_head_pos,
                     to_copy * sizeof(MVMGrapheme32));
                 pos += to_copy;
@@ -555,7 +555,7 @@ MVMString * MVM_string_decodestream_get_available(MVMThreadContext *tc, MVMDecod
 }
 
 /* Checks if we have the number of bytes requested. */
-MVMint64 MVM_string_decodestream_have_bytes(MVMThreadContext *tc, const MVMDecodeStream *ds, MVMint32 bytes) {
+MVMint64 MVM_string_decodestream_have_bytes(MVMThreadContext *tc, const MVMDecodeStream *ds, MVMint64 bytes) {
     MVMDecodeStreamBytes *cur_bytes = ds->bytes_head;
     MVMint32 found = 0;
     while (cur_bytes) {
@@ -585,7 +585,7 @@ MVMint64 MVM_string_decodestream_bytes_available(MVMThreadContext *tc, const MVM
 /* Copies up to the requested number of bytes into the supplied buffer, and
  * returns the number of bytes we actually copied. Takes from from the start
  * of the stream. */
-MVMint64 MVM_string_decodestream_bytes_to_buf(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 **buf, MVMint32 bytes) {
+MVMint64 MVM_string_decodestream_bytes_to_buf(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 **buf, MVMint64 bytes) {
     MVMint32 taken = 0;
     *buf = NULL;
     while (taken < bytes && ds->bytes_head) {

--- a/src/strings/decode_stream.h
+++ b/src/strings/decode_stream.h
@@ -19,17 +19,17 @@ struct MVMDecodeStream {
     MVMint64 abs_byte_pos;
 
     /* How far we've eaten into the current head bytes buffer. */
-    MVMint32 bytes_head_pos;
+    MVMint64 bytes_head_pos;
 
     /* How far we've eaten into the current head char buffer. */
-    MVMint32 chars_head_pos;
+    MVMint64 chars_head_pos;
 
     /* The encoding we're using. */
     MVMint32 encoding;
 
     /* Suggestion for decoders of how many bytes to guess at when allocating
      * decoded result buffers. */
-    MVMint32 result_size_guess;
+    MVMint64 result_size_guess;
 
     /* Normalizer. */
     MVMNormalizer norm;
@@ -51,14 +51,14 @@ struct MVMDecodeStream {
  * one, if any. */
 struct MVMDecodeStreamBytes {
     MVMuint8             *bytes;
-    MVMint32              length;
+    MVMint64              length;
     MVMDecodeStreamBytes *next;
 };
 
 /* A bunch of characters already decoded, with a link to the next bunch. */
 struct MVMDecodeStreamChars {
     MVMGrapheme32        *chars;
-    MVMint32              length;
+    MVMint64              length;
     MVMDecodeStreamChars *next;
 };
 
@@ -92,9 +92,9 @@ struct MVMDecodeStreamSeparators {
  * see if we hit the final grapheme of any of the separators, which is all we
  * demand the actual encodings themselves work out (multi-grapheme separators
  * are handled in the decode stream logic itself). */
-MVM_STATIC_INLINE MVMint32 MVM_string_decode_stream_maybe_sep(MVMThreadContext *tc, MVMDecodeStreamSeparators *sep_spec, MVMGrapheme32 g) {
+MVM_STATIC_INLINE MVMint64 MVM_string_decode_stream_maybe_sep(MVMThreadContext *tc, MVMDecodeStreamSeparators *sep_spec, MVMGrapheme32 g) {
     if (sep_spec && g <= sep_spec->max_final_grapheme) {
-        MVMint32 i;
+        MVMint64 i;
         for (i = 0; i < sep_spec->num_seps; i++)
             if (sep_spec->final_graphemes[i] == g)
                 return 1;
@@ -103,17 +103,17 @@ MVM_STATIC_INLINE MVMint32 MVM_string_decode_stream_maybe_sep(MVMThreadContext *
 }
 
 MVMDecodeStream * MVM_string_decodestream_create(MVMThreadContext *tc, MVMint32 encoding, MVMint64 abs_byte_pos, MVMint32 translate_newlines);
-void MVM_string_decodestream_add_bytes(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 *bytes, MVMint32 length);
-void MVM_string_decodestream_add_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMGrapheme32 *chars, MVMint32 length);
-void MVM_string_decodestream_discard_to(MVMThreadContext *tc, MVMDecodeStream *ds, const MVMDecodeStreamBytes *bytes, MVMint32 pos);
-MVMString * MVM_string_decodestream_get_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint32 chars, MVMint64 eof);
+void MVM_string_decodestream_add_bytes(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 *bytes, MVMint64 length);
+void MVM_string_decodestream_add_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMGrapheme32 *chars, MVMint64 length);
+void MVM_string_decodestream_discard_to(MVMThreadContext *tc, MVMDecodeStream *ds, const MVMDecodeStreamBytes *bytes, MVMint64 pos);
+MVMString * MVM_string_decodestream_get_chars(MVMThreadContext *tc, MVMDecodeStream *ds, MVMint64 chars, MVMint64 eof);
 MVMString * MVM_string_decodestream_get_until_sep(MVMThreadContext *tc, MVMDecodeStream *ds, MVMDecodeStreamSeparators *seps, MVMint32 chomp);
 MVMString * MVM_string_decodestream_get_until_sep_eof(MVMThreadContext *tc, MVMDecodeStream *ds, MVMDecodeStreamSeparators *sep_spec, MVMint32 chomp);
 MVMString * MVM_string_decodestream_get_all(MVMThreadContext *tc, MVMDecodeStream *ds);
 MVMString * MVM_string_decodestream_get_available(MVMThreadContext *tc, MVMDecodeStream *ds);
-MVMint64 MVM_string_decodestream_have_bytes(MVMThreadContext *tc, const MVMDecodeStream *ds, MVMint32 bytes);
+MVMint64 MVM_string_decodestream_have_bytes(MVMThreadContext *tc, const MVMDecodeStream *ds, MVMint64 bytes);
 MVMint64 MVM_string_decodestream_bytes_available(MVMThreadContext *tc, const MVMDecodeStream *ds);
-MVMint64 MVM_string_decodestream_bytes_to_buf(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 **buf, MVMint32 bytes);
+MVMint64 MVM_string_decodestream_bytes_to_buf(MVMThreadContext *tc, MVMDecodeStream *ds, MVMuint8 **buf, MVMint64 bytes);
 MVMint64 MVM_string_decodestream_tell_bytes(MVMThreadContext *tc, const MVMDecodeStream *ds);
 MVMint32 MVM_string_decodestream_is_empty(MVMThreadContext *tc, MVMDecodeStream *ds);
 void MVM_string_decodestream_destroy(MVMThreadContext *tc, MVMDecodeStream *ds);


### PR DESCRIPTION
Currently when slurping a 2gb file MoarVM will panic trying to allocate an impossible amount of memory. This is due to various length type values being 32 bit and overflowing with large files. This commit changes such values to instead be 64 bit.

Resolves https://github.com/rakudo/rakudo/issues/5727