### PR TITLE
When decoding over 10k bytes of utf8 or utf8-c8 data, mark thread blo…

### DIFF
--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,9 @@
+New in 2026.06
+
++ Allow GC to run while decoding large buffers of utf8/c8
+
 New in 2026.05
+
 + Output JITDUMP format with MVM_JIT_PERF_DUMP
 + debugserver improvements
 + Bump mimalloc to v2.3.2

--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -233,7 +233,7 @@ void utf8_decode_errors(MVMThreadContext *tc, const char *utf8, size_t bytes) {
 /* Decodes the specified number of bytes of utf8 into an NFG string, creating
  * a result of the specified type. The type must have the MVMString REPR. */
 MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result_type, const char *utf8, size_t bytes) {
-    MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    MVMString *result = NULL;
     MVMint32 count = 0;
     MVMCodepoint codepoint;
     MVMint32 state = 0;
@@ -242,6 +242,17 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
     size_t orig_bytes = bytes;
     const char *orig_utf8 = utf8;
     MVMint32 ready;
+    MVMuint8 did_mark_thread_blocked = 0;
+
+    MVM_gc_root_temp_push_slow(tc, (MVMCollectable **)&result_type);
+
+    /* If we have to go through a lot of bytes, mark the thread as blocked so
+     * that GC can happen at the same time. Remember the decision so we unblock
+     * it after the main work is done. */
+    if (bytes > 10000) {
+        MVM_gc_mark_thread_blocked(tc);
+        did_mark_thread_blocked = 1;
+    }
 
     /* Need to normalize to NFG as we decode. */
     MVMNormalizer norm;
@@ -285,6 +296,21 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
     }
     MVM_unicode_normalizer_cleanup(tc, &norm);
 
+    if (did_mark_thread_blocked) {
+        /* Cannot allocate on a blocked thread. */
+        MVM_gc_mark_thread_unblocked(tc);
+    }
+
+    result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));
+    /* set a storage type that states that body->storage.any
+     * is not a pointer. */
+    result->body.storage_type    = MVM_STRING_IN_SITU_8;
+
+    if (did_mark_thread_blocked) {
+        MVM_gc_root_temp_push_slow(tc, (MVMCollectable **)&result);
+        MVM_gc_mark_thread_blocked(tc);
+    }
+
     /* If we're lucky, we can fit our string in 8 bits per grapheme. */
     if (MVM_string_buf32_can_fit_into_8bit(buffer, count)) {
         MVMGrapheme8 *storage;
@@ -311,6 +337,14 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
         result->body.storage_type    = MVM_STRING_GRAPHEME_32;
     }
     result->body.num_graphs      = count;
+
+    if (did_mark_thread_blocked) {
+        MVM_gc_root_temp_pop_n(tc, 2);
+        MVM_gc_mark_thread_unblocked(tc);
+    }
+    else {
+        MVM_gc_root_temp_pop(tc);
+    }
 
     return result;
 }

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -438,8 +438,8 @@ MVMString * MVM_string_utf8_c8_decode(MVMThreadContext *tc, const MVMObject *res
 
     if (did_mark_thread_blocked) {
         MVM_gc_mark_thread_unblocked(tc);
-        MVM_gc_root_temp_pop(tc);
     }
+    MVM_gc_root_temp_pop(tc);
 
     {
         MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));

--- a/src/strings/utf8_c8.c
+++ b/src/strings/utf8_c8.c
@@ -345,6 +345,18 @@ MVMString * MVM_string_utf8_c8_decode(MVMThreadContext *tc, const MVMObject *res
     if (bytes == 0)
         return tc->instance->str_consts.empty;
 
+    MVMuint8 did_mark_thread_blocked = 0;
+
+    MVM_gc_root_temp_push_slow(tc, (MVMCollectable **)&result_type);
+
+    /* If we have to go through a lot of bytes, mark the thread as blocked so
+     * that GC can happen at the same time. Remember the decision so we unblock
+     * it after the main work is done. */
+    if (bytes > 10000) {
+        MVM_gc_mark_thread_blocked(tc);
+        did_mark_thread_blocked = 1;
+    }
+
     /* Decoding state, in a struct to easily pass to utility routines.
      * Result buffer is a maximum estimate to avoid realloc; we can shrink
      * it at the end. */
@@ -423,6 +435,11 @@ MVMString * MVM_string_utf8_c8_decode(MVMThreadContext *tc, const MVMObject *res
 
     MVM_free(state.orig_codes);
     MVM_unicode_normalizer_cleanup(tc, &(state.norm));
+
+    if (did_mark_thread_blocked) {
+        MVM_gc_mark_thread_unblocked(tc);
+        MVM_gc_root_temp_pop(tc);
+    }
 
     {
         MVMString *result = (MVMString *)REPR(result_type)->allocate(tc, STABLE(result_type));


### PR DESCRIPTION
…cked

this allows GC runs to happen while a thread is busy going through a large buffer of bytes.

Smaller buffers of bytes don't really need us to go to the effort of blocking and unblocking the thread, as with a series of smaller decodes, the allocation of the resulting string would join in on GC runs waiting to happen in a timely manner, I expect.

lizmat spotted this from the snapper having a suspiciously long gap between snapshots when decoding a huge buffer of zeroes:

https://gist.github.com/lizmat/905751e5c763a21670fdb3c22a8c9d9c