### PR TITLE
Always check the return value of getenv()

### DIFF
--- a/src/disp/syscall.c
+++ b/src/disp/syscall.c
@@ -1525,18 +1525,20 @@ static void stat_is_executable_impl(MVMThreadContext *tc, MVMArgs arg_info) {
             /* true if fileext is in PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC */
             MVMint64 n = MVM_string_index_from_end(tc, stat_obj->body.filename, tc->instance->str_consts.dot, 0);
             if (n >= 0) {
-                MVMString *fileext = MVM_string_substring(tc, stat_obj->body.filename, n, -1);
-                char *ext  = MVM_string_utf8_c8_encode_C_string(tc, fileext);
                 char *pext = getenv("PATHEXT");
-                int plen   = strlen(pext);
-                int i;
-                for (i = 0; i < plen; i++) {
-                    if (0 == stricmp(ext, pext++)) {
-                         r = 1;
-                         break;
+                if (pext) {
+                    MVMString *fileext = MVM_string_substring(tc, stat_obj->body.filename, n, -1);
+                    char *ext  = MVM_string_utf8_c8_encode_C_string(tc, fileext);
+                    int plen   = strlen(pext);
+                    int i;
+                    for (i = 0; i < plen; i++) {
+                        if (0 == stricmp(ext, pext++)) {
+                             r = 1;
+                             break;
+                        }
                     }
+                    MVM_free(ext);
                 }
-                MVM_free(ext);
             }
         }
 #else

--- a/src/io/fileops.c
+++ b/src/io/fileops.c
@@ -248,18 +248,20 @@ MVMint64 MVM_file_isexecutable(MVMThreadContext *tc, MVMString *filename, MVMint
         /* true if fileext is in PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC */
         MVMint64 n = MVM_string_index_from_end(tc, filename, tc->instance->str_consts.dot, 0);
         if (n >= 0) {
-            MVMString *fileext = MVM_string_substring(tc, filename, n, -1);
-            char *ext  = MVM_string_utf8_c8_encode_C_string(tc, fileext);
             char *pext = getenv("PATHEXT");
-            int plen   = strlen(pext);
-            int i;
-            for (i = 0; i < plen; i++) {
-                if (0 == stricmp(ext, pext++)) {
-                     r = 1;
-                     break;
+            if (pext) {
+                MVMString *fileext = MVM_string_substring(tc, filename, n, -1);
+                char *ext  = MVM_string_utf8_c8_encode_C_string(tc, fileext);
+                int plen   = strlen(pext);
+                int i;
+                for (i = 0; i < plen; i++) {
+                    if (0 == stricmp(ext, pext++)) {
+                         r = 1;
+                         break;
+                    }
                 }
+                MVM_free(ext);
             }
-            MVM_free(ext);
         }
     }
     return r;

--- a/src/moar.c
+++ b/src/moar.c
@@ -116,10 +116,11 @@ MVMInstance * MVM_vm_create_instance(void) {
 #endif
 
 #ifdef HAVE_TELEMEH
-    if (getenv("MVM_TELEMETRY_LOG")) {
+    char *telemeh_log = getenv("MVM_TELEMETRY_LOG");
+    if (telemeh_log) {
         char path[256];
         FILE *fp;
-        snprintf(path, 255, "%s.%d", getenv("MVM_TELEMETRY_LOG"),
+        snprintf(path, 255, "%s.%d", telemeh_log,
 #ifdef _WIN32
              _getpid()
 #else
@@ -355,7 +356,7 @@ MVMInstance * MVM_vm_create_instance(void) {
         if (jit_perf_jitdump && *jit_perf_jitdump) {
             char perf_dump_filename[1024];
             snprintf(perf_dump_filename, sizeof(perf_dump_filename),
-                     "%s/jit-%"PRIi64".dump", getenv("MVM_JIT_PERF_DUMP"), MVM_proc_getpid(NULL));
+                     "%s/jit-%"PRIi64".dump", jit_perf_jitdump, MVM_proc_getpid(NULL));
             instance->jit_perf_jitdump = MVM_platform_fopen(perf_dump_filename, "w+");
         }
     }
@@ -443,20 +444,24 @@ MVMInstance * MVM_vm_create_instance(void) {
         instance->cross_thread_write_logging = 0;
     }
 
-    if (getenv("MVM_COVERAGE_LOG")) {
-        char *coverage_log = getenv("MVM_COVERAGE_LOG");
+    char *coverage_log = getenv("MVM_COVERAGE_LOG");
+    if (coverage_log) {
         instance->coverage_logging = 1;
         instance->instrumentation_level++;
-        if (coverage_log[0])
+        if (coverage_log[0]) {
             instance->coverage_log_fh = fopen_perhaps_with_pid("MVM_COVERAGE_LOG", coverage_log, "a");
-        else
+        }
+        else {
             instance->coverage_log_fh = stderr;
+        }
 
-        instance->coverage_control = 0;
-        if (getenv("MVM_COVERAGE_CONTROL")) {
-            char *coverage_control = getenv("MVM_COVERAGE_CONTROL");
-            if (coverage_control && coverage_control[0])
-                instance->coverage_control = atoi(coverage_control);
+        char *coverage_control = getenv("MVM_COVERAGE_CONTROL");
+        if (coverage_control && coverage_control[0]) {
+            /* This is a pretty low-level feature, don't need any error handling for getting the numeric value. */
+            instance->coverage_control = atoi(coverage_control);
+        }
+        else {
+            instance->coverage_control = 0;
         }
     }
     else {


### PR DESCRIPTION
To prevent a possible NULL dereference.