### PR TITLE
Make accesses to spesh arg guard atomic

### DIFF
--- a/src/6model/reprs/MVMSpeshCandidate.c
+++ b/src/6model/reprs/MVMSpeshCandidate.c
@@ -377,7 +377,7 @@ void MVM_spesh_candidate_add(MVMThreadContext *tc, MVMSpeshPlanned *p) {
     /* If we're logging, dump the updated arg guards also. */
     if (MVM_spesh_debug_enabled(tc)) {
         char *guard_dump = MVM_spesh_dump_arg_guard(tc, p->sf,
-                p->sf->body.spesh->body.spesh_arg_guard);
+                (MVMSpeshArgGuard *)MVM_load(&p->sf->body.spesh->body.spesh_arg_guard));
         MVM_spesh_debug_printf(tc, "%s========\n\n", guard_dump);
         fflush(tc->instance->spesh_log_fh);
         MVM_free(guard_dump);

--- a/src/6model/reprs/MVMStaticFrameSpesh.c
+++ b/src/6model/reprs/MVMStaticFrameSpesh.c
@@ -26,7 +26,7 @@ static void copy_to(MVMThreadContext *tc, MVMSTable *st, void *src, MVMObject *d
 static void gc_mark(MVMThreadContext *tc, MVMSTable *st, void *data, MVMGCWorklist *worklist) {
     MVMStaticFrameSpeshBody *body = (MVMStaticFrameSpeshBody *)data;
     MVM_spesh_stats_gc_mark(tc, body->spesh_stats, worklist);
-    MVM_spesh_arg_guard_gc_mark(tc, body->spesh_arg_guard, worklist);
+    MVM_spesh_arg_guard_gc_mark(tc, (MVMSpeshArgGuard *)MVM_load(&body->spesh_arg_guard), worklist);
     if (body->num_spesh_candidates) {
         MVMuint32 i;
         for (i = 0; i < body->num_spesh_candidates; i++) {
@@ -40,7 +40,7 @@ static void gc_free(MVMThreadContext *tc, MVMObject *obj) {
     MVMStaticFrameSpesh *sfs = (MVMStaticFrameSpesh *)obj;
     MVM_spesh_stats_destroy(tc, sfs->body.spesh_stats);
     MVM_free(sfs->body.spesh_stats);
-    MVM_spesh_arg_guard_destroy(tc, sfs->body.spesh_arg_guard, 0);
+    MVM_spesh_arg_guard_destroy(tc, (MVMSpeshArgGuard *)MVM_load(&sfs->body.spesh_arg_guard), 0);
     MVM_free(sfs->body.spesh_candidates);
 }
 

--- a/src/6model/reprs/MVMStaticFrameSpesh.h
+++ b/src/6model/reprs/MVMStaticFrameSpesh.h
@@ -4,7 +4,8 @@
 
 struct MVMStaticFrameSpeshBody {
     /* Specialization argument guard tree, for selecting a specialization. */
-    MVMSpeshArgGuard *spesh_arg_guard;
+    /* This is a pointer to MVMSpeshArgGuard, but we access it atomically. */
+    AO_t spesh_arg_guard;
 
     /* Specializations array, if there are any. Candidates themselves never
      * move in memory; the array of pointers to them is managed using the

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -468,14 +468,14 @@ void MVM_frame_dispatch(MVMThreadContext *tc, MVMCode *code, MVMArgs args, MVMin
 
         /* Run the specialization argument guard to see if we can use one. */
         spesh = static_frame->body.spesh;
-        spesh_cand = MVM_spesh_arg_guard_run(tc, spesh->body.spesh_arg_guard,
+        spesh_cand = MVM_spesh_arg_guard_run(tc, (MVMSpeshArgGuard *)MVM_load(&spesh->body.spesh_arg_guard),
             args, NULL);
     }
     else {
         spesh = static_frame->body.spesh;
 #if MVM_SPESH_CHECK_PRESELECTION
         MVMint32 certain = -1;
-        MVMint32 correct = MVM_spesh_arg_guard_run(tc, spesh->body.spesh_arg_guard,
+        MVMint32 correct = MVM_spesh_arg_guard_run(tc, (MVMSpeshArgGuard *)MVM_load(&spesh->body.spesh_arg_guard),
             args, &certain);
         if (spesh_cand != correct && spesh_cand != certain) {
             fprintf(stderr, "Inconsistent spesh preselection of '%s' (%s): got %d, not %d\n",

--- a/src/spesh/arg_guard.c
+++ b/src/spesh/arg_guard.c
@@ -655,6 +655,6 @@ void MVM_spesh_arg_guard_discard(MVMThreadContext *tc, MVMStaticFrame *sf) {
     MVMStaticFrameSpesh *spesh = sf->body.spesh;
     if (spesh && spesh->body.spesh_arg_guard) {
         MVM_spesh_arg_guard_destroy(tc, (MVMSpeshArgGuard *)MVM_load(&spesh->body.spesh_arg_guard), 1);
-        MVM_store(spesh->body.spesh_arg_guard, NULL);
+        MVM_store(&spesh->body.spesh_arg_guard, NULL);
     }
 }

--- a/src/spesh/arg_guard.c
+++ b/src/spesh/arg_guard.c
@@ -276,7 +276,7 @@ static MVMuint32 add_nodes_for_typed_argument(MVMThreadContext *tc,
             if (additional_update_node != -1)
                 tree->nodes[additional_update_node].no = certain_fallback;
         }
-        
+
         /* Clean up. */
         for (i = 0; i < MVM_VECTOR_ELEMS(by_type); i++)
             MVM_VECTOR_DESTROY(by_type[i].cand_idxs);
@@ -307,7 +307,7 @@ static void add_nodes_for_callsite(MVMThreadContext *tc, MVMSpeshArgGuard *tree,
 
 /* Produce and install an updated set of guards, incorporating the new
  * candidate. */
-void MVM_spesh_arg_guard_regenerate(MVMThreadContext *tc, MVMSpeshArgGuard **guard_ptr,
+void MVM_spesh_arg_guard_regenerate(MVMThreadContext *tc, AO_t *guard_ptr,
         MVMSpeshCandidate **candidates, MVMuint32 num_spesh_candidates) {
     MVMSpeshArgGuard *tree;
 
@@ -358,7 +358,7 @@ void MVM_spesh_arg_guard_regenerate(MVMThreadContext *tc, MVMSpeshArgGuard **gua
         }
 
         /* Need a node for the result also. */
-        tree_size++; 
+        tree_size++;
     }
 
     /* Allocate the guards tree, and add a node for each callsite (we do it
@@ -383,12 +383,19 @@ void MVM_spesh_arg_guard_regenerate(MVMThreadContext *tc, MVMSpeshArgGuard **gua
 
     /* Install the produced argument guard. */
     if (*guard_ptr) {
-        MVMSpeshArgGuard *prev = *guard_ptr;
-        *guard_ptr = tree;
+        /* Ensure that the tree is already fully out of our cache.
+         * This is not necessary on x86_64, which has
+         * Total Store Ordering, but architectures like ARM are weaker
+         * and other cores can observe older contents of the tree nodes
+         * array after seeing the new value of the pointer. */
+        MVM_barrier();
+        MVMSpeshArgGuard *prev = (MVMSpeshArgGuard *)MVM_load(guard_ptr);
+        MVM_store(guard_ptr, tree);
         MVM_spesh_arg_guard_destroy(tc, prev, 1);
     }
     else {
-        *guard_ptr = tree;
+        MVM_barrier();
+        MVM_store(guard_ptr, tree);
     }
 
     /* Clean up working state. */
@@ -647,7 +654,7 @@ void MVM_spesh_arg_guard_destroy(MVMThreadContext *tc, MVMSpeshArgGuard *ag, MVM
 void MVM_spesh_arg_guard_discard(MVMThreadContext *tc, MVMStaticFrame *sf) {
     MVMStaticFrameSpesh *spesh = sf->body.spesh;
     if (spesh && spesh->body.spesh_arg_guard) {
-        MVM_spesh_arg_guard_destroy(tc, spesh->body.spesh_arg_guard, 1);
-        spesh->body.spesh_arg_guard = NULL;
+        MVM_spesh_arg_guard_destroy(tc, (MVMSpeshArgGuard *)MVM_load(&spesh->body.spesh_arg_guard), 1);
+        MVM_store(spesh->body.spesh_arg_guard, NULL);
     }
 }

--- a/src/spesh/arg_guard.h
+++ b/src/spesh/arg_guard.h
@@ -73,8 +73,8 @@ struct MVMSpeshArgGuardNode {
     };
 };
 
-void MVM_spesh_arg_guard_regenerate(MVMThreadContext *tc, MVMSpeshArgGuard **guard_ptr,
-        MVMSpeshCandidate **candidates, MVMuint32 num_spesh_candidates); 
+void MVM_spesh_arg_guard_regenerate(MVMThreadContext *tc, AO_t *guard_ptr,
+        MVMSpeshCandidate **candidates, MVMuint32 num_spesh_candidates);
 MVMint32 MVM_spesh_arg_guard_run_types(MVMThreadContext *tc, MVMSpeshArgGuard *ag,
     MVMCallsite *cs, MVMSpeshStatsType *types);
 MVMint32 MVM_spesh_arg_guard_run(MVMThreadContext *tc, MVMSpeshArgGuard *ag,

--- a/src/spesh/optimize.c
+++ b/src/spesh/optimize.c
@@ -1539,7 +1539,7 @@ static void optimize_runbytecode(MVMThreadContext *tc, MVMSpeshGraph *g, MVMSpes
     }
 
     /* Try to find a specialization. */
-    MVMSpeshArgGuard *ag = target_sf->body.spesh->body.spesh_arg_guard;
+    MVMSpeshArgGuard *ag = (MVMSpeshArgGuard *)MVM_load(&target_sf->body.spesh->body.spesh_arg_guard);
     MVMint16 spesh_cand = MVM_spesh_arg_guard_run_types(tc, ag, cs, stable_type_tuple);
    if (spesh_cand >= 0) {
        /* Found a candidate. Stack up any required guards. */

--- a/src/spesh/osr.c
+++ b/src/spesh/osr.c
@@ -103,7 +103,7 @@ void MVM_spesh_osr_poll_for_result(MVMThreadContext *tc) {
             if (!tc->cur_frame->extra || !tc->cur_frame->extra->caller_pos_needed) {
                 /* Check if there's a candidate available and install it if so. */
                 MVMint32 ag_result = MVM_spesh_arg_guard_run(tc,
-                    spesh->body.spesh_arg_guard,
+                    (MVMSpeshArgGuard *)MVM_load(&spesh->body.spesh_arg_guard),
                     tc->cur_frame->params.arg_info, NULL);
                 if (ag_result >= 0) {
                     perform_osr(tc, spesh->body.spesh_candidates[ag_result]);


### PR DESCRIPTION
On ARM and other platforms with less strict memory ordering guarantees than x86, the step that spesh does to switch the pointer around to the newly created spesh arg guard can be seen by another thread before the contents of the arg guard are seen, causing the thread to jump into uninitialised "code". Until recently, this just caused freezing or random behaviour. Then we got a panic or oops in moar when the code "jumped" out of bounds, which is both better and worse.

This is a real fix for the issue.

Need to check if the performance impact on x86_64 is significant. In that case, for that arch, we could conditionally use regular access instead of atomic ops. Alternatively the switch-over of the spesh arg guard pointer could be delayed, but then I don't know how to guarantee the new spesh arg guard contents are really visible at that time.