### PR TITLE
Stop using Windows 2019 runner

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -48,7 +48,7 @@ jobs:
   build_Windows_MoarVM:
     strategy:
       matrix:
-        windows-os: [windows-2019, windows-2022]
+        windows-os: [windows-2022]
         
     runs-on: ${{ matrix.windows-os }}
     if: github.event.ref_type == 'tag'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,12 +56,12 @@ stages:
          # The Windows job names start with '_' so they are lexicographically first. They usually
          # take the longest to run, so this way we get better pipelining among all the jobs.
          _Win_MVM:
-           IMAGE_NAME: 'windows-2019'
+           IMAGE_NAME: 'windows-2022'
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=moar'
            MOAR_OPTIONS: ''
          _Win_MVM_reloc:
-           IMAGE_NAME: 'windows-2019'
+           IMAGE_NAME: 'windows-2022'
            RELOCATABLE: 'yes'
            RAKUDO_OPTIONS: '--relocatable'
            NQP_OPTIONS: '--backends=moar --relocatable'
@@ -157,7 +157,7 @@ stages:
            MOAR_OPTIONS: '--has-libffi --cc=clang --debug=3'
            CHECK_LEAKS: 'yes'
 #         MVM_gcc_mingw:
-#           IMAGE_NAME: 'windows-2019'
+#           IMAGE_NAME: 'windows-2022'
 #           RAKUDO_OPTIONS: ''
 #           NQP_OPTIONS: '--backends=moar'
 #           MOAR_OPTIONS: '--os=mingw32'


### PR DESCRIPTION
They are no longer supported starting 2025-06-30. See also https://github.com/actions/runner-images/issues/12045