### PR TITLE
MVM_platform_sleep takes no tc argument

### DIFF
--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -3560,10 +3560,9 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_sleep: {
         MVMint16 time = ins->operands[0].reg.orig;
         MVMJitCallArg block_args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } } };
-        MVMJitCallArg sleep_args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
-                                       { MVM_JIT_REG_VAL_F, { time } } };
+        MVMJitCallArg sleep_args[] = { { MVM_JIT_REG_VAL_F, { time } } };
         jg_append_call_c(tc, jg, MVM_gc_mark_thread_blocked, 1, block_args, MVM_JIT_RV_VOID, -1);
-        jg_append_call_c(tc, jg, op_to_func(tc, op), 2, sleep_args, MVM_JIT_RV_VOID, -1);
+        jg_append_call_c(tc, jg, op_to_func(tc, op), 1, sleep_args, MVM_JIT_RV_VOID, -1);
         jg_append_call_c(tc, jg, MVM_gc_mark_thread_unblocked, 1, block_args, MVM_JIT_RV_VOID, -1);
         break;
     }


### PR DESCRIPTION
This was causing the amount of seconds to land in the xmm1 register on windows, where the function wasn't looking, and therefore any loop that was attempting to run "slowly" by calling sleep to accidentally sleep by whatever happened to still be in that register, which turned out to be 0.0, which is roughly equivalent to a thread_yield operation.

On linux, the first float argument seen in a signature would always go into xmm0, which is why the jitted result was still behaving correctly.

Thanks to @zhuomingliang++ for tracking this down in https://github.com/rakudo/rakudo/issues/5789