### PR TITLE
Add type specialized VMArray atpos implementations

### DIFF
--- a/src/6model/reprconv.c
+++ b/src/6model/reprconv.c
@@ -95,8 +95,12 @@ MVM_PUBLIC MVMint64 MVM_repr_exists_pos(MVMThreadContext *tc, MVMObject *obj, MV
 MVMint64 MVM_repr_at_pos_i(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) {
     MVMRegister value;
     if (REPR(obj)->ID == MVM_REPR_ID_VMArray) {
-        MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
-            idx, &value, MVM_reg_int64);
+        if (((MVMArrayREPRData *)STABLE(obj)->REPR_data)->slot_type == MVM_ARRAY_I64) {
+            MVM_VMArray_at_pos_i(tc, STABLE(obj), obj, OBJECT_BODY(obj), idx, &value);
+        }
+        else {
+            MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj), idx, &value, MVM_reg_int64);
+        }
     }
     else {
         REPR(obj)->pos_funcs.at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
@@ -108,8 +112,12 @@ MVMint64 MVM_repr_at_pos_i(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) {
 MVMuint64 MVM_repr_at_pos_u(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) {
     MVMRegister value;
     if (REPR(obj)->ID == MVM_REPR_ID_VMArray) {
-        MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
-            idx, &value, MVM_reg_uint64);
+        if (((MVMArrayREPRData *)STABLE(obj)->REPR_data)->slot_type == MVM_ARRAY_U64) {
+            MVM_VMArray_at_pos_u(tc, STABLE(obj), obj, OBJECT_BODY(obj), idx, &value);
+        }
+        else {
+            MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj), idx, &value, MVM_reg_uint64);
+        }
     }
     else {
         REPR(obj)->pos_funcs.at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
@@ -121,8 +129,12 @@ MVMuint64 MVM_repr_at_pos_u(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) 
 MVMnum64 MVM_repr_at_pos_n(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) {
     MVMRegister value;
     if (REPR(obj)->ID == MVM_REPR_ID_VMArray) {
-        MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
-            idx, &value, MVM_reg_num64);
+        if (((MVMArrayREPRData *)STABLE(obj)->REPR_data)->slot_type == MVM_ARRAY_N64) {
+            MVM_VMArray_at_pos_n(tc, STABLE(obj), obj, OBJECT_BODY(obj), idx, &value);
+        }
+        else {
+            MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj), idx, &value, MVM_reg_num64);
+        }
     }
     else {
         REPR(obj)->pos_funcs.at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
@@ -134,8 +146,8 @@ MVMnum64 MVM_repr_at_pos_n(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) {
 MVMString * MVM_repr_at_pos_s(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx) {
     MVMRegister value;
     if (REPR(obj)->ID == MVM_REPR_ID_VMArray) {
-        MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
-            idx, &value, MVM_reg_str);
+        MVM_VMArray_at_pos_s(tc, STABLE(obj), obj, OBJECT_BODY(obj),
+            idx, &value);
     }
     else {
         REPR(obj)->pos_funcs.at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
@@ -148,8 +160,8 @@ MVMObject * MVM_repr_at_pos_o(MVMThreadContext *tc, MVMObject *obj, MVMint64 idx
     if (MVM_LIKELY(IS_CONCRETE(obj))) {
         MVMRegister value;
         if (REPR(obj)->ID == MVM_REPR_ID_VMArray) {
-            MVM_VMArray_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),
-                idx, &value, MVM_reg_obj);
+            MVM_VMArray_at_pos_o(tc, STABLE(obj), obj, OBJECT_BODY(obj),
+                idx, &value);
         }
         else if (REPR(obj)->ID == MVM_REPR_ID_P6opaque) {
             MVM_P6opaque_at_pos(tc, STABLE(obj), obj, OBJECT_BODY(obj),

--- a/src/6model/reprs/VMArray.c
+++ b/src/6model/reprs/VMArray.c
@@ -143,6 +143,100 @@ static const MVMStorageSpec * get_storage_spec(MVMThreadContext *tc, MVMSTable *
     return &storage_spec;
 }
 
+void MVM_VMArray_at_pos_s(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value) {
+    MVMArrayREPRData *repr_data = (MVMArrayREPRData *)st->REPR_data;
+    MVMArrayBody     *body      = (MVMArrayBody *)data;
+
+    /* Handle negative indexes. */
+    if (index < 0) {
+        index += body->elems;
+        if (index < 0)
+            MVM_exception_throw_adhoc(tc, "MVMArray: Index out of bounds");
+    }
+
+    /* Go by type. */
+    if (repr_data->slot_type != MVM_ARRAY_STR)
+        MVM_exception_throw_adhoc(tc, "MVMArray: atpos expected a string register, but %u is not MVM_ARRAY_STR", repr_data->slot_type);
+    if (index >= body->elems)
+        value->s = NULL;
+    else
+        value->s = body->slots.s[body->start + index];
+}
+
+void MVM_VMArray_at_pos_i(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value) {
+    MVMArrayBody     *body      = (MVMArrayBody *)data;
+
+    /* Handle negative indexes. */
+    if (index < 0) {
+        index += body->elems;
+        if (index < 0)
+            MVM_exception_throw_adhoc(tc, "MVMArray: Index out of bounds");
+    }
+
+    /* Go by type. */
+    if (index >= body->elems)
+        value->i64 = 0;
+    else
+        value->i64 = (MVMint64)body->slots.i64[body->start + index];
+}
+
+void MVM_VMArray_at_pos_u(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value) {
+    MVMArrayBody     *body      = (MVMArrayBody *)data;
+
+    /* Handle negative indexes. */
+    if (index < 0) {
+        index += body->elems;
+        if (index < 0)
+            MVM_exception_throw_adhoc(tc, "MVMArray: Index out of bounds");
+    }
+
+    /* Go by type. */
+    if (index >= body->elems)
+        value->u64 = 0;
+    else
+        value->u64 = (MVMuint64)body->slots.u64[body->start + index];
+}
+
+void MVM_VMArray_at_pos_n(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value) {
+    MVMArrayBody     *body      = (MVMArrayBody *)data;
+
+    /* Handle negative indexes. */
+    if (index < 0) {
+        index += body->elems;
+        if (index < 0)
+            MVM_exception_throw_adhoc(tc, "MVMArray: Index out of bounds");
+    }
+
+    /* Go by type. */
+    if (index >= body->elems)
+        value->n64 = 0;
+    else
+        value->n64 = (MVMnum64)body->slots.n64[body->start + index];
+}
+
+void MVM_VMArray_at_pos_o(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value) {
+    MVMArrayREPRData *repr_data = (MVMArrayREPRData *)st->REPR_data;
+    MVMArrayBody     *body      = (MVMArrayBody *)data;
+
+    /* Handle negative indexes. */
+    if (index < 0) {
+        index += body->elems;
+        if (index < 0)
+            MVM_exception_throw_adhoc(tc, "MVMArray: Index out of bounds");
+    }
+
+    /* Go by type. */
+    if (repr_data->slot_type != MVM_ARRAY_OBJ)
+        MVM_exception_throw_adhoc(tc, "MVMArray: atpos with an object register, but array type %u is not MVM_ARRAY_OBJ", repr_data->slot_type);
+    if (index >= body->elems) {
+        value->o = tc->instance->VMNull;
+    }
+    else {
+        MVMObject *found = body->slots.o[body->start + index];
+        value->o = found ? found : tc->instance->VMNull;
+    }
+}
+
 void MVM_VMArray_at_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value, MVMuint16 kind) {
     MVMArrayREPRData *repr_data = (MVMArrayREPRData *)st->REPR_data;
     MVMArrayBody     *body      = (MVMArrayBody *)data;

--- a/src/6model/reprs/VMArray.h
+++ b/src/6model/reprs/VMArray.h
@@ -76,6 +76,11 @@ struct MVMArrayREPRData {
     MVMObject *elem_type;
 };
 void MVM_VMArray_at_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value, MVMuint16 kind);
+void MVM_VMArray_at_pos_s(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value);
+void MVM_VMArray_at_pos_i(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value);
+void MVM_VMArray_at_pos_u(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value);
+void MVM_VMArray_at_pos_n(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value);
+void MVM_VMArray_at_pos_o(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister *value);
 void *MVM_VMArray_find_fast_impl_for_jit(MVMThreadContext *tc, MVMSTable *st, MVMint16 op, MVMuint16 kind);
 void MVM_VMArray_bind_pos(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data, MVMint64 index, MVMRegister value, MVMuint16 kind);
 

--- a/src/6model/sc.c
+++ b/src/6model/sc.c
@@ -157,7 +157,7 @@ MVMint64 MVM_sc_find_code_idx(MVMThreadContext *tc, MVMSerializationContext *sc,
     count = MVM_repr_elems(tc, roots);
     for (i = 0; i < count; i++) {
         MVMRegister test;
-        MVM_VMArray_at_pos(tc, STABLE(roots), roots, OBJECT_BODY(roots), i, &test, MVM_reg_obj);
+        MVM_VMArray_at_pos_o(tc, STABLE(roots), roots, OBJECT_BODY(roots), i, &test);
         if (test.o == obj)
             return i;
     }

--- a/src/spesh/stats.c
+++ b/src/spesh/stats.c
@@ -641,8 +641,7 @@ void MVM_spesh_stats_cleanup(MVMThreadContext *tc, MVMObject *check_frames) {
         MVMint64 i;
         for (i = 0; i < elems; i++) {
             MVMRegister sf_reg;
-            MVM_VMArray_at_pos(tc, check_frames_st, check_frames, check_frames_data,
-                    i, &sf_reg, MVM_reg_obj);
+            MVM_VMArray_at_pos_o(tc, check_frames_st, check_frames, check_frames_data, i, &sf_reg);
             MVMStaticFrame *sf = (MVMStaticFrame *)sf_reg.o;
             MVMROOT(tc, sf) {
                 MVMStaticFrameSpesh *spesh = sf->body.spesh;


### PR DESCRIPTION
For the numeric type ops (`*_[iun]`) I only added the most common sizes (64-bit) and check beforehand that the array's slot type matches, otherwise just go through the specialized-for-core-types function. For the string and object type ops we can just go directly to the single new version.

Then call these new versions directly when we can elsewhere in the code.

Time to compile CORE.c.setting seemed to decrease from ~45.6s to ~44.4s.