### PR TITLE
Output JITDUMP format with MVM_JIT_PERF_DUMP

### DIFF
--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -353,6 +353,8 @@ struct MVMInstance {
     MVMint32 jit_expr_last_bb;
     /* File for JIT perf map logging */
     FILE *jit_perf_map;
+    /* File for JIT perf jitdump output to be used with perf-inject */
+    FILE *jit_perf_jitdump;
 
     /* Directory name for JIT bytecode dumps */
     char *jit_bytecode_dir;

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -142,6 +142,9 @@ MVMJitCode * MVM_jit_compile_graph(MVMThreadContext *tc, MVMJitGraph *jg) {
         case MVM_JIT_NODE_DEOPT_CHECK:
             MVM_jit_emit_deopt_check(tc, &cl);
             break;
+        case MVM_JIT_NODE_ALL_BB_LABELS:
+            MVM_jit_emit_all_bb_jumps(tc, &cl, node->u.label.name);
+            break;
         }
         node = node->next;
     }

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -8,6 +8,24 @@ void MVM_jit_compiler_deinit(MVMThreadContext *tc, MVMJitCompiler *compiler);
 MVMJitCode * MVM_jit_compiler_assemble(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg);
 void MVM_jit_compile_expr_tree(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *graph, MVMJitExprTree *tree);
 
+#if linux
+#include <unistd.h>
+#include <time.h>
+
+struct jitdump_jit_load_record {
+    uint32_t id;         // a value identifying the record type (see below)
+    uint32_t total_size; // the size in bytes of the record including the header.
+    uint64_t timestamp;  // a timestamp of when the record was created.
+    uint32_t pid; // OS process id of the runtime generating the jitted code
+    uint32_t tid; // OS thread identification of the runtime thread generating the jitted code
+    uint64_t vma; // virtual address of jitted code start
+    uint64_t code_addr; // code start address for the jitted code. By default vma = code_addr
+    uint64_t code_size; // size in bytes of the generated jitted code
+    uint64_t code_index; // unique identifier for the jitted code
+    // char[n]; //  function name in ASCII including the null termination
+    // native code; // : raw byte encoding of the jitted code
+};
+#endif
 
 #define COPY_ARRAY(a, n) ((n) > 0) ? memcpy(MVM_malloc((n) * sizeof(a[0])), a, (n) * sizeof(a[0])) : NULL;
 
@@ -153,6 +171,38 @@ MVMJitCode * MVM_jit_compile_graph(MVMThreadContext *tc, MVMJitGraph *jg) {
         fflush(tc->instance->jit_perf_map);
         MVM_free(file_location);
         MVM_free(frame_name);
+    }
+
+    if (tc->instance->jit_perf_jitdump && code) {
+        char symbol_name[2048] = {0};
+        MVMStaticFrame *sf = jg->sg->sf;
+        if (sf) {
+            char *file_location = MVM_staticframe_file_location(tc, sf);
+            char *frame_name = MVM_string_utf8_encode_C_string(tc, sf->body.name);
+            snprintf(symbol_name, sizeof(symbol_name) - 1,
+                    "%s(%s)",  frame_name, file_location);
+            MVM_free(file_location);
+            MVM_free(frame_name);
+        }
+        else {
+            snprintf(symbol_name, sizeof(symbol_name) - 1, "jitted_frame_%d", code->seq_nr);
+        }
+        struct timespec creation_timestamp;
+        clock_gettime(CLOCK_MONOTONIC, &creation_timestamp);
+
+        struct jitdump_jit_load_record load_record = {
+            0, // JIT_CODE_LOAD
+            sizeof(struct jitdump_jit_load_record) + strlen(symbol_name) + 1 + code->size,
+            (creation_timestamp.tv_sec) * 1000000000 + (creation_timestamp.tv_nsec),
+            getpid(), gettid(),
+            (uintptr_t)code->func_ptr, (uintptr_t)code->func_ptr, code->size,
+            code->seq_nr
+        };
+        fwrite(&load_record, sizeof(struct jitdump_jit_load_record), 1, tc->instance->jit_perf_jitdump);
+        fwrite(&symbol_name, 1, strlen(symbol_name) + 1, tc->instance->jit_perf_jitdump);
+        if (fwrite(code->func_ptr, 1, code->size, tc->instance->jit_perf_jitdump) != code->size) {
+            fprintf(stderr, "shit, didn't write full jit code ...\n");
+        }
     }
 #endif
 

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -3849,7 +3849,6 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_sp_runcfunc_o: {
         int start = (op == MVM_OP_sp_runcfunc_v) ? 0 : 1;
         MVMint16 dst          = ins->operands[0].reg.orig;
-        MVMint16 code         = ins->operands[0 + start].reg.orig;
         MVMCallsite *callsite = (MVMCallsite*)ins->operands[1 + start].lit_ui64;
 
         /* get label /after/ current (invoke) ins, where we'll need to reenter the JIT */
@@ -3870,7 +3869,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
                                 ? MVM_RETURN_NUM
                                 : MVM_RETURN_OBJ;
         node->u.runccode.return_register = dst;
-        node->u.runccode.code_register   = code;
+        node->u.runccode.code_operand    = ins->operands[start];
         node->u.runccode.map             = &ins->operands[2 + start];
         node->u.runccode.reentry_label   = reentry_label;
         jg_append_node(jg, node);

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -4261,6 +4261,13 @@ MVMJitGraph * MVM_jit_try_make_graph(MVMThreadContext *tc, MVMSpeshGraph *sg) {
     /* append the end-of-graph label */
     jg_append_label(tc, graph, MVM_jit_label_after_graph(tc, graph, sg));
 
+    if (tc->instance->jit_perf_jitdump) {
+        /* Put a readable-ish header in front of a BB. */
+        MVMJitNode *node   = MVM_spesh_alloc(tc, graph->sg, sizeof(MVMJitNode));
+        node->type         = MVM_JIT_NODE_ALL_BB_LABELS;
+        jg_append_node(graph, node);
+    }
+
     /* Calculate number of basic block + graph labels */
     graph->num_labels    = graph->obj_label_ofs + graph->obj_labels_num;
 

--- a/src/jit/graph.c
+++ b/src/jit/graph.c
@@ -167,9 +167,6 @@ static void * op_to_func(MVMThreadContext *tc, MVMint16 opcode) {
     case MVM_OP_unbox_u: return MVM_repr_get_uint;
     case MVM_OP_unbox_s: return MVM_repr_get_str;
     case MVM_OP_unbox_n: return MVM_repr_get_num;
-    case MVM_OP_isint: case MVM_OP_isnum: case MVM_OP_isstr: /* continued */
-    case MVM_OP_islist: case MVM_OP_ishash: return MVM_repr_compare_repr_id;
-    case MVM_OP_iscoderef: return MVM_code_iscode;
     case MVM_OP_wval: case MVM_OP_wval_wide: return MVM_sc_get_sc_object;
     case MVM_OP_scgetobjidx: return MVM_sc_find_object_idx_jit;
     case MVM_OP_getdynlex: return MVM_frame_getdynlex;
@@ -1815,6 +1812,7 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
     case MVM_OP_isstr:
     case MVM_OP_islist:
     case MVM_OP_ishash:
+    case MVM_OP_iscoderef:
     case MVM_OP_sp_boolify_iter_arr:
     case MVM_OP_lexprimspec:
     case MVM_OP_objprimspec:
@@ -2285,14 +2283,6 @@ static MVMint32 consume_ins(MVMThreadContext *tc, MVMJitGraph *jg,
         jg_append_call_c(tc, jg, op_to_func(tc, op), 2, args,
                 op == MVM_OP_istrue_s ? MVM_JIT_RV_INT : MVM_JIT_RV_INT_NEGATED,
                 dst);
-        break;
-    }
-    case MVM_OP_iscoderef: {
-        MVMint16 dst = ins->operands[0].reg.orig;
-        MVMint16 obj = ins->operands[1].reg.orig;
-        MVMJitCallArg args[] = { { MVM_JIT_INTERP_VAR, { MVM_JIT_INTERP_TC } },
-                                 { MVM_JIT_REG_VAL, { obj } } };
-        jg_append_call_c(tc, jg, op_to_func(tc, op), 2, args, MVM_JIT_RV_INT, dst);
         break;
     }
     case MVM_OP_clone: {

--- a/src/jit/graph.h
+++ b/src/jit/graph.h
@@ -206,7 +206,7 @@ struct MVMJitRunCCode {
     MVMCallsite  *callsite;
     MVMReturnType return_type;
     MVMint16      return_register;
-    MVMint16      code_register;
+    MVMSpeshOperand code_operand;
     MVMSpeshOperand *map;
     MVMint32      reentry_label;
 };

--- a/src/jit/graph.h
+++ b/src/jit/graph.h
@@ -278,6 +278,7 @@ typedef enum {
     MVM_JIT_NODE_RUNNATIVECALL,
     MVM_JIT_NODE_DISPATCH,
     MVM_JIT_NODE_ISTYPE,
+    MVM_JIT_NODE_ALL_BB_LABELS,
 } MVMJitNodeType;
 
 struct MVMJitNode {

--- a/src/jit/internal.h
+++ b/src/jit/internal.h
@@ -38,6 +38,7 @@ void MVM_jit_emit_conditional_branch(MVMThreadContext *tc, MVMJitCompiler *compi
                                      MVMint32 cond, MVMint32 label, MVMuint8 test_type);
 void MVM_jit_emit_block_branch(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg,
                                MVMJitBranch *branch_spec);
+void MVM_jit_emit_all_bb_jumps(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMint32 name);
 void MVM_jit_emit_label(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg,
                         MVMint32 label);
 void MVM_jit_emit_guard(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg,

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -1716,6 +1716,7 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
         | mov WORK[reg_a], RV;
         break;
     }
+    case MVM_OP_iscoderef:
     case MVM_OP_isint:
     case MVM_OP_isnum:
     case MVM_OP_isstr:
@@ -1727,14 +1728,20 @@ void MVM_jit_emit_primitive(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJ
                           op == MVM_OP_isnum ? MVM_REPR_ID_P6num :
                           op == MVM_OP_isstr ? MVM_REPR_ID_P6str :
                           op == MVM_OP_islist ? MVM_REPR_ID_VMArray :
-                     /*  op == MVM_OP_ishash */ MVM_REPR_ID_MVMHash;
+                          op == MVM_OP_ishash ? MVM_REPR_ID_MVMHash :
+                       /* op == MVM_OP_iscoderef ? */ MVM_REPR_ID_MVMCode;
         | mov TMP1, aword WORK[obj];
         | test TMP1, TMP1;
         | jz >1;
-        | mov TMP1, OBJECT:TMP1->st;
-        | mov TMP1, STABLE:TMP1->REPR;
-        | cmp qword REPR:TMP1->ID, reprid;
+        | mov TMP2, OBJECT:TMP1->st;
+        | mov TMP2, STABLE:TMP2->REPR;
+        | cmp qword REPR:TMP2->ID, reprid;
         | jne >1;
+        /* iscoderef also tests for concreteness */
+        if (op == MVM_OP_iscoderef) {
+            | test_type_object TMP1;
+            | jnz >1;
+        }
         | mov qword WORK[dst], 1;
         | jmp >2;
         |1:

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -2932,6 +2932,19 @@ void MVM_jit_emit_call_c(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitG
     }
 }
 
+void MVM_jit_emit_all_bb_jumps(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMint32 name) {
+    | jmp >1;
+    | nop;
+    for (MVMuint32 bbidx = 0; bbidx < compiler->graph->sg->num_bbs; bbidx++) {
+        if (bbidx % 16 == 0) {
+            | mov rax, bbidx;
+        }
+        | jmp =>(bbidx);
+    }
+    | nop;
+    |1:
+}
+
 void MVM_jit_emit_block_branch(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg,
                                MVMJitBranch * branch) {
     MVMSpeshIns *ins = branch->ins;

--- a/src/jit/x64/emit.dasc
+++ b/src/jit/x64/emit.dasc
@@ -3390,9 +3390,20 @@ void MVM_jit_emit_runccode(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJi
     | lea TMP6, [<5];
     | mov aword [rsp+0x10], TMP6;
     |.endif
-    | mov FUNCTION, aword WORK[runcode->code_register];
-    | mov FUNCTION, CFUNCTION:FUNCTION->body.func;
-    | call FUNCTION
+
+    // If we know the value in the code register (because we just had it
+    // loaded from a "getspeshslot" operation) we can just put the value
+    // here literally.
+    MVMSpeshFacts *function_facts = MVM_spesh_get_facts(tc, jg->sg, runcode->code_operand);
+
+    if ((function_facts->flags & MVM_SPESH_FACT_KNOWN_VALUE) && function_facts->value.o) {
+        uintptr_t call_target = (uintptr_t)(((MVMCFunction *)function_facts->value.o)->body.func);
+        | callp call_target;
+    } else {
+        | mov FUNCTION, aword WORK[runcode->code_operand.reg.orig];
+        | mov FUNCTION, CFUNCTION:FUNCTION->body.func;
+        | call FUNCTION;
+    }
 }
 
 void MVM_jit_emit_runnativecall(MVMThreadContext *tc, MVMJitCompiler *compiler, MVMJitGraph *jg, MVMJitRunNativeCall *runcode) {

--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,7 @@ The following environment variables are respected:\n\
     MVM_JIT_EXPR_ENABLE         Enable advanced 'expression' JIT\n\
     MVM_JIT_DEBUG               Add JIT debugging information to spesh log\n\
     MVM_JIT_PERF_MAP            Create a map file for the 'perf' profiler (linux only)\n\
+    MVM_JIT_PERF_DUMP           Create a jitdump file for the 'perf' profiler (linux only)\n\
     MVM_JIT_DUMP_BYTECODE       Dump bytecode in temporary directory\n\
     MVM_SPESH_INLINE_LOG        Dump details of inlining attempts to stderr\n\
     MVM_CROSS_THREAD_WRITE_LOG  Log unprotected cross-thread object writes to stderr\n\

--- a/src/main.c
+++ b/src/main.c
@@ -97,7 +97,7 @@ The following environment variables are respected:\n\
     MVM_JIT_EXPR_ENABLE         Enable advanced 'expression' JIT\n\
     MVM_JIT_DEBUG               Add JIT debugging information to spesh log\n\
     MVM_JIT_PERF_MAP            Create a map file for the 'perf' profiler (linux only)\n\
-    MVM_JIT_PERF_DUMP           Create a jitdump file for the 'perf' profiler (linux only)\n\
+    MVM_JIT_PERF_DUMP           Create a jitdump file for the 'perf' profiler in the given folder (linux only)\n\
     MVM_JIT_DUMP_BYTECODE       Dump bytecode in temporary directory\n\
     MVM_SPESH_INLINE_LOG        Dump details of inlining attempts to stderr\n\
     MVM_CROSS_THREAD_WRITE_LOG  Log unprotected cross-thread object writes to stderr\n\

--- a/src/moar.c
+++ b/src/moar.c
@@ -353,9 +353,9 @@ MVMInstance * MVM_vm_create_instance(void) {
 
         char *jit_perf_jitdump = getenv("MVM_JIT_PERF_DUMP");
         if (jit_perf_jitdump && *jit_perf_jitdump) {
-            char perf_dump_filename[32];
+            char perf_dump_filename[1024];
             snprintf(perf_dump_filename, sizeof(perf_dump_filename),
-                     "jit-%"PRIi64".dump", MVM_proc_getpid(NULL));
+                     "%s/jit-%"PRIi64".dump", getenv("MVM_JIT_PERF_DUMP"), MVM_proc_getpid(NULL));
             instance->jit_perf_jitdump = MVM_platform_fopen(perf_dump_filename, "w+");
         }
     }

--- a/src/moar.c
+++ b/src/moar.c
@@ -350,6 +350,14 @@ MVMInstance * MVM_vm_create_instance(void) {
                      "/tmp/perf-%"PRIi64".map", MVM_proc_getpid(NULL));
             instance->jit_perf_map = MVM_platform_fopen(perf_map_filename, "w");
         }
+
+        char *jit_perf_jitdump = getenv("MVM_JIT_PERF_DUMP");
+        if (jit_perf_jitdump && *jit_perf_jitdump) {
+            char perf_dump_filename[32];
+            snprintf(perf_dump_filename, sizeof(perf_dump_filename),
+                     "jit-%"PRIi64".dump", MVM_proc_getpid(NULL));
+            instance->jit_perf_jitdump = MVM_platform_fopen(perf_dump_filename, "w+");
+        }
     }
 #endif
 


### PR DESCRIPTION
It's a bit of a hassle, but together with `perf inject` you can now get samples along with the correct assembly code shown in `perf report`.

Highly recommend building with `-fno-omit-frame-pointer` in the CFLAGS as well as LDFLAGS of moarvm and rakudo.

```
rm perf.data* perf.jit.data* jit-*.dump jitted-*.so
env MVM_JIT_PERF_DUMP=1 perf record -g -k 1 rakudo example_code.raku
perf inject --jit --input perf.data --output perf.jit.data
mv perf.jit.data perf.data
perf report
```

With this feature, `perf report` will allow you to open the "annotate" view for jitted code frames:

<img width="952" height="1124" alt="image" src="https://github.com/user-attachments/assets/2ecf30c2-9a08-476d-b79b-3730ecf764c0" />
<img width="958" height="1160" alt="image" src="https://github.com/user-attachments/assets/e3817ded-a661-491b-8b97-01ccafca58c7" />

The jitdump format also allows adding line numbers to memory locations inside of the jitted code. I will have to experiment with that a little bit.

https://raw.githubusercontent.com/torvalds/linux/refs/heads/master/tools/perf/Documentation/jitdump-specification.txt

This article helped me get started:

https://theunixzoo.co.uk/blog/2025-09-14-linux-perf-jit.html