### PR TITLE
Don't try to enable the JIT unless it's possible

### DIFF
--- a/src/moar.c
+++ b/src/moar.c
@@ -328,7 +328,7 @@ MVMInstance * MVM_vm_create_instance(void) {
 
     /* JIT environment/logging setup. */
     jit_disable = getenv("MVM_JIT_DISABLE");
-    if (!jit_disable || !jit_disable[0])
+    if (MVM_jit_support() && (!jit_disable || !jit_disable[0]))
         instance->jit_enabled = 1;
 
     jit_expr_enable = getenv("MVM_JIT_EXPR_ENABLE");


### PR DESCRIPTION
Currently the *only* way to disable some JIT-related functionality is to set `MVM_JIT_DISABLE`. But if it's not even possible to have a JIT (e.g., it doesn't exist for the architecture (e.g., AARCH64)), let's disable it then also.