### PR TITLE
Guard against out-of-bounds jumps in spesh arg guard program.

### DIFF
--- a/src/spesh/arg_guard.c
+++ b/src/spesh/arg_guard.c
@@ -510,8 +510,13 @@ MVMint32 MVM_spesh_arg_guard_run(MVMThreadContext *tc, MVMSpeshArgGuard *ag,
                 break;
             case MVM_SPESH_GUARD_OP_RESULT:
                 return agn->result;
+            default:
+                MVM_oops(tc, "Unknown spesh arg guard opcode %d reached", agn->op);
         }
-    } while (current_node != 0);
+    } while (current_node != 0 && current_node < ag->num_nodes);
+    if (current_node >= ag->num_nodes) {
+        MVM_oops(tc, "Spesh arg guard program jumped out of bounds: index %u is above %u", current_node, ag->num_nodes);
+    }
     return -1;
 }
 


### PR DESCRIPTION
This seems to be what sometimes happens on arm builds for our debian package, and hitting this oops should be better than running into an endless do-nothing loop.