### PR TITLE
Add/Avoid MVMROOT in C[PP]Struct and MVMCompUnit

### DIFF
--- a/src/6model/reprs/CStruct.c
+++ b/src/6model/reprs/CStruct.c
@@ -21,14 +21,12 @@ static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *
     MVM_gc_root_temp_push(tc, (MVMCollectable **)&st);
     MVM_gc_root_temp_push(tc, (MVMCollectable **)&mro);
 
+    /* We're only ever called with tc->allocate_in_gen2 set, so no need to MVMROOT here. */
     flat_list = MVM_repr_alloc_init(tc, MVM_hll_current(tc)->slurpy_array_type);
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&flat_list);
 
     class_list = MVM_repr_alloc_init(tc, MVM_hll_current(tc)->slurpy_array_type);
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&class_list);
 
     attr_map_list = MVM_repr_alloc_init(tc, MVM_hll_current(tc)->slurpy_array_type);
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&attr_map_list);
 
     /* Walk through the parents list. */
     while (mro_idx)
@@ -41,17 +39,19 @@ static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *
         MVMObject *parents     = MVM_repr_at_pos_o(tc, type_info, 2);
         MVMint32  num_parents = MVM_repr_elems(tc, parents);
 
-        MVM_gc_root_temp_push(tc, (MVMCollectable **)&current_class);
         if (num_parents <= 1) {
             /* Get attributes and iterate over them. */
             MVMObject *attributes     = MVM_repr_at_pos_o(tc, type_info, 1);
-            MVMIter * const attr_iter = (MVMIter *)MVM_iter(tc, attributes);
             MVMObject *attr_map = NULL;
+            MVMIter   *attr_iter;
+
+            /* Add to class list firstly, so we can avoid a MVMROOT. */
+            MVM_repr_push_o(tc, class_list, current_class);
+
+            attr_iter = (MVMIter *)MVM_iter(tc, attributes);
 
             if (MVM_iter_istrue(tc, attr_iter)) {
-                MVMROOT(tc, attr_iter) {
-                    attr_map = MVM_repr_alloc_init(tc, MVM_hll_current(tc)->slurpy_hash_type);
-                }
+                attr_map = MVM_repr_alloc_init(tc, MVM_hll_current(tc)->slurpy_hash_type);
             }
 
             while (MVM_iter_istrue(tc, attr_iter)) {
@@ -76,8 +76,7 @@ static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *
                 MVM_repr_push_o(tc, flat_list, attr);
             }
 
-            /* Add to class list and map list. */
-            MVM_repr_push_o(tc, class_list, current_class);
+            /* Add to map list. */
             MVM_repr_push_o(tc, attr_map_list, attr_map);
         }
         else {
@@ -85,11 +84,9 @@ static MVMObject * index_mapping_and_flat_list(MVMThreadContext *tc, MVMObject *
             MVM_exception_throw_adhoc(tc,
                 "CStruct representation does not support multiple inheritance");
         }
-
-        MVM_gc_root_temp_pop(tc); /* current_class */
     }
 
-    MVM_gc_root_temp_pop_n(tc, 5); /* mro, st, flat_list, class_list, attr_map_list */
+    MVM_gc_root_temp_pop_n(tc, 2); /* mro, st */
 
     /* We can now form the name map. */
     num_classes = MVM_repr_elems(tc, class_list);
@@ -120,9 +117,10 @@ static MVMint32 round_up_to_multi(MVMint32 i, MVMint32 m) {
 static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_info, MVMCStructREPRData *repr_data, MVMSTable *st) {
     /* Compute index mapping table and get flat list of attributes. */
     MVMObject *flat_list;
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&st);
-    MVM_gc_root_temp_push(tc, (MVMCollectable **)&repr_info);
-    flat_list = index_mapping_and_flat_list(tc, repr_info, repr_data, st);
+
+    MVMROOT(tc, st) {
+        flat_list = index_mapping_and_flat_list(tc, repr_info, repr_data, st);
+    }
 
     /* If we have no attributes in the index mapping, then just the header. */
     if (repr_data->name_to_index_mapping[0].class_key == NULL) {
@@ -363,8 +361,6 @@ static void compute_allocation_strategy(MVMThreadContext *tc, MVMObject *repr_in
         if (repr_data->initialize_slots)
             repr_data->initialize_slots[cur_init_slot] = -1;
     }
-
-    MVM_gc_root_temp_pop_n(tc, 2); /* repr_info, st */
 }
 
 /* Helper for reading a pointer at the specified offset. */

--- a/src/6model/reprs/MVMCompUnit.c
+++ b/src/6model/reprs/MVMCompUnit.c
@@ -22,11 +22,8 @@ static MVMObject * type_object_for(MVMThreadContext *tc, MVMObject *HOW) {
 static void initialize(MVMThreadContext *tc, MVMSTable *st, MVMObject *root, void *data) {
     /* We're only ever called with tc->allocate_in_gen2 set, so no need to MVMROOT */
     MVMCompUnit *cu = (MVMCompUnit *)root;
-    MVMROOT(tc, cu) {
-        MVMObject *rm = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTReentrantMutex);
-        MVM_ASSIGN_REF(tc, &(root->header), cu->body.deserialize_frame_mutex, rm);
-    }
-
+    MVMObject *rm = MVM_repr_alloc_init(tc, tc->instance->boot_types.BOOTReentrantMutex);
+    MVM_ASSIGN_REF(tc, &(root->header), cu->body.deserialize_frame_mutex, rm);
     cu->body.inline_tweak_mutex = MVM_malloc(sizeof(uv_mutex_t));
     uv_mutex_init(cu->body.inline_tweak_mutex);
 }


### PR DESCRIPTION
This commit reverts https://github.com/MoarVM/MoarVM/commit/6d3fceeb9c, and add missing MVMROOT
```
MVM_gc_root_temp_push(tc, (MVMCollectable **)&st);
MVM_gc_root_temp_push(tc, (MVMCollectable **)&mro);
```
to CPPStruct, and avoids a MVMROOT to 'current_class' by re-order a bit code of C[PP]Struct.