### PR TITLE
Zero top of register when getting uint32 class member

### DIFF
--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -837,7 +837,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         } else if (op == MVM_OP_sp_p6oget_i32) {
             | movsxd TMP3, dword [TMP2];
         } else if (op == MVM_OP_sp_p6oget_u32) {
-            | mov TMP3, [TMP2];
+            | mov TMP3d, [TMP2d];
         }
         else {
             /* the regular case */


### PR DESCRIPTION
I incorrectly addressed nine++'s comment (https://github.com/MoarVM/MoarVM/pull/1746#discussion_r1134483289) by accidentally just copying what was in the `else` without adjusting it down to 32 bit operations.

Fixes https://github.com/rakudo/rakudo/issues/5954.