### PR TITLE
fix: the moarvm debug server accepts connections and... in debugserver.c

### DIFF
--- a/src/debug/debugserver.c
+++ b/src/debug/debugserver.c
@@ -216,7 +216,7 @@ MVM_PUBLIC void MVM_debugserver_register_line(MVMThreadContext *tc, char *filena
         found = &table->files[table->files_used - 1];
 
         found->filename = MVM_calloc(filename_len + 1, sizeof(char));
-        strncpy(found->filename, filename, filename_len);
+        memcpy(found->filename, filename, filename_len);
 
         if (tc->instance->debugserver->debugspam_protocol)
             fprintf(stderr, "created new file entry at %u for %s\n", table->files_used - 1, found->filename);
@@ -3590,6 +3590,18 @@ static void debugserver_worker(MVMThreadContext *tc, MVMArgs arg_info) {
 
         MVM_gc_mark_thread_blocked(tc);
         clientsocket = accept(listensocket, NULL, NULL);
+        /* Only allow the process owner to connect to the debug server */
+#if !defined(_WIN32) && defined(SO_PEERCRED)
+        {
+            struct ucred cr;
+            socklen_t cr_len = sizeof(cr);
+            if (getsockopt(clientsocket, SOL_SOCKET, SO_PEERCRED, &cr, &cr_len) == 0
+                    && cr.uid != getuid()) {
+                MVM_platform_close_socket(clientsocket);
+                continue;
+            }
+        }
+#endif
         MVM_gc_mark_thread_unblocked(tc);
 
         send_greeting(&clientsocket);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/debug/debugserver.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-012 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-012` |
| **File** | `src/debug/debugserver.c:2013` |

**Description**: The MoarVM debug server accepts connections and processes debug protocol commands — including thread suspension, breakpoint injection, and heap object inspection — without requiring any authentication. Any local process (or remote process if the server is not bound to loopback) can connect and issue arbitrary debug commands, gaining the same level of control over the MoarVM process as the process owner.

## Changes
- `src/debug/debugserver.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
