### PR TITLE
Some simplifications to MVM_string_utf8_decode

### DIFF
--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -310,18 +310,11 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
         /* just keep the same buffer as the MVMString's buffer.  Later
          * we can add heuristics to resize it if we have enough free
          * memory */
-        if (count <= 2) {
-            memcpy(result->body.storage.in_situ_32, buffer, count * sizeof(MVMGrapheme32));
-            result->body.storage_type    = MVM_STRING_IN_SITU_32;
-            MVM_free(buffer);
+        if (bufsize - count > 8) {
+            buffer = MVM_realloc(buffer, count * sizeof(MVMGrapheme32));
         }
-        else {
-            if (bufsize - count > 4) {
-                buffer = MVM_realloc(buffer, count * sizeof(MVMGrapheme32));
-            }
-            result->body.storage.blob_32 = buffer;
-            result->body.storage_type    = MVM_STRING_GRAPHEME_32;
-        }
+        result->body.storage.blob_32 = buffer;
+        result->body.storage_type    = MVM_STRING_GRAPHEME_32;
     }
     result->body.num_graphs      = count;
 

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -197,11 +197,6 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
             MVMGrapheme32 g;
             ready = MVM_unicode_normalizer_process_codepoint_to_grapheme(tc, &norm, codepoint, &g);
             if (ready) {
-                while (count + ready > bufsize) { /* if the buffer's full make a bigger one */
-                    buffer = MVM_realloc(buffer, sizeof(MVMGrapheme32) * (
-                        bufsize >= UTF8_MAXINC ? (bufsize += UTF8_MAXINC) : (bufsize *= 2)
-                    ));
-                }
                 buffer[count++] = g;
                 while (--ready > 0) {
                     buffer[count++] = MVM_unicode_normalizer_get_grapheme(tc, &norm);
@@ -274,9 +269,6 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
     MVM_unicode_normalizer_eof(tc, &norm);
     ready = MVM_unicode_normalizer_available(tc, &norm);
     if (ready) {
-        if (count + ready > bufsize) {
-            buffer = MVM_realloc(buffer, sizeof(MVMGrapheme32) * (count + ready));
-        }
         while (ready--) {
             buffer[count++] =  MVM_unicode_normalizer_get_grapheme(tc, &norm);
         }

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -277,20 +277,17 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
 
     /* If we're lucky, we can fit our string in 8 bits per grapheme. */
     if (MVM_string_buf32_can_fit_into_8bit(buffer, count)) {
+        MVMGrapheme8 *storage;
         if (count <= 8) {
-            MVM_VECTORIZE_LOOP
-            for (ready = 0; ready < count; ready++) {
-                result->body.storage.in_situ_8[ready] = buffer[ready];
-            }
+            storage = result->body.storage.in_situ_8;
             result->body.storage_type    = MVM_STRING_IN_SITU_8;
         } else {
-            MVMGrapheme8 *new_buffer = MVM_malloc(sizeof(MVMGrapheme8) * count);
-            MVM_VECTORIZE_LOOP
-            for (ready = 0; ready < count; ready++) {
-                new_buffer[ready] = buffer[ready];
-            }
-            result->body.storage.blob_8  = new_buffer;
+            storage = result->body.storage.blob_8 = MVM_malloc(sizeof(MVMGrapheme8) * count);
             result->body.storage_type    = MVM_STRING_GRAPHEME_8;
+        }
+        MVM_VECTORIZE_LOOP
+        for (ready = 0; ready < count; ready++) {
+            storage[ready] = buffer[ready];
         }
         MVM_free(buffer);
     } else {

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -247,16 +247,13 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
     MVMint32 state = 0;
     MVMint32 bufsize = bytes;
     MVMGrapheme32 *buffer = MVM_malloc(sizeof(MVMGrapheme32) * bufsize);
-    size_t orig_bytes;
-    const char *orig_utf8;
+    size_t orig_bytes = bytes;
+    const char *orig_utf8 = utf8;
     MVMint32 ready;
 
     /* Need to normalize to NFG as we decode. */
     MVMNormalizer norm;
     MVM_unicode_normalizer_init(tc, &norm, MVM_NORMALIZE_NFG);
-
-    orig_bytes = bytes;
-    orig_utf8 = utf8;
 
     for (; bytes; ++utf8, --bytes) {
         switch(MVM_EXPECT(decode_utf8_byte(&state, &codepoint, (MVMuint8)*utf8), UTF8_ACCEPT)) {


### PR DESCRIPTION
`MVM_SPESH_BLOCKING=1 raku -e 'my $l = 0; for ^50 { $l++ for "/dev/shm/CORE.c.setting".IO.slurp.lines }; say now - INIT now; say $l'` takes ~2.02s on main, but ~1.94s on this branch.