### PR TITLE
Add libffi as a 3rdparty submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,7 +29,7 @@
 	url = https://github.com/Nicoshev/rapidhash
 [submodule "3rdparty/libffi"]
 	path = 3rdparty/libffi
-	url = https://github.com/libffi/libffi.git
+	url = https://github.com/MoarVM/libffi.git
 
 
 # adding `shallow = true` to each submodule would save about 12M on a

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,6 +27,9 @@
 [submodule "3rdparty/rapidhash"]
 	path = 3rdparty/rapidhash
 	url = https://github.com/Nicoshev/rapidhash
+[submodule "3rdparty/libffi"]
+	path = 3rdparty/libffi
+	url = https://github.com/libffi/libffi.git
 
 
 # adding `shallow = true` to each submodule would save about 12M on a

--- a/Configure.pl
+++ b/Configure.pl
@@ -351,9 +351,7 @@ if ($args{'has-libffi'}) {
     $config{nativecall_backend} = 'libffi';
     unshift @{$config{usrlibs}}, 'ffi';
     push @{$config{defs}}, 'HAVE_LIBFFI';
-    $defaults{-thirdparty}->{dc}  = undef;
-    $defaults{-thirdparty}->{dcb} = undef;
-    $defaults{-thirdparty}->{dl}  = undef;
+    $defaults{-thirdparty}->{libffi}  = undef;
     if ($config{pkgconfig_works}) {
         setup_native_library('libffi');
     }
@@ -368,31 +366,15 @@ if ($args{'has-libffi'}) {
         }
     }
 }
-elsif ($args{'has-dyncall'}) {
-    unshift @{$config{usrlibs}}, 'dyncall_s', 'dyncallback_s', 'dynload_s';
-    $defaults{-thirdparty}->{dc}  = undef;
-    $defaults{-thirdparty}->{dcb} = undef;
-    $defaults{-thirdparty}->{dl}  = undef;
-    $config{nativecall_backend} = 'dyncall';
-    if (not $config{crossconf}) {
-        if (index($config{cincludes}, '-I/usr/local/include') == -1) {
-            $config{cincludes} = join(' ', $config{cincludes}, '-I/usr/local/include');
-        }
-        if (index($config{lincludes}, '-L/usr/local/lib') == -1) {
-            $config{lincludes} = join(' ', $config{lincludes}, '-L/usr/local/lib');
-        }
-    }
-}
 else {
-    $config{nativecall_backend} = 'dyncall';
-    $config{moar_cincludes} .= ' ' . $defaults{ccinc} . '3rdparty/dyncall/dynload'
-                             . ' ' . $defaults{ccinc} . '3rdparty/dyncall/dyncall'
-                             . ' ' . $defaults{ccinc} . '3rdparty/dyncall/dyncallback';
-    $config{install}   .= "\t\$(MKPATH) \"\$(DESTDIR)\$(PREFIX)/include/dyncall\"\n"
-                        . "\t\$(CP) 3rdparty/dyncall/dynload/*.h \"\$(DESTDIR)\$(PREFIX)/include/dyncall\"\n"
-                        . "\t\$(CP) 3rdparty/dyncall/dyncall/*.h \"\$(DESTDIR)\$(PREFIX)/include/dyncall\"\n"
-                        . "\t\$(CP) 3rdparty/dyncall/dyncallback/*.h \"\$(DESTDIR)\$(PREFIX)/include/dyncall\"\n";
-    push @hllincludes, 'dyncall';
+    push @{$config{defs}}, 'HAVE_LIBFFI';
+    $config{nativecall_backend} = 'libffi';
+    $config{moar_cincludes} .= ' ' . $defaults{ccinc} . '3rdparty/libffi/install/include';
+    $config{install}   .= "\t\$(MKPATH) \"\$(DESTDIR)\$(PREFIX)/include/libffi\"\n"
+                        . "\t\$(CP) 3rdparty/libffi/install/include/*.h \"\$(DESTDIR)\$(PREFIX)/include/libffi\"\n";
+    $config{libffi_include} = '@ccincsystem@3rdparty/libffi/install/include';
+    $config{libffi_object} = '3rdparty/libffi/install/lib/@obj@';
+    push @hllincludes, 'ffi';
 }
 
 # The ZSTD_CStream API is only exposed starting at version 1.0.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,19 +248,19 @@ stages:
         # Build MoarVM
         - script: |
             perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
+            make -j2 install
+          workingDirectory: '$(Pipeline.Workspace)/MoarVM'
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+          displayName: Build MoarVM (Linux)
+        - script: |
+            perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
             cd 3rdparty/libffi
             python generate-darwin-source-and-headers.py --only-osx
             cd ../..
             make -j2 install
           workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
-          displayName: Build MoarVM
-        - script: |
-            perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
-            make -j2 install
-          workingDirectory: '$(Pipeline.Workspace)/MoarVM'
           condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
-          displayName: Build MoarVM
+          displayName: Build MoarVM (Mac)
         - pwsh: |
             ${{ variables.PWSH_DEV }}
             perl Configure.pl --prefix=..\$(INSTALL_DIR) $(MOAR_OPTIONS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,8 +223,7 @@ stages:
 
         - script: |
             brew install automake
-            export CC=gcc-15
-            export CXX=g++-15
+            python generate-darwin-source-and-headers.py --only-osx
           condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
           displayName: Install automake and gcc
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,6 +222,11 @@ stages:
           condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
         - script: |
+            brew install automake
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
+          displayName: Install automake
+
+        - script: |
             sudo apt-get update
             sudo apt-get install libzstd-dev valgrind libltdl-dev
             # The loop with libc-bin and glibc-tools are because catchsegv moved packages with Ubuntu 20.04 and again with 22.04

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,6 +222,11 @@ stages:
           condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
         - script: |
+            brew install automake
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
+          displayName: Install automake
+
+        - script: |
             sudo apt-get update
             sudo apt-get install libzstd-dev valgrind libltdl-dev
             # The loop with libc-bin and glibc-tools are because catchsegv moved packages with Ubuntu 20.04 and again with 22.04
@@ -240,20 +245,21 @@ stages:
           workingDirectory: $(Pipeline.Workspace)
           displayName: Checkout repositories
 
+        # Build MoarVM
         - script: |
-            brew install automake
+            perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
             cd 3rdparty/libffi
             python generate-darwin-source-and-headers.py --only-osx
+            cd ../..
+            make -j2 install
           workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
-          displayName: Install automake and generate libffi darwin files
-
-        # Build MoarVM
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+          displayName: Build MoarVM
         - script: |
             perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
             make -j2 install
           workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ))
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
           displayName: Build MoarVM
         - pwsh: |
             ${{ variables.PWSH_DEV }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,34 +55,34 @@ stages:
        matrix:
          # The Windows job names start with '_' so they are lexicographically first. They usually
          # take the longest to run, so this way we get better pipelining among all the jobs.
-         A_Win_MVM:
-           IMAGE_NAME: 'windows-2022'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: ''
-         A_Win_MVM_reloc:
-           IMAGE_NAME: 'windows-2022'
-           RELOCATABLE: 'yes'
-           RAKUDO_OPTIONS: '--relocatable'
-           NQP_OPTIONS: '--backends=moar --relocatable'
-           MOAR_OPTIONS: '--relocatable'
+#         A_Win_MVM:
+#           IMAGE_NAME: 'windows-2022'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: ''
+#         A_Win_MVM_reloc:
+#           IMAGE_NAME: 'windows-2022'
+#           RELOCATABLE: 'yes'
+#           RAKUDO_OPTIONS: '--relocatable'
+#           NQP_OPTIONS: '--backends=moar --relocatable'
+#           MOAR_OPTIONS: '--relocatable'
 
          Mac_MVM:
            IMAGE_NAME: 'macOS-14'
            RAKUDO_OPTIONS: ''
            NQP_OPTIONS: '--backends=moar'
            MOAR_OPTIONS: ''
-         Mac_MVM_reloc:
-           IMAGE_NAME: 'macOS-14'
-           RELOCATABLE: 'yes'
-           RAKUDO_OPTIONS: '--relocatable'
-           NQP_OPTIONS: '--backends=moar --relocatable'
-           MOAR_OPTIONS: '--relocatable'
-         Mac_MVM_no_C11_atomics:
-           IMAGE_NAME: 'macOS-14'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--no-c11-atomics'
+#         Mac_MVM_reloc:
+#           IMAGE_NAME: 'macOS-14'
+#           RELOCATABLE: 'yes'
+#           RAKUDO_OPTIONS: '--relocatable'
+#           NQP_OPTIONS: '--backends=moar --relocatable'
+#           MOAR_OPTIONS: '--relocatable'
+#         Mac_MVM_no_C11_atomics:
+#           IMAGE_NAME: 'macOS-14'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--no-c11-atomics'
 
          Lin_MVM:
            IMAGE_NAME: 'ubuntu-24.04'
@@ -90,62 +90,62 @@ stages:
            NQP_OPTIONS: '--backends=moar'
            MOAR_OPTIONS: '--debug=3'
            CHECK_LEAKS: 'yes'
-         Lin_MVM_reloc:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RELOCATABLE: 'yes'
-           RAKUDO_OPTIONS: '--relocatable'
-           NQP_OPTIONS: '--backends=moar --relocatable'
-           MOAR_OPTIONS: '--relocatable --debug=3'
-           CHECK_LEAKS: 'yes'
+#         Lin_MVM_reloc:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RELOCATABLE: 'yes'
+#           RAKUDO_OPTIONS: '--relocatable'
+#           NQP_OPTIONS: '--backends=moar --relocatable'
+#           MOAR_OPTIONS: '--relocatable --debug=3'
+#           CHECK_LEAKS: 'yes'
 
-         MVM_gcc_njit:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--no-jit --cc=gcc --debug=3'
-           CHECK_LEAKS: 'yes'
-         MVM_gcc:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=gcc --debug=3'
-           CHECK_LEAKS: 'yes'
-         MVM_clang_njit:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--no-jit --cc=clang --debug=3'
-           CHECK_LEAKS: 'yes'
-         MVM_clang:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=clang --debug=3'
-           CHECK_LEAKS: 'yes'
-         MVM_gcc_njit_libffi:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--has-libffi --no-jit --cc=gcc --debug=3'
-           CHECK_LEAKS: 'yes'
-         MVM_gcc_libffi:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--has-libffi --cc=gcc --debug=3'
-           CHECK_LEAKS: 'yes'
-         MVM_clang_njit_libffi:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--has-libffi --no-jit --cc=clang --debug=3'
-           CHECK_LEAKS: 'yes'
-         MVM_clang_libffi:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--has-libffi --cc=clang --debug=3'
-           CHECK_LEAKS: 'yes'
+#         MVM_gcc_njit:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--no-jit --cc=gcc --debug=3'
+#           CHECK_LEAKS: 'yes'
+#         MVM_gcc:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=gcc --debug=3'
+#           CHECK_LEAKS: 'yes'
+#         MVM_clang_njit:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--no-jit --cc=clang --debug=3'
+#           CHECK_LEAKS: 'yes'
+#         MVM_clang:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=clang --debug=3'
+#           CHECK_LEAKS: 'yes'
+#         MVM_gcc_njit_libffi:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--has-libffi --no-jit --cc=gcc --debug=3'
+#           CHECK_LEAKS: 'yes'
+#         MVM_gcc_libffi:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--has-libffi --cc=gcc --debug=3'
+#           CHECK_LEAKS: 'yes'
+#         MVM_clang_njit_libffi:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--has-libffi --no-jit --cc=clang --debug=3'
+#           CHECK_LEAKS: 'yes'
+#         MVM_clang_libffi:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--has-libffi --cc=clang --debug=3'
+#           CHECK_LEAKS: 'yes'
 #         MVM_gcc_mingw:
 #           IMAGE_NAME: 'windows-2022'
 #           RAKUDO_OPTIONS: ''
@@ -158,42 +158,42 @@ stages:
 #           MOAR_OPTIONS: '--compiler=clang --coverage --optimize=0 --debug=3 --cc=clang'
 #           COVERAGE: 'yes'
 
-         MVM_gcc_malloc:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=gcc --debug=3 --no-mimalloc'
-           CHECK_LEAKS: 'yes'
-         MVM_clang_malloc:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=clang --debug=3 --no-mimalloc'
-           CHECK_LEAKS: 'yes'
-         MVM_gcc_no_c11_atomics:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=gcc --debug=3 --no-c11-atomics'
-           CHECK_LEAKS: 'yes'
-         MVM_clang_no_c11_atomics:
-           IMAGE_NAME: 'ubuntu-24.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=clang --debug=3 --no-c11-atomics'
-           CHECK_LEAKS: 'yes'
+#         MVM_gcc_malloc:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=gcc --debug=3 --no-mimalloc'
+#           CHECK_LEAKS: 'yes'
+#         MVM_clang_malloc:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=clang --debug=3 --no-mimalloc'
+#           CHECK_LEAKS: 'yes'
+#         MVM_gcc_no_c11_atomics:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=gcc --debug=3 --no-c11-atomics'
+#           CHECK_LEAKS: 'yes'
+#         MVM_clang_no_c11_atomics:
+#           IMAGE_NAME: 'ubuntu-24.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=clang --debug=3 --no-c11-atomics'
+#           CHECK_LEAKS: 'yes'
 
-         # Backwards compatability jobs, using the oldest OS version that azure pipelines support
-         MVM_Ub_22_gcc:
-           IMAGE_NAME: 'ubuntu-22.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=gcc --debug=3'
-         MVM_Ub_22_clang:
-           IMAGE_NAME: 'ubuntu-22.04'
-           RAKUDO_OPTIONS: ''
-           NQP_OPTIONS: '--backends=moar'
-           MOAR_OPTIONS: '--cc=clang --debug=3'
+#         # Backwards compatability jobs, using the oldest OS version that azure pipelines support
+#         MVM_Ub_22_gcc:
+#           IMAGE_NAME: 'ubuntu-22.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=gcc --debug=3'
+#         MVM_Ub_22_clang:
+#           IMAGE_NAME: 'ubuntu-22.04'
+#           RAKUDO_OPTIONS: ''
+#           NQP_OPTIONS: '--backends=moar'
+#           MOAR_OPTIONS: '--cc=clang --debug=3'
 
       pool:
         vmImage: $(IMAGE_NAME)
@@ -250,8 +250,15 @@ stages:
             perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
             make -j2 install
           workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ))
-          displayName: Build MoarVM
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+          displayName: Build MoarVM (Linux)
+        - script: |
+            export CC=gcc-15
+            perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
+            make -j2 install
+          workingDirectory: '$(Pipeline.Workspace)/MoarVM'
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
+          displayName: Build MoarVM (Mac)
         - pwsh: |
             ${{ variables.PWSH_DEV }}
             perl Configure.pl --prefix=..\$(INSTALL_DIR) $(MOAR_OPTIONS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,9 +222,9 @@ stages:
           condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
         - script: |
-            brew install automake
+            brew install automake gcc
           condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
-          displayName: Install automake
+          displayName: Install automake and gcc
 
         - script: |
             sudo apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -250,17 +250,8 @@ stages:
             perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
             make -j2 install
           workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
-          displayName: Build MoarVM (Linux)
-        - script: |
-            perl Configure.pl --prefix=../$(INSTALL_DIR) $(MOAR_OPTIONS)
-            cd 3rdparty/libffi
-            python generate-darwin-source-and-headers.py --only-osx
-            cd ../..
-            make -j2 install
-          workingDirectory: '$(Pipeline.Workspace)/MoarVM'
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
-          displayName: Build MoarVM (Mac)
+          condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT' ))
+          displayName: Build MoarVM
         - pwsh: |
             ${{ variables.PWSH_DEV }}
             perl Configure.pl --prefix=..\$(INSTALL_DIR) $(MOAR_OPTIONS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,7 +223,7 @@ stages:
 
         - script: |
             sudo apt-get update
-            sudo apt-get install libzstd-dev valgrind
+            sudo apt-get install libzstd-dev valgrind autoconf automake libtool texinfo
             # The loop with libc-bin and glibc-tools are because catchsegv moved packages with Ubuntu 20.04 and again with 22.04
             for pkg in libc-bin glibc-tools
             do

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,7 +222,9 @@ stages:
           condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
         - script: |
-            brew install automake gcc
+            brew install automake
+            export CC=gcc-15
+            export CXX=g++-15
           condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
           displayName: Install automake and gcc
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,13 +222,6 @@ stages:
           condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
         - script: |
-            brew install automake
-            cd 3rdparty/libffi
-            python generate-darwin-source-and-headers.py --only-osx
-          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
-          displayName: Install automake and generate libffi darwin files
-
-        - script: |
             sudo apt-get update
             sudo apt-get install libzstd-dev valgrind libltdl-dev
             # The loop with libc-bin and glibc-tools are because catchsegv moved packages with Ubuntu 20.04 and again with 22.04
@@ -246,6 +239,14 @@ stages:
         - script: perl selfrepo/tools/build/checkout-repos-for-test.pl $(RAKUDO_CHECKOUT_TYPE) $(NQP_CHECKOUT_TYPE) $(MOAR_CHECKOUT_TYPE)
           workingDirectory: $(Pipeline.Workspace)
           displayName: Checkout repositories
+
+        - script: |
+            brew install automake
+            cd 3rdparty/libffi
+            python generate-darwin-source-and-headers.py --only-osx
+          workingDirectory: '$(Pipeline.Workspace)/MoarVM'
+          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
+          displayName: Install automake and generate libffi darwin files
 
         # Build MoarVM
         - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,9 +223,10 @@ stages:
 
         - script: |
             brew install automake
+            cd 3rdparty/libffi
             python generate-darwin-source-and-headers.py --only-osx
           condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin' ))
-          displayName: Install automake and gcc
+          displayName: Install automake and generate libffi darwin files
 
         - script: |
             sudo apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,7 +223,7 @@ stages:
 
         - script: |
             sudo apt-get update
-            sudo apt-get install libzstd-dev valgrind autoconf automake libtool texinfo
+            sudo apt-get install libzstd-dev valgrind libltdl-dev
             # The loop with libc-bin and glibc-tools are because catchsegv moved packages with Ubuntu 20.04 and again with 22.04
             for pkg in libc-bin glibc-tools
             do

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -721,12 +721,9 @@ tools/repr_size_table@exe@: tools/repr_size_table@obj@ @moarlib@ $(DLL_LIBS)
 	$(MSG) linking $@
 	$(CMD)@cmprule@ $(NOOUT)
 
-@dclib@:
-	$(MSG) building dyncall...
-	$(CMD)@dcrule@ $(NOOUT)
-	$(MSG) done.
-
-@dcblib@ @dllib@: @dclib@
+@lflib@: @lfobjects@
+	$(MSG) linking $@
+	$(CMD)@lfrule@ $(NOOUT)
 
 pkgconfig/moar.pc: build/mk-moar-pc.pl
 	$(PERL) build/mk-moar-pc.pl $@
@@ -746,7 +743,6 @@ realclean: clean
 	-$(RM) @laolib@ $(NOOUT) $(NOERR)
 	-$(CMD)@tomclean@ $(NOOUT) $(NOERR)
 	-$(CMD)@shaclean@ $(NOOUT) $(NOERR)
-	-$(CMD)@dcclean@ $(NOOUT) $(NOERR)
 	-$(CMD)@cmpclean@ $(NOOUT) $(NOERR)
 	-$(RM) $(MINILUA) $(NOOUT) $(NOERR)
 

--- a/build/Makefile.in
+++ b/build/Makefile.in
@@ -607,7 +607,7 @@ reconfig: realclean
 clangcheck gcccheck:
 	@$(MAKE) --no-print-directory -f tools/check.mk $@
 
-moar@exe@: $(MAIN_OBJECTS) @moar@
+moar@exe@: @lflib@ $(MAIN_OBJECTS) @moar@
 	$(MSG) linking $@
 	$(CMD)$(LD) @ldout@$@ $(LDFLAGS) $(MINGW_UNICODE) $(MAIN_OBJECTS) $(MAIN_LIBS)
 

--- a/build/check.mk.in
+++ b/build/check.mk.in
@@ -4,9 +4,7 @@ CINCLUDES := -Isrc \
              -isystem 3rdparty/libtommath \
              -isystem 3rdparty/sha1 \
              -isystem 3rdparty/dynasm \
-             -isystem 3rdparty/dyncall/dynload \
-             -isystem 3rdparty/dyncall/dyncall \
-             -isystem 3rdparty/dyncall/dyncallback \
+             -isystem 3rdparty/libffi/install/include \
              -isystem 3rdparty
 
 

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -2,7 +2,7 @@ package main;
 use strict;
 use warnings;
 
-use File::Spec::Functions qw(devnull);
+use File::Spec::Functions qw(devnull catdir rel2abs);
 my $devnull = devnull();
 
 # 3rdparty library configuration
@@ -24,25 +24,6 @@ my %TP_TOM = (
     name => 'tommath',
     path => '3rdparty/libtommath',
     src  => [ '3rdparty/libtommath' ],
-);
-
-my %TP_DC = (
-    name  => 'dyncall_s',
-    path  => '3rdparty/dyncall/dyncall',
-    rule  => 'cd 3rdparty/dyncall &&  ./configure && CC=\'$(CC)\' CFLAGS=\'-fPIC\' $(MAKE) -f Makefile ',
-    clean => 'cd 3rdparty/dyncall && $(MAKE) -f Makefile clean',
-);
-
-my %TP_DCB = (
-    name  => 'dyncallback_s',
-    path  => '3rdparty/dyncall/dyncallback',
-    dummy => 1, # created as part of dyncall build
-);
-
-my %TP_DL = (
-    name  => 'dynload_s',
-    path  => '3rdparty/dyncall/dynload',
-    dummy => 1, # created as part of dyncall build
 );
 
 my %TP_CMP = (
@@ -67,15 +48,20 @@ my %TP_UV = (
     # the OS needs to provide a C<src> or C<objects> setting
 );
 
+my %TP_LF = (
+    name  => 'ffi/install/lib/libffi',
+    path  => '3rdparty',
+    rule  => 'cd 3rdparty/libffi && ./autogen.sh && ./configure --disable-builddir --disable-docs --prefix=' . catdir(rel2abs(), '3rdparty', 'libffi', 'install') . ' CC=\'$(CC)\' CFLAGS=\'$(CFLAGS) -Wno-error=pointer-arith\' && $(MAKE) install',
+    clean => 'cd 3rdparty/libffi && $(MAKE) clean',
+);
+
 our %THIRDPARTY = (
     lao => { %TP_LAO },
     tom => { %TP_TOM },
     sha => { %TP_SHA },
-    dc  => { %TP_DC },
-    dcb => { %TP_DCB },
-    dl  => { %TP_DL },
     uv  => { %TP_UVDUMMY },
     cmp => { %TP_CMP },
+    lf  => { %TP_LF },
 );
 
 # shell configuration
@@ -262,18 +248,6 @@ TERM
     dlllocal  => '',
 
     -auxfiles => [ qw( @name@.ilk @name@.pdb @moardll@.lib @moardll@.exp vc100.pdb ) ],
-
-    -thirdparty => {
-        dc => {
-            %TP_DC,
-            name  => 'libdyncall_s',
-            rule  => 'cd 3rdparty/dyncall && configure.bat /target-x86 && $(MAKE) -f Nmakefile',
-            clean => '$(RM) 3rdparty/dyncall/ConfigVars @dclib@ @dcblib@ @dllib@ 3rdparty/dyncall/dyncall/*@obj@ 3rdparty/dyncall/dyncallback/*@obj@ 3rdparty/dyncall/dynload/*@obj@',
-        },
-
-        dcb => { %TP_DCB, name => 'libdyncallback_s' },
-        dl  => { %TP_DL, name => 'libdynload_s' },
-    },
 );
 
 my %TC_MINGW32 = (
@@ -296,14 +270,6 @@ my %TC_MINGW32 = (
     dllimport => '__declspec(dllimport)',
     dllexport => '__declspec(dllexport)',
     dlllocal  => '',
-
-    -thirdparty => {
-        dc => {
-            %TP_DC,
-            rule  => 'cd 3rdparty/dyncall && ./configure.bat /target-x86 /tool-gcc && $(MAKE) -f Makefile.embedded mingw32',
-            clean => $TC_MSVC{-thirdparty}->{dc}->{clean},
-        },
-    },
 );
 
 my %TC_CYGWIN = (
@@ -588,10 +554,6 @@ my %OS_SOLARIS = (
     mknoisy => '',
 
     -thirdparty => {
-        dc => { %TP_DC,
-            rule  => 'cd 3rdparty/dyncall &&  CC=\'$(CC)\' CFLAGS=\'$(CFLAGS) -U_FILE_OFFSET_BITS\' $(MAKE) -f Makefile.embedded sun',
-            clean => 'cd 3rdparty/dyncall &&  CC=\'$(CC)\' CFLAGS=\'$(CFLAGS)\' $(MAKE) -f Makefile.embedded clean',
-        },
         uv => { %TP_UVDUMMY, objects => '$(UV_SOLARIS)' },
     },
 );

--- a/build/setup.pm
+++ b/build/setup.pm
@@ -51,7 +51,7 @@ my %TP_UV = (
 my %TP_LF = (
     name  => 'ffi/install/lib/libffi',
     path  => '3rdparty',
-    rule  => 'cd 3rdparty/libffi && ./autogen.sh && ./configure --disable-builddir --disable-docs --prefix=' . catdir(rel2abs(), '3rdparty', 'libffi', 'install') . ' CC=\'$(CC)\' CFLAGS=\'$(CFLAGS) -Wno-error=pointer-arith\' && $(MAKE) install',
+    rule  => 'cd 3rdparty/libffi && ./autogen.sh && python generate-darwin-source-and-headers.py --only-osx && ./configure --disable-builddir --disable-docs --prefix=' . catdir(rel2abs(), '3rdparty', 'libffi', 'install') . ' CC=\'$(CC)\' CFLAGS=\'$(CFLAGS) -Wno-error=pointer-arith\' && $(MAKE) install',
     clean => 'cd 3rdparty/libffi && $(MAKE) clean',
 );
 

--- a/src/core/nativecall_libffi.c
+++ b/src/core/nativecall_libffi.c
@@ -113,7 +113,6 @@ static void * unmarshal_callback(MVMThreadContext *tc, MVMCode *callback, MVMObj
         void *cb;
         ffi_cif *cif;
         ffi_closure *closure;
-        ffi_status status;
 
         num_info = MVM_repr_elems(tc, sig_info);
 
@@ -176,7 +175,7 @@ static void * unmarshal_callback(MVMThreadContext *tc, MVMCode *callback, MVMObj
         callback_data->instance  = tc->instance;
         callback_data->cs        = cs;
         callback_data->target    = callback;
-        status                   = ffi_prep_cif(cif, callback_data->convention, (unsigned int)cs->arg_count,
+        ffi_status status        = ffi_prep_cif(cif, callback_data->convention, (unsigned int)cs->arg_count,
             callback_data->ffi_ret_type, callback_data->ffi_arg_types);
         if (status != FFI_OK)
             MVM_exception_throw_adhoc(tc, "Failure to set up FFI call interface");

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -5,7 +5,7 @@ VERSION=$1
 {
     echo MANIFEST
     git ls-files | perl -ne "print unless /^3rdparty\/\w+$/"
-    for submod in 3rdparty/libatomicops/ 3rdparty/dyncall/ 3rdparty/libuv/ 3rdparty/dynasm/ 3rdparty/libtommath/ 3rdparty/cmp/ 3rdparty/ryu/ 3rdparty/mimalloc/ 3rdparty/rapidhash/; do
+    for submod in 3rdparty/libatomicops/ 3rdparty/dyncall/ 3rdparty/libuv/ 3rdparty/dynasm/ 3rdparty/libtommath/ 3rdparty/cmp/ 3rdparty/ryu/ 3rdparty/mimalloc/ 3rdparty/rapidhash/ 3rdparty/libffi/; do
         cd $submod
         git ls-files | perl -pe "s{^}{$submod}"
         cd ../..;


### PR DESCRIPTION
Also remove dyncall, so the only options now are building libffi or using the system libffi.

This work on my ARM Linux laptop, but I've not yet tried to follow the directions here (https://github.com/libffi/libffi#installing-libffi) for Windows.