### PR TITLE
Correctly populate dest array in nqp::strtocodes

### DIFF
--- a/src/strings/normalize.c
+++ b/src/strings/normalize.c
@@ -200,6 +200,7 @@ void MVM_unicode_string_to_codepoints(MVMThreadContext *tc, MVMString *s, MVMNor
     ((MVMArray *)out)->body.slots.u32 = (MVMuint32 *)result;
     ((MVMArray *)out)->body.start     = 0;
     ((MVMArray *)out)->body.elems     = result_pos;
+    ((MVMArray *)out)->body.ssize     = result_alloc;
 }
 
 /* Initialize the MVMNormalizer pointed to to perform the specified kind of


### PR DESCRIPTION
The array populated by nqp::strtocodes (i.e.,
MVM_unicode_string_to_codepoints), wasn't getting its `ssize` set. Some uses of it would be ok, but attempting to resize it could go bady.

Fixes `use nqp; nqp::strtocodes("3.9999999999", 1, my int32 @a); dd @a; nqp::splice(@a, nqp::list, 1, 1); dd @a`. It used to segfault, now it prints:
```
int32  = array[int32].new(51, 46, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57)
int32  = array[int32].new(51, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57)
```