### PR TITLE
Only look for lexicals in frames that have any

### DIFF
--- a/src/6model/reprs/NativeRef.c
+++ b/src/6model/reprs/NativeRef.c
@@ -296,7 +296,9 @@ MVMObject * MVM_nativeref_lex_s(MVMThreadContext *tc, MVMuint16 outers, MVMuint1
 static MVMObject * lexref_by_name(MVMThreadContext *tc, MVMObject *type, MVMString *name, MVMint16 kind) {
     MVMFrame *cur_frame = tc->cur_frame;
     while (cur_frame != NULL) {
-        MVMuint32 idx = MVM_get_lexical_by_name(tc, cur_frame->static_info, name);
+        MVMuint32 idx = cur_frame->static_info->body.num_lexicals
+            ? MVM_get_lexical_by_name(tc, cur_frame->static_info, name)
+            : MVM_INDEX_HASH_NOT_FOUND;
         if (idx != MVM_INDEX_HASH_NOT_FOUND) {
             MVMint16 lex_kind = cur_frame->static_info->body.lexical_types[idx];
             if (lex_kind == kind) {

--- a/src/spesh/frame_walker.c
+++ b/src/spesh/frame_walker.c
@@ -228,6 +228,8 @@ MVMuint32 MVM_spesh_frame_walker_get_lex(MVMThreadContext *tc, MVMSpeshFrameWalk
     MVMStaticFrame *sf;
     MVMuint32 base_index;
     find_lex_info(tc, fw, &cur_frame, &sf, &base_index);
+    if (sf->body.num_lexicals == 0)
+        return 0;
     MVMuint32 idx = MVM_get_lexical_by_name(tc, sf, name);
     if (idx != MVM_INDEX_HASH_NOT_FOUND) {
         MVMint32 index = base_index + idx;
@@ -425,6 +427,8 @@ MVMint64 MVM_spesh_frame_walker_get_lexical_primspec(MVMThreadContext *tc,
     MVMStaticFrame *sf;
     MVMuint32 base_index;
     find_lex_info(tc, fw, &cur_frame, &sf, &base_index);
+    if (sf->body.num_lexicals == 0)
+        return -1;
     MVMuint32 idx = MVM_get_lexical_by_name(tc, sf, name);
     if (idx != MVM_INDEX_HASH_NOT_FOUND)
         return MVM_frame_translate_to_primspec(tc, sf->body.lexical_types[idx]);


### PR DESCRIPTION
The change in frame_walker.c got rid of 37m calls to MVM_get_lexical_by_name() when compiling CORE.c.