### PR TITLE
Fix error message typo in build probe script

### DIFF
--- a/build/probe.pm
+++ b/build/probe.pm
@@ -938,7 +938,7 @@ EOT
     die "Unable to run probe, so something is badly wrong"
         unless defined $size;
     chomp $size;
-    die "Probe gave nonsensical answer '$size', so something it badly wrong"
+    die "Probe gave nonsensical answer '$size', so something is badly wrong"
         unless $size =~ /\A[0-9]+\z/;
     print "$size\n";
     $config->{ptr_size} = $size;


### PR DESCRIPTION
(I just encountered this error message when trying to upgrade to [`rakudo-star` 25.01 using Homebrew](https://formulae.brew.sh/formula/rakudo-star#default) (compiling from source, not downloading the binary 'bottle'), but still need to work out what's going on there)
