### PR TITLE
utf8: Do not lock up when very long string has invalid utf8 in it.

### DIFF
--- a/src/strings/utf8.c
+++ b/src/strings/utf8.c
@@ -276,6 +276,8 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
              * line and col numbers. */
             MVM_unicode_normalizer_cleanup(tc, &norm); /* Since we'll throw. */
             MVM_free(buffer);
+            if (did_mark_thread_blocked)
+                MVM_gc_mark_thread_unblocked(tc);
             utf8_decode_errors(tc, orig_utf8, orig_bytes);
             break;
         }
@@ -283,6 +285,8 @@ MVMString * MVM_string_utf8_decode(MVMThreadContext *tc, const MVMObject *result
     if (state != UTF8_ACCEPT) {
         MVM_unicode_normalizer_cleanup(tc, &norm);
         MVM_free(buffer);
+        if (did_mark_thread_blocked)
+            MVM_gc_mark_thread_unblocked(tc);
         MVM_exception_throw_adhoc(tc, "Malformed termination of UTF-8 string");
     }
 


### PR DESCRIPTION
Marking the thread blocked when doing the work made it possible for other threads to do GC while it's working, but if the thread tries to allocate an exception object to throw while it's marked blocked, it will enter a gc run that no other thread ever start.