### PR TITLE
Add code coverage instrumentation filtering

### DIFF
--- a/docs/moar.pod
+++ b/docs/moar.pod
@@ -47,6 +47,31 @@ to an object it didn't allocate and doesn't have a lock for.
 Same as MVM_CROSS_THREAD_WRITE_LOG, except objects that are locked are included
 as well.
 
+=item MVM_COVERAGE_LOG
+
+If set, MoarVM instruments bytecode to log a C<HIT E<lt>fileE<gt> E<lt>lineE<gt>>
+entry to this file each time a new source line is entered. If the value is an
+empty string the log is written to stderr. The file is opened in append mode.
+If the path contains C<%d> it is replaced with the process ID.
+
+By default each (file, line) pair is logged once per static frame ("de-duped").
+See C<MVM_COVERAGE_CONTROL> to disable.
+
+=item MVM_COVERAGE_CONTROL
+
+Controls de-duping behaviour of C<MVM_COVERAGE_LOG>. If set to C<1>, the
+non-de-duping mode is enabled at runtime when C<nqp::coveragecontrol(1)> is
+called. If set to C<2>, non-de-duping mode is enabled from the start of the
+program. Has no effect unless C<MVM_COVERAGE_LOG> is also set.
+
+=item MVM_COVERAGE_FILES
+
+A comma-separated list of substrings. When set, only source files whose path
+contains at least one of the substrings are instrumented for coverage. Other files
+(such as the Raku standard library and NQP internals) are left uninstrumented and
+incur no coverage overhead. Unset or empty means instrument everything
+(the default). Has no effect unless C<MVM_COVERAGE_LOG> is also set.
+
 =back
 
 =head1 REPORTING BUGS

--- a/src/core/instance.h
+++ b/src/core/instance.h
@@ -552,6 +552,10 @@ struct MVMInstance {
     FILE *coverage_log_fh;
     MVMuint32  coverage_control;
 
+    /* Filters for coverage instrumentation. */
+    char     **coverage_file_filters;
+    MVMuint32  coverage_file_filter_count;
+
     /* The time it takes to run the profiler instrumentation. */
     MVMuint64 profiling_overhead;
 

--- a/src/instrument/line_coverage.c
+++ b/src/instrument/line_coverage.c
@@ -4,6 +4,45 @@
 #define snprintf _snprintf
 #endif
 
+/* Returns 1 if no filter is configured or the static frame's source file
+ * passes the configured filter, 0 otherwise. */
+static int sf_passes_file_filter(MVMThreadContext *tc, MVMStaticFrame *sf) {
+    MVMInstance *inst = tc->instance;
+    MVMBytecodeAnnotation *ann;
+    MVMString *filename;
+    char *encoded;
+    int matched = 0;
+    MVMuint32 i;
+
+    if (inst->coverage_file_filter_count == 0)
+        return 1;
+
+    /* Get the static frame's primary filename: */
+    ann = MVM_bytecode_resolve_annotation(tc, &sf->body, 0);
+
+    /* Pass through, so we don't miss code. */
+    if (!ann)
+        return 1;
+
+    /* Look up the filename in the comp unit. */
+    filename = MVM_cu_string(tc, sf->body.cu, ann->filename_string_heap_index);
+    MVM_free(ann);
+
+    /* Encode so we can run strstr on it. */
+    encoded = MVM_string_utf8_encode_C_string(tc, filename);
+
+    /* Match if any one of the configured substrings is found. */
+    for (i = 0; i < inst->coverage_file_filter_count; i++) {
+        if (strstr(encoded, inst->coverage_file_filters[i])) {
+            matched = 1;
+            break;
+        }
+    }
+
+    MVM_free(encoded);
+    return matched;
+}
+
 static void instrument_graph_with_breakpoints(MVMThreadContext *tc, MVMSpeshGraph *g) {
     MVMSpeshBB *bb = g->entry->linear_next;
 
@@ -298,6 +337,32 @@ static void line_numbers_instrument(MVMThreadContext *tc, MVMStaticFrame *sf, MV
 
 /* Instruments code with per-line logging of code coverage */
 void MVM_line_coverage_instrument(MVMThreadContext *tc, MVMStaticFrame *sf) {
+    if (!sf_passes_file_filter(tc, sf)) {
+        /* File didn't match the filter.
+         *
+         * We want to leave this frame's bytecode unchanged, but we still have
+         * to record "already handled" so we don't get called again on every
+         * future entry. (line_numbers_instrument skips re-entry when
+         * sf->body.bytecode == instrumented_bytecode.) */
+
+        /* Allocate the instrumentation struct if it doesn't exist yet. */
+        MVMStaticFrameInstrumentation *ins = sf->body.instrumentation;
+        if (!ins)
+            ins = MVM_calloc(1, sizeof(MVMStaticFrameInstrumentation));
+
+        /* Point both bytecode pairs at the existing buffer so the above gating
+         * is satisfied next time. */
+        ins->instrumented_bytecode        = sf->body.bytecode;
+        ins->instrumented_handlers        = sf->body.handlers;
+        ins->instrumented_bytecode_size   = sf->body.bytecode_size;
+
+        ins->uninstrumented_bytecode      = sf->body.bytecode;
+        ins->uninstrumented_handlers      = sf->body.handlers;
+        ins->uninstrumented_bytecode_size = sf->body.bytecode_size;
+
+        sf->body.instrumentation = ins;
+        return;
+    }
     line_numbers_instrument(tc, sf, 1);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -103,7 +103,9 @@ The following environment variables are respected:\n\
     MVM_CROSS_THREAD_WRITE_LOG  Log unprotected cross-thread object writes to stderr\n\
     MVM_COVERAGE_LOG            Append (de-duped by default) line-by-line coverage messages to this file\n\
     MVM_COVERAGE_CONTROL        If set to 1, non-de-duping coverage started with nqp::coveragecontrol(1),\n\
-                                  if set to 2, non-de-duping coverage started right away\n"
+                                  if set to 2, non-de-duping coverage started right away\n\
+    MVM_COVERAGE_FILES          Comma-separated list of substrings. Source files whose path contains\n\
+                                  at least one of them are instrumented for coverage (default: all files)\n"
     TELEMEH_USAGE;
 
 static int cmp_flag(const void *key, const void *value)

--- a/src/moar.c
+++ b/src/moar.c
@@ -469,25 +469,21 @@ MVMInstance * MVM_vm_create_instance(void) {
             char *coverage_files = getenv("MVM_COVERAGE_FILES");
 
             if (coverage_files && coverage_files[0]) {
-                /* Copy, so we can chop into substrings in place. */
-                char *buf = MVM_malloc(strlen(coverage_files) + 1);
                 char **filters;
                 char *p;
-                char *tok = buf;
+                char *tok = coverage_files;
                 MVMuint32 count = 1;
                 MVMuint32 i = 0;
                 int last;
 
-                strcpy(buf, coverage_files);
-
                 /* Count comma-delimited substrings. */
-                for (p = buf; *p; p++)
+                for (p = coverage_files; *p; p++)
                     if (*p == ',') count++;
 
                 filters = MVM_malloc(count * sizeof(char *));
 
                 /* Replace commas with \0 and store pointers to non-empty substrings. */
-                for (p = buf; ; p++) {
+                for (p = coverage_files; ; p++) {
                     if (*p == ',' || *p == '\0') {
                         last = (*p == '\0');
                         *p = '\0';
@@ -501,8 +497,7 @@ MVMInstance * MVM_vm_create_instance(void) {
                     }
                 }
 
-                /* Assign filters.
-                 * buf and filters intentionally kept for the lifetime of the VM. */
+                /* Assign filters. */
                 instance->coverage_file_filters = filters;
                 instance->coverage_file_filter_count = i;
             }
@@ -813,6 +808,9 @@ void MVM_vm_destroy_instance(MVMInstance *instance) {
     if (instance->jit_breakpoints) {
         MVM_VECTOR_DESTROY(instance->jit_breakpoints);
     }
+
+    /* Clean up coverage file filters */
+    MVM_free(instance->coverage_file_filters);
 
     /* Clean up cross-thread-write-logging mutex */
     uv_mutex_destroy(&instance->mutex_cross_thread_write_logging);

--- a/src/moar.c
+++ b/src/moar.c
@@ -463,6 +463,50 @@ MVMInstance * MVM_vm_create_instance(void) {
         else {
             instance->coverage_control = 0;
         }
+
+        /* Parse coverage file filters. */
+        {
+            char *coverage_files = getenv("MVM_COVERAGE_FILES");
+
+            if (coverage_files && coverage_files[0]) {
+                /* Copy, so we can chop into substrings in place. */
+                char *buf = MVM_malloc(strlen(coverage_files) + 1);
+                char **filters;
+                char *p;
+                char *tok = buf;
+                MVMuint32 count = 1;
+                MVMuint32 i = 0;
+                int last;
+
+                strcpy(buf, coverage_files);
+
+                /* Count comma-delimited substrings. */
+                for (p = buf; *p; p++)
+                    if (*p == ',') count++;
+
+                filters = MVM_malloc(count * sizeof(char *));
+
+                /* Replace commas with \0 and store pointers to non-empty substrings. */
+                for (p = buf; ; p++) {
+                    if (*p == ',' || *p == '\0') {
+                        last = (*p == '\0');
+                        *p = '\0';
+
+                        if (tok[0])
+                            filters[i++] = tok;
+
+                        if (last) break;
+
+                        tok = p + 1;
+                    }
+                }
+
+                /* Assign filters.
+                 * buf and filters intentionally kept for the lifetime of the VM. */
+                instance->coverage_file_filters = filters;
+                instance->coverage_file_filter_count = i;
+            }
+        }
     }
     else {
         instance->coverage_logging = 0;


### PR DESCRIPTION
When using `MVM_COVERAGE_LOG` to measure code coverage of a single module or app, MoarVM currently instruments _everything_ that loads, including the Raku standard library and NQP internals.

Add the new `MVM_COVERAGE_FILES` environment variable that filters code coverage instrumentation to source files whose path matches one of a set of comma-delimited substrings. This allows skipping the non-matching files at instrumentation time so they never reach the coverage log and incur no instrumentation overhead.

When `MVM_COVERAGE_FILES` is unset or empty, _everything_ gets instrumented, so this is opt-in and backward compatible with existing behavior.

Here is a demo script for a simple method:

```raku
#!/usr/bin/env raku

# Set MVM_COVERAGE_FILES to a substring and only files whose path contains it
# get coverage instrumentation.

my $workdir = $*TMPDIR.add('test-moar-coverage');
$workdir.mkdir;

my $target = $workdir.add('coverage_demo_target.raku');
$target.spurt: q:to/CODE/;
    sub greet($name) {
        say "hello, $name";
    }
    greet('coverage');
    CODE

# Distinct source files appearing in the coverage log
sub coverage-files(%extra --> List) {
    my $log = $workdir.add('cov.log');
    my $proc = run $*EXECUTABLE, $target.absolute, :out, :err,
                   env => %( %*ENV, MVM_COVERAGE_LOG => $log.absolute, |%extra );
    
    $proc.out.slurp(:close);
    $proc.err.slurp(:close);

    # Each log line is: HIT  <file>  <line>
    my @files = $log.lines.map({ m/^ 'HIT' \s+ (.+) \s+ \d+ $/ ?? ~$0 !! Empty }).unique.sort;
    $log.unlink;
    @files.List;
}

my @without = coverage-files(%());
my @with    = coverage-files(%( MVM_COVERAGE_FILES => 'coverage_demo_target' ));

say "without filter: { @without.elems }";
say "with filter: { @with.elems }";

$target.unlink;
$workdir.rmdir;

```

```shell
> ./moar_coverage.raku
without filter: 366
with filter: 1
```

Tested against latest source builds:

```shell
> raku --version
Welcome to Rakudo™ v2026.05-117-g9b162bcf7.
Implementing the Raku® Programming Language v6.d.
Built on MoarVM version 2026.05.1-12-g2c16915d5.
```