### PR TITLE
Fix smallint branch of MVM_bigint_mod for values that wrap

### DIFF
--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,3 +1,6 @@
+New in 2026.06
++ Fix smallint branch of MVM_bigint_mod for values that wrap
+
 New in 2026.05
 + Output JITDUMP format with MVM_JIT_PERF_DUMP
 + debugserver improvements

--- a/src/math/bigintops.c
+++ b/src/math/bigintops.c
@@ -558,8 +558,10 @@ MVMObject * MVM_bigint_mod(MVMThreadContext *tc, MVMObject *result_type, MVMObje
             store_bigint_result(bc, ic);
             adjust_nursery(tc, bc);
         } else {
-            /* % in C technically gives the remainder, but we want the modulus. */
-            store_int64_result(tc, bc, ((ba->u.smallint.value % bb->u.smallint.value) + bb->u.smallint.value) % bb->u.smallint.value);
+            /* % in C technically gives the remainder, but we want the modulus. Force everything to 64-bit so intermediate calculations don't overflow/wrap. */
+            MVMint64 a = ba->u.smallint.value;
+            MVMint64 b = bb->u.smallint.value;
+            store_int64_result(tc, bc, ((a % b) + b) % b);
         }
     }
 


### PR DESCRIPTION
by promoting all intermediate calculations to 64-bit.

Fixes https://github.com/rakudo/rakudo/issues/6210.