### PR TITLE
Re-instate lookup of synthetic codepoint info for find_cclass

### DIFF
--- a/src/strings/ops.c
+++ b/src/strings/ops.c
@@ -2852,14 +2852,16 @@ MVMint64 MVM_string_find_cclass(MVMThreadContext *tc, MVMint64 cclass, MVMString
             switch (cclass) {
                 case MVM_CCLASS_WHITESPACE:
                     for (pos = offset; pos < end; pos++) {
-                        MVMCodepoint cp = (MVMCodepoint)s->body.storage.in_situ_8[pos];
+                        MVMGrapheme32 g = (MVMGrapheme32)s->body.storage.in_situ_8[pos];
+                        MVMCodepoint cp = 0 <= g ? g : MVM_nfg_get_synthetic_info(tc, g)->codes[0];
                         if (MVM_CP_is_White_Space(cp))
                             return pos;
                     }
                     break;
                 case MVM_CCLASS_NEWLINE:
                     for (pos = offset; pos < end; pos++) {
-                        MVMCodepoint cp = (MVMCodepoint)s->body.storage.in_situ_8[pos];
+                        MVMGrapheme32 g = (MVMGrapheme32)s->body.storage.in_situ_8[pos];
+                        MVMCodepoint cp = 0 <= g ? g : MVM_nfg_get_synthetic_info(tc, g)->codes[0];
                         if (cp == '\n' || cp == 0x0b || cp == 0x0c || cp == '\r' ||
                             cp == 0x85 || MVM_CP_is_gencat_name_Zl(cp) || MVM_CP_is_gencat_name_Zp(cp))
                             return pos;
@@ -2878,14 +2880,16 @@ MVMint64 MVM_string_find_cclass(MVMThreadContext *tc, MVMint64 cclass, MVMString
             switch (cclass) {
                 case MVM_CCLASS_WHITESPACE:
                     for (pos = offset; pos < end; pos++) {
-                        MVMCodepoint cp = (MVMCodepoint)s->body.storage.blob_8[pos];
+                        MVMGrapheme32 g = (MVMGrapheme32)s->body.storage.blob_8[pos];
+                        MVMCodepoint cp = 0 <= g ? g : MVM_nfg_get_synthetic_info(tc, g)->codes[0];
                         if (MVM_CP_is_White_Space(cp))
                             return pos;
                     }
                     break;
                 case MVM_CCLASS_NEWLINE:
                     for (pos = offset; pos < end; pos++) {
-                        MVMCodepoint cp = (MVMCodepoint)s->body.storage.blob_8[pos];
+                        MVMGrapheme32 g = (MVMGrapheme32)s->body.storage.blob_8[pos];
+                        MVMCodepoint cp = 0 <= g ? g : MVM_nfg_get_synthetic_info(tc, g)->codes[0];
                         if (cp == '\n' || cp == 0x0b || cp == 0x0c || cp == '\r' ||
                             cp == 0x85 || MVM_CP_is_gencat_name_Zl(cp) || MVM_CP_is_gencat_name_Zp(cp))
                             return pos;


### PR DESCRIPTION
It got left out accidentally. Since GRAPHEME_8 and IN_SITU_8 can store negative numbers, and especially newlines are a case of this because of the crlf synth, we need to go through the synthetic info lookup.

Fixes:

```
21:17 <timo> m: .raku.say for "Hello there\r\nHow are you".encode("latin-1").decode("latin-1").lines
21:17 <camelia> rakudo-moar 62c83711d: OUTPUT: «"Hello there\r\nHow are you"␤»
```

This was found in HTTP::Tiny's test suite.

We should maybe do something automated that double-checks everything we do with strings in the test suite with the different storage kinds?