### PR TITLE
Check results of explicitly allocating from libc

### DIFF
--- a/src/strings/ascii.c
+++ b/src/strings/ascii.c
@@ -220,7 +220,7 @@ char * MVM_string_ascii_encode_any(MVMThreadContext *tc, MVMString *str) {
     return MVM_string_ascii_encode(tc, str, NULL, 0);
 }
 
-/* Encodes the specified string to ASCII using libc malloc.  */
+/* Encodes the specified string to ASCII using libc malloc/realloc.  */
 char * MVM_string_ascii_encode_malloc(MVMThreadContext *tc, MVMString *str) {
     /* ASCII is a single byte encoding, but \r\n is a 2-byte grapheme, so we
      * may have to resize as we go. */
@@ -228,7 +228,10 @@ char * MVM_string_ascii_encode_malloc(MVMThreadContext *tc, MVMString *str) {
 
     size_t         result_alloc = lengthu;
     MVMuint8      *result = malloc(result_alloc + 1);
-    if (str->body.storage_type == MVM_STRING_GRAPHEME_ASCII) {
+    if (!result) {
+        MVM_exception_throw_adhoc(tc, "Error encoding ASCII string: could not allocate %ld bytes", result_alloc + 1);
+    }
+    else if (str->body.storage_type == MVM_STRING_GRAPHEME_ASCII) {
         /* No encoding needed; directly copy. */
         memcpy(result, str->body.storage.blob_ascii, lengthu);
         result[lengthu] = 0;
@@ -241,16 +244,19 @@ char * MVM_string_ascii_encode_malloc(MVMThreadContext *tc, MVMString *str) {
             MVMCodepoint ord = MVM_string_ci_get_codepoint(tc, &ci);
             if (i == result_alloc) {
                 result_alloc += 8;
-                result = realloc(result, result_alloc + 1);
+                MVMuint8 *new_result = realloc(result, result_alloc + 1);
+                if (!new_result) {
+                    free(result);
+                    MVM_exception_throw_adhoc(tc, "Error encoding ASCII string: could not reallocate to %ld bytes", result_alloc + 1);
+                }
+                result = new_result;
             }
             if (0 <= ord && ord <= 127) {
                 result[i++] = (MVMuint8)ord;
             }
             else {
                 free(result);
-                MVM_exception_throw_adhoc(tc,
-                    "Error encoding ASCII string: could not encode codepoint %d",
-                    ord);
+                MVM_exception_throw_adhoc(tc, "Error encoding ASCII string: could not encode codepoint %d", ord);
             }
         }
         result[i] = 0;

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -617,14 +617,17 @@ char * MVM_string_utf8_encode_C_string(MVMThreadContext *tc, MVMString *str) {
     return utf8_string;
 }
 
-/* Encodes the specified string to a UTF-8 C string. */
+/* Encodes the specified string to a UTF-8 C string using libc malloc/realloc. */
 char * MVM_string_utf8_encode_C_string_malloc(MVMThreadContext *tc, MVMString *str) {
     MVMint64         length = MVM_string_graphs(tc, str);
     /* Guesstimate that we'll be within 2 bytes for most chars most of the
      * time, and give ourselves 4 bytes breathing space, plus 1 for the NUL. */
     size_t           result_limit = 2 * length;
-    MVMuint8        *result = malloc(result_limit + 4 + 1);
     size_t           result_pos = 0;
+    MVMuint8        *result = malloc(result_limit + 4 + 1);
+    if (!result) {
+        MVM_exception_throw_adhoc(tc, "Error encoding utf8 string: could not allocate %ld bytes", result_limit + 4 + 1);
+    }
 
     /* Iterate the codepoints and encode them. */
     MVMCodepointIter ci;
@@ -633,7 +636,12 @@ char * MVM_string_utf8_encode_C_string_malloc(MVMThreadContext *tc, MVMString *s
         MVMCodepoint cp = MVM_string_ci_get_codepoint(tc, &ci);
         if (result_pos >= result_limit) {
             result_limit *= 2;
-            result = realloc(result, result_limit + 4 + 1);
+            MVMuint8 *new_result = realloc(result, result_limit + 4 + 1);
+            if (!new_result) {
+                free(result);
+                MVM_exception_throw_adhoc(tc, "Error encoding utf8 string: could not reellocate to %ld bytes", result_limit + 4 + 1);
+            }
+            result = new_result;
         }
         MVMint32 bytes = utf8_encode(result + result_pos, cp);
         if (bytes)


### PR DESCRIPTION
Otherwise we could leak and/or dereference NULLs.

These were found by Snyk.