### PR TITLE
general GDB plugin improvements + prototype of `moar rrdb` command

### DIFF
--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,6 +1,7 @@
 New in 2026.07
 
 + Bump mimalloc to v2.4.1
++ Many improvements and additions to the gdb python plugin
 
 New in 2026.06.1
 

--- a/src/6model/reprs/P6opaque.c
+++ b/src/6model/reprs/P6opaque.c
@@ -2427,7 +2427,7 @@ static void dump_p6opaque(MVMThreadContext *tc, MVMObject *obj, int nested) {
                                 else
                                     fprintf(stderr, "<already seen>");
                             }
-                            if (value != NULL && REPR(value)->ID == MVM_REPR_ID_MVMCode) {
+                            else if (value != NULL && REPR(value)->ID == MVM_REPR_ID_MVMCode) {
                                 MVMCode *code = (MVMCode*)value;
                                 MVMStaticFrame *sf = code->body.sf;
                                 fprintf(
@@ -2439,12 +2439,22 @@ static void dump_p6opaque(MVMThreadContext *tc, MVMObject *obj, int nested) {
                                     sf->body.cuuid  ? MVM_string_utf8_maybe_encode_C_string(tc, sf->body.cuuid)  : "<null>"
                                 );
                             }
+                            else if (value != NULL) {
+                                fprintf(stderr, "=%s (%s) %p", value->st->REPR->name, value->st->debug_name, value);
+                            }
                         }
                         else {
                             if (attr_st->REPR->ID == MVM_REPR_ID_P6str) {
                                 MVMString *str = (MVMString *)get_obj_at_offset(data, offset);
                                 char * const c_str = str ? MVM_string_utf8_encode_C_string(tc, str) : "<null>";
-                                fprintf(stderr, "='%s'", c_str);
+                                unsigned long orig_len = strlen(c_str);
+                                if (orig_len > 256) {
+                                    c_str[256] = 0;
+                                    fprintf(stderr, "='%s'(...%lu bytes)", c_str, orig_len);
+                                }
+                                else {
+                                    fprintf(stderr, "='%s'", c_str);
+                                }
                                 if (str)
                                     MVM_free(c_str);
                             }

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1382,7 +1382,8 @@ def can_read_path(val: gdb.Value, *path: str):
             try:
                 val.cast(uint32p_t).dereference()
             except gdb.error as ex:
-                print("harmless gdb error: ", ex)
+                # print("harmless gdb error: ", ex)
+                pass
         except gdb.MemoryError:
             return False
     return True
@@ -1466,8 +1467,8 @@ def find_tc():
         frame = frame.older()
 
     tcs_by_score = sorted(found_tcs, key = lambda ts: is_tc_plausible(ts))
-    for tc in found_tcs:
-       print(" found a TC with value ", hex(tc), " with score ", is_tc_plausible(tc))
+    # for tc in found_tcs:
+       # print(" found a TC with value ", hex(tc), " with score ", is_tc_plausible(tc))
 
     return found_tcs[0]
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1244,7 +1244,7 @@ def string_from_cu(cu, index):
         data = (strheap + 4).string("utf-8", "backslashreplace", entrysize)
         return data
     else:
-        return gdb.printing.make_visualizer(strp.dereference()).to_string()
+        return gdb.printing.make_visualizer(strp.dereference()).stringify()
 
 def resolve_annotation(sfb, offset):
     if not (sfb["num_annotations"] > 0 and offset > 0 and offset < sfb["bytecode_size"]):

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1687,13 +1687,31 @@ def frame_effective_bytecode(frame):
         return spesh_cand["body"]["bytecode"]
     return frame["static_info"]["body"]["bytecode"]
 
+def decode_utf8_in_stringheap(val, entrysize):
+    data = val.string("utf-8", "backslashreplace", entrysize)
+
 def string_from_cu(cu, index):
-    strp = cu["body"]["strings"][index]
+    cub = cu["body"]
+    strp = cub["strings"][index]
 
     if int(strp) == 0:
         # not decoded yet, have to do it in here
-        strheap = cu["body"]["string_heap_start"]
-        found_idx = 0
+
+        # can hopefully at least find it quickly with the fast table?
+        fast_table_top = cub["string_heap_fast_table_top"]
+
+        # TODO can we safely get this with gdb from dwarf data?
+        bin = index // 16
+
+        fast_table = cub["string_heap_fast_table"]
+
+        # don't try to read outside the fast table!
+        if bin > int(fast_table_top):
+            bin = int(fast_table_top)
+
+        strheap = cub["string_heap_start"] + fast_table[bin]
+        found_idx = bin * 16
+
         while found_idx < index:
             entrysize = int(int(strheap.cast(uint32p_t).dereference()) // 2)
             if entrysize & 3:
@@ -1704,19 +1722,20 @@ def string_from_cu(cu, index):
         size_and_flag = int(strheap.cast(uint32p_t).dereference())
         entrysize = size_and_flag // 2
 
-        data = (strheap + 4).string("utf-8", "backslashreplace", entrysize)
+        data = decode_utf8_in_stringheap(strheap + 4, entrysize)
         return data
     else:
         return mvmstr_to_str(strp.dereference())
 
 def resolve_annotation(sfb, offset):
-    if not (sfb["num_annotations"] >= 0 and offset >= 0 and offset < sfb["bytecode_size"]):
+    num_anno = sfb["num_annotations"]
+    if not (num_anno >= 0 and offset >= 0 and offset < sfb["bytecode_size"]):
         return (None, None)
 
     ann_offs = 0
     cur_anno = sfb["annotations_data"]
     p_cur_anno = None
-    for i in range(0, sfb["num_annotations"]):
+    for i in range(0, num_anno):
         ann_offs = int(cur_anno.cast(uint32p_t).dereference())
 
         if ann_offs > offset:
@@ -1875,7 +1894,7 @@ class MoarStackFrame:
         map = self._arg_info["map"]
 
         return [
-            source[map[i]] for i in range(len(csinfo))]
+            source[int(map[i])] for i in range(len(csinfo))]
 
     @property
     def cuuid(self):
@@ -1973,6 +1992,8 @@ class MoarBtCommands(gdb.Command):
 
         stack_idx = 0
 
+        output = []
+
         while cur_frame is not None:
             name = cur_frame.name
             fn, ln = cur_frame.resolve_annotation()
@@ -1986,7 +2007,6 @@ class MoarBtCommands(gdb.Command):
             outer_str = ""
             if not name and (fn is None or ln is None):
                 outer_frame = cur_frame.outer
-                print("outer frame is: ", outer_frame)
                 outer_fn, outer_ln = outer_frame.resolve_annotation(0)
                 outer_locstr = ""
                 if outer_fn is not None and outer_ln is not None:
@@ -2010,10 +2030,12 @@ class MoarBtCommands(gdb.Command):
             if outer_str:
                 locstr = locstr + " " + outer_str
 
-            print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, locstr)
+            output.append(f"#{stack_idx:3d} {str(cur_frame.ptr):20s} {name} {csinfo_str} {locstr}")
 
             cur_frame = cur_frame.caller
             stack_idx += 1
+
+        print("\n".join(output))
 
 
 def do_single_frame_command_stuff(cur_frame : MoarStackFrame, stack_idx = None):

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1395,6 +1395,9 @@ def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
     # mangled when they are not explicitly stored in a way the debug
     # symbols tell us ...
 
+    if str(tc.type) != "MVMThreadContext *":
+        return -math.inf
+
     def deduct(n):
         nonlocal score
         score -= n
@@ -1423,11 +1426,11 @@ def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
             deduct(100)
         if int(tc["cur_frame"]) != 0 and not can_read_path(tc, "cur_frame", "static_info"):
             deduct(150)
-        if int(tc["num_finalize"]) > int(tc["alloc_finalize"]):
+        if int(tc["num_finalize"]) >= int(tc["alloc_finalize"]):
             deduct(50)
-        if int(tc["num_temproots"]) > int(tc["alloc_temproots"]):
+        if int(tc["num_temproots"]) >= int(tc["alloc_temproots"]):
             deduct(50)
-        if not (1024 < int(tc["nursery_fromspace_size"]) <= 4 * 4194304):
+        if not (1024 <= int(tc["nursery_fromspace_size"]) <= 4 * 4194304):
             deduct(50)
 
     except EarlyAbortException:
@@ -1462,7 +1465,7 @@ def find_tc():
 
         frame = frame.older()
 
-    tcs_by_score = sorted(found_tcs, lambda ts: is_tc_plausible(ts))
+    tcs_by_score = sorted(found_tcs, key = lambda ts: is_tc_plausible(ts))
     for tc in found_tcs:
        print(" found a TC with value ", hex(tc), " with score ", is_tc_plausible(tc))
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1128,13 +1128,22 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         return row
 
+    _last_saved_movement_event = -1
+
     def _register_object_movement(self):
         to_addr   = int(gdb.parse_and_eval("(uintptr_t)new_addr"))
         from_addr = int(gdb.parse_and_eval("(uintptr_t)item"))
+        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
 
-        query = "INSERT INTO object_movements VALUES (?, ?);"
-        self._db_cur.execute(query, (from_addr, to_addr))
-        self._db_conn.commit()
+        if self._last_saved_movement_event != rr_event:
+            query = "INSERT INTO object_movements VALUES (?, ?, ?);"
+            self._db_cur.execute(query, (rr_event, from_addr, to_addr))
+            self._db_conn.commit()
+            self._last_saved_movement_event = rr_event
+        else:
+            query = "INSERT INTO object_movements VALUES (null, ?, ?);"
+            self._db_cur.execute(query, (from_addr, to_addr))
+            self._db_conn.commit()
 
 
     def setup(self):
@@ -1229,6 +1238,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         self._db_cur.execute("""
             create table object_movements (
+                rr_event integer,
                 to_addr integer,
                 from_addr integer
             );

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -46,6 +46,7 @@
 # - Offer an HTML rendering of the stats, since gdb insists on printing
 #   a pager header right in between our pretty gen2 graphs most of the time
 
+from enum import Enum
 import gdb
 from collections import defaultdict
 from itertools import chain
@@ -1309,7 +1310,6 @@ def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
 
     return score
 
-
 def find_tc():
     frame = gdb.selected_frame()
     found_tcs = []
@@ -1371,7 +1371,7 @@ def string_from_cu(cu, index):
         data = (strheap + 4).string("utf-8", "backslashreplace", entrysize)
         return data
     else:
-        return gdb.printing.make_visualizer(strp.dereference()).to_string()
+        return mvmstr_to_str(strp.dereference())
 
 def resolve_annotation(sfb, offset):
     if not (sfb["num_annotations"] > 0 and offset > 0 and offset < sfb["bytecode_size"]):
@@ -1439,115 +1439,264 @@ def parse_callsite(cs):
 
     return args
 
+class MoarStackFrame:
+    """Representation of a frame on moarvm's stack, based on a pointer to
+    the MVMFrame struct"""
+
+    class Relation(Enum):
+        CALLER = "caller"
+        CALLEE = "callee"
+        OUTER = "outer"
+        INNER = "inner"
+        CUR_FRAME = "cur_frame"
+        MANUAL = "manual"
+
+    ptr : gdb.Value
+    related : MoarStackFrame | gdb.Value | None
+    relation : Relation | None
+
+    def __init__(self, ptr : gdb.Value, related : MoarStackFrame | gdb.Value | None = None, relation : Relation| None = None):
+        if relation is MoarStackFrame.Relation.CUR_FRAME or relation is MoarStackFrame.Relation.MANUAL:
+            assert isinstance(related, gdb.Value)
+        elif related is not None:
+            assert isinstance(related, MoarStackFrame)
+
+        self.ptr = ptr
+        self.related = related
+        self.relation = relation
+
+    @classmethod
+    def from_tc(cls, tc : gdb.Value | None = None):
+        if tc is None:
+            tc = find_tc()
+
+        if int(tc["cur_frame"]) == 0:
+            return None
+
+        return MoarStackFrame(tc["cur_frame"], tc, MoarStackFrame.Relation.CUR_FRAME)
+
+    @property
+    def caller(self):
+        caller = self.ptr["caller"]
+        if int(caller) != 0:
+            return MoarStackFrame(caller, self, MoarStackFrame.Relation.CALLEE)
+        else:
+            return None
+
+    @property
+    def outer(self):
+        outer = self.ptr["outer"]
+        if int(outer) != 0:
+            return MoarStackFrame(outer, self, MoarStackFrame.Relation.INNER)
+        else:
+            return None
+
+    @property
+    def name(self):
+        sfb = self.ptr["static_info"]["body"]
+        return mvmstr_to_str(sfb["name"].dereference())
+
+    @property
+    def cur_op(self):
+        if self.relation == MoarStackFrame.Relation.CUR_FRAME:
+            assert isinstance(self.related, gdb.Value)
+            return self.related["interp_cur_op"].dereference()
+        else:
+            return self.ptr["return_address"]
+
+    @property
+    def bytecode_offs(self):
+        sfb = self.ptr["static_info"]["body"]
+        bc = frame_effective_bytecode(self.ptr)
+        return int(self.cur_op) - int(bc)
+
+    @property
+    def params(self):
+        return self.ptr["params"]
+
+    @property
+    def param_vals(self):
+        callsite = self.params["arg_info"]["callsite"]
+        csinfo = parse_callsite(callsite)
+
+        return [
+            self.params["arg_info"]["source"][
+                self.params["arg_info"]["map"][i]
+            ] for i in range(len(csinfo))]
+
+    def resolve_annotation(self, offs : int | None = None):
+        if offs is None:
+            offs = self.bytecode_offs
+
+        sfb = self.ptr["static_info"]["body"]
+
+        return resolve_annotation(sfb, offs)
+
+def extract_moar_stack_frame_args(cur_frame):
+    # TODO extract to global scope and lookup on init
+    stooge_t = gdb.lookup_symbol("MVMObjectStooge")[0].type.strip_typedefs()
+    stoogep_t = stooge_t.pointer()
+    mvmstr_t = gdb.lookup_symbol("MVMString")[0].type
+    mvmstrp_t = mvmstr_t.pointer()
+
+    callsite = cur_frame.params["arg_info"]["callsite"]
+    csinfo = parse_callsite(callsite)
+    param_vals = cur_frame.param_vals
+
+    infoparts = []
+
+    for i, csi in enumerate(csinfo):
+        # info = csinfo[i][0]
+        subpart  = csi[1](param_vals[i])
+        typename = csi[2][1]
+        argname  = csi[2][0]
+
+        string_of_subpart = None
+
+        #print("adding arg of", typename, argname, repr(subpart))
+        if typename == "obj":
+            flags1 = int(subpart["header"]["flags1"])
+            if flags1 & 2: # MVM_CF_STABLE
+                is_obj = False
+                pass
+            elif flags1 & 1: # MVM_CF_TYPE_OBJECT
+                is_obj = True
+                is_concrete = False
+            elif flags1 & 4: # MVM_CF_FRAME
+                is_obj = False
+            else:
+                is_obj = True
+                is_concrete = True
+
+            if is_obj:
+                reprname = subpart["st"]["REPR"]["name"].string()
+                if reprname == "P6str" and is_concrete:
+                    #print("casting to p6str? before:")
+                    #print(repr(subpart), repr(subpart.type))
+                    subpart = subpart.cast(stoogep_t)["data"].cast(mvmstrp_t)
+                    #print(repr(subpart), repr(subpart.type))
+                    #print("trying to mvmstr_to_str this:", repr(mvmstr_to_str(subpart)))
+                    string_of_subpart = "((MVMString *)" + hex(int(subpart)) + ")=" + repr(mvmstr_to_str(subpart, truncate=128))
+                elif int(subpart["st"]["debug_name"]) != 0:
+                    typename = reprname + "#" + subpart["st"]["debug_name"].string()
+                    if is_concrete:
+                        typename = typename + ".new"
+
+        if string_of_subpart is None:
+            string_of_subpart = gdb.printing.make_visualizer(subpart).to_string()
+        if string_of_subpart is None:
+            string_of_subpart = "<???>"
+
+        infoparts.append(
+            (argname + "=" if argname else "")
+            + typename
+            + "("
+            + string_of_subpart
+            + ")")
+
+    return infoparts
+
 class MoarBtCommands(gdb.Command):
     """Commands to look at a moar-level backtrace."""
     def __init__(self):
         super(MoarBtCommands, self).__init__("moar bt", gdb.COMMAND_STACK, prefix=True)
 
-    def invoke(self, arg, from_tty):
-        tc = find_tc()
-
-        stack_idx = 0
-
+    def invoke(self, argument, from_tty):
         stooge_t = gdb.lookup_symbol("MVMObjectStooge")[0].type.strip_typedefs()
         stoogep_t = stooge_t.pointer()
         mvmstr_t = gdb.lookup_symbol("MVMString")[0].type
         mvmstrp_t = mvmstr_t.pointer()
 
-        cur_frame = tc["cur_frame"]
-        try:
-            int(cur_frame)
-        except gdb.MemoryError:
-            print("couldn't get cur_frame from the tc ...")
+        tc = find_tc()
+        cur_frame : MoarStackFrame = MoarStackFrame.from_tc(tc)
 
-        while int(cur_frame) != 0:
-            sfb = cur_frame["static_info"]["body"]
+        stack_idx = 0
 
-            name = sfb["name"].dereference()
+        while cur_frame is not None:
+            name = cur_frame.name
+            fn, ln = cur_frame.resolve_annotation()
 
-            bc = frame_effective_bytecode(cur_frame)
-
-            if stack_idx == 0:
-                cur_op = tc["interp_cur_op"].dereference()
-            else:
-                cur_op = cur_frame["return_address"]
-
-            offs = int(cur_op) - int(bc)
-            fn, ln = resolve_annotation(sfb, offs)
-
-            callsite = cur_frame["params"]["arg_info"]["callsite"]
-            csinfo = parse_callsite(callsite)
-
-            param_vals = [
-                cur_frame["params"]["arg_info"]["source"][
-                    cur_frame["params"]["arg_info"]["map"][i]
-                ] for i in range(len(csinfo))]
-
-            infoparts = []
-
-            for i in range(len(csinfo)):
-                # info = csinfo[i][0]
-                subpart = csinfo[i][1](param_vals[i])
-                typename = csinfo[i][2][1]
-                argname = csinfo[i][2][0]
-
-                string_of_subpart = None
-
-                #print("adding arg of", typename, argname, repr(subpart))
-                if typename == "obj":
-                    flags1 = int(subpart["header"]["flags1"])
-                    if flags1 & 2: # MVM_CF_STABLE
-                        is_obj = False
-                        pass
-                    elif flags1 & 1: # MVM_CF_TYPE_OBJECT
-                        is_obj = True
-                        is_concrete = False
-                    elif flags1 & 4: # MVM_CF_FRAME
-                        is_obj = False
-                    else:
-                        is_obj = True
-                        is_concrete = True
-
-                    if is_obj:
-                        reprname = subpart["st"]["REPR"]["name"].string()
-                        if reprname == "P6str" and is_concrete:
-                            #print("casting to p6str? before:")
-                            #print(repr(subpart), repr(subpart.type))
-                            subpart = subpart.cast(stoogep_t)["data"].cast(mvmstrp_t)
-                            #print(repr(subpart), repr(subpart.type))
-                            #print("trying to mvmstr_to_str this:", repr(mvmstr_to_str(subpart)))
-                            string_of_subpart = "((MVMString *)" + hex(int(subpart)) + ")=" + repr(mvmstr_to_str(subpart, truncate=128))
-                        elif int(subpart["st"]["debug_name"]) != 0:
-                            typename = reprname + "#" + subpart["st"]["debug_name"].string()
-                            if is_concrete:
-                                typename = typename + ".new"
-
-                if string_of_subpart is None:
-                    string_of_subpart = gdb.printing.make_visualizer(subpart).to_string()
-                if string_of_subpart is None:
-                    string_of_subpart = "<???>"
-
-                infoparts.append(
-                    (argname + "=" if argname else "")
-                    + typename
-                    + "("
-                    + string_of_subpart
-                    + ")")
+            infoparts = extract_moar_stack_frame_args(cur_frame)
 
             csinfo_str = "args=(" + ", ".join(infoparts) + ")"
 
+            name = "''" if name == "" else name
+
             if fn is not None and ln is not None:
-                print(f"#{stack_idx}", cur_frame, name, csinfo_str, fn, ":", ln)
+                print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, fn, ":", ln)
             else:
-                print(f"#{stack_idx}", cur_frame, name, csinfo_str, "<unknown>:1")
+                print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, "<unknown>:1")
 
+            cur_frame = cur_frame.caller
             stack_idx += 1
-            cur_frame = cur_frame["caller"]
 
-            try:
-                int(cur_frame)
-            except gdb.MemoryError:
-                print("couldn't get cur_frame from the tc ...")
+class MoarBtFrameCommand(gdb.Command):
+    """Get all details of one stack frame on the moarvm stack"""
+    def __init__(self):
+        super(MoarBtFrameCommand, self).__init__("moar bt frame", gdb.COMMAND_STACK)
+
+    def invoke(self, argument, from_tty):
+        if argument == "" or argument is None:
+            cur_frame = MoarStackFrame.from_tc(tc)
+        elif argument[0] == "*":
+            evaled = gdb.parse_and_eval(argument[1:])
+            cur_frame = MoarStackFrame(evaled, evaled, MoarStackFrame.Relation.MANUAL)
+        else:
+            evaled = int(gdb.parse_and_eval(argument))
+            cur_frame = MoarStackFrame.from_tc()
+            stack_idx = 0
+            while stack_idx < evaled and cur_frame is not None:
+                cur_frame = cur_frame.caller
+                stack_idx += 1
+            if cur_frame is None:
+                print(f"Frame with index {evaled} could not be found; stack exhausted after {stack_idx} steps!")
+
+        gdb.set_convenience_variable("mframe", cur_frame.ptr)
+        print(f"var $mframe set to {cur_frame.ptr}")
+
+        fn, ln = cur_frame.resolve_annotation()
+        infoparts = extract_moar_stack_frame_args(cur_frame)
+
+        csinfo_str = "args=(" + ", ".join(infoparts) + ")"
+
+        name = cur_frame.name
+        name = "''" if name == "" else name
+
+        if fn is not None and ln is not None:
+            print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, fn, ":", ln)
+        else:
+            print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, "<unknown>:1")
+
+        csinfo = parse_callsite(cur_frame.params["arg_info"]["callsite"])
+        param_vals = cur_frame.param_vals
+
+        prev_margs_cnt = 0
+        unset_val = None
+        try:
+            prev_margs_cnt_val = gdb.parse_and_eval("$margs_cnt")
+            if prev_margs_cnt_val.type.name != "void":
+                prev_margs_cnt = int(prev_margs_cnt_val)
+            unset_val = gdb.parse_and_eval("$okay_so_hear_me_out_i_need_a_gdb_value_that_is_void_but_not_a_void_pointer_or_anything_and_i_dont_know_how_to_create_it_from_python_so_please_dont_put_anything_in_this_variable_thank_you")
+        except:
+            print("could not unset obsolete margs convenience vars")
+
+        gdb.set_convenience_variable("margs_cnt", len(csinfo))
+        print(f"var $margs_cnt set to {len(csinfo)}")
+        for i, csi in enumerate(csinfo):
+            # info = csinfo[i][0]
+            subpart  = csi[1](param_vals[i])
+
+            varname = f"margs_{i}"
+            gdb.set_convenience_variable(varname, subpart)
+            print(f"var ${varname} set to {subpart}")
+
+        try:
+            for i in range(len(csinfo), prev_margs_cnt):
+                varname = f"margs_{i}"
+                gdb.set_convenience_variable(varname, unset_val)
+                print(f"var ${varname} unset")
+        except:
+            print("could not unset obsolete margs convenience vars")
 
 #                  _   _                   _     _
 #     _ __ _ _ ___| |_| |_ _  _   _ __ _ _(_)_ _| |_ ___ _ _ ___
@@ -1599,6 +1748,7 @@ def register_commands(objfile):
     print("moar break commands registered")
 
     commands.append(MoarBtCommands())
+    commands.append(MoarBtFrameCommand())
     print("moar bt commands registered")
 
 # We have to introduce our classes to gdb so that they can be used

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -65,8 +65,13 @@ import gdb.printing
 
 import traceback # debugging
 
-uint32_t : gdb.Type | None
+uint32_t  : gdb.Type | None
 uint32p_t : gdb.Type | None
+
+stooge_t  : gdb.Type | None
+stoogep_t : gdb.Type | None
+mvmstr_t  : gdb.Type | None
+mvmstrp_t : gdb.Type | None
 
 # These are the flags from MVMString's body.flags
 str_t_info = {0: 'blob_32',
@@ -1930,12 +1935,6 @@ class MoarStackFrame:
         return resolve_annotation(sfb, offs, str_cache)
 
 def extract_moar_stack_frame_args(cur_frame, str_cache = None):
-    # TODO extract to global scope and lookup on init
-    stooge_t = gdb.lookup_symbol("MVMObjectStooge")[0].type.strip_typedefs()
-    stoogep_t = stooge_t.pointer()
-    mvmstr_t = gdb.lookup_symbol("MVMString")[0].type
-    mvmstrp_t = mvmstr_t.pointer()
-
     callsite = cur_frame.params["arg_info"]["callsite"]
     if str_cache is not None and int(callsite) in str_cache:
         csinfo = str_cache[int(callsite)]
@@ -2027,12 +2026,15 @@ class MoarBtCommands(gdb.Command):
     def __init__(self):
         super(MoarBtCommands, self).__init__("moar bt", gdb.COMMAND_STACK, prefix=True)
 
-    def invoke(self, argument, from_tty):
-        stooge_t = gdb.lookup_symbol("MVMObjectStooge")[0].type.strip_typedefs()
-        stoogep_t = stooge_t.pointer()
-        mvmstr_t = gdb.lookup_symbol("MVMString")[0].type
-        mvmstrp_t = mvmstr_t.pointer()
+    # def invoke(self, argument, from_tty):
+    #     import cProfile
+    #     pr = cProfile.Profile()
+    #     with pr:
+    #         self.invoke_(argument, from_tty)
 
+    #     pr.print_stats(1)
+
+    def invoke(self, argument, from_tty):
         str_cache = {}
 
         tc = find_tc()
@@ -2337,7 +2339,14 @@ if __name__ == "__main__":
     try:
         uint32_t  = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
         uint32p_t = uint32_t.pointer()
+
+        stooge_t = gdb.lookup_symbol("MVMObjectStooge")[0].type.strip_typedefs()
+        stoogep_t = stooge_t.pointer()
+
+        mvmstr_t = gdb.lookup_symbol("MVMString")[0].type
+        mvmstrp_t = mvmstr_t.pointer()
+
     except gdb.error as ex:
-        print("Couldn't get MVMuint32 type!?", ex)
+        print("Couldn't get types!?", ex)
 
     init_repr_types_and_structs()

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -46,6 +46,8 @@
 # - Offer an HTML rendering of the stats, since gdb insists on printing
 #   a pager header right in between our pretty gen2 graphs most of the time
 
+from dataclasses import dataclass
+from pathlib import Path
 from collections.abc import Mapping, Sequence, Set
 from enum import Enum
 import gdb
@@ -1067,6 +1069,11 @@ class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
 
 execution_db = None
 
+def follow_fields(val : gdb.Value, fields : list[str]):
+    for step in fields:
+        val = val[step]
+    return val
+
 class MakeExecutionDatabaseCommand(gdb.Command):
     """Run execution from beginning to end, creating a database with interesting events.
 
@@ -1088,8 +1095,23 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     _gc_seq_num = None
 
     class _EXP:
-        tid = lambda _: ["tid", gdb.selected_thread().ptid_string]
-        gdb_eval = lambda _, sub, code, pytype: lambda: [sub, pytype(gdb.parse_and_eval(code))]
+        tid         = lambda _: lambda _: ["tid", gdb.selected_thread().ptid_string]
+        gdb_eval    = lambda _, sub, code, pytype: lambda _: [sub, pytype(gdb.parse_and_eval(code))]
+        local_var   = lambda _, sub, var_name, pytype: lambda frame: [sub, pytype(frame.read_var(var_name))]
+        local_field = lambda _, sub, var_name, steps, pytype: lambda frame: [sub, pytype(follow_fields(frame.read_var(var_name), steps))]
+
+        def local_fields(cls, var_name, steps, fields, pytype):
+            def local_fields_impl(frame):
+                val = frame.read_var(var_name)
+                for step in steps:
+                    val = val[step]
+                res_keys = []
+                res_vals = []
+                for (colname, fieldname) in fields:
+                    res_keys.append(colname)
+                    res_vals.append(pytype(val[fieldname]))
+                return res_keys, res_vals
+            return local_fields_impl
 
     _prev_tl_entry = None
     _prev_thread = None
@@ -1098,8 +1120,23 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     _last_saved_event_time = -1
 
     def _register_event_sql(self, table_name, column_expr, exprs):
-        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
-        rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
+        conn = gdb.connections()[0]
+        assert isinstance(conn, gdb.RemoteTargetConnection)
+
+        currthreadptid = conn.send_packet("qC")
+        currthreadptid = int(currthreadptid[currthreadptid.rindex(b".") + 1:], 16)
+
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+        rr_event = int(resp[resp.rindex(b' '):])
+
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when-ticks:' + str(currthreadptid)))
+        rr_tick  = int(resp[resp.rindex(b' '):])
+
+        frame = gdb.selected_frame()
+
+        # rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
+        # rr_tick = 0
+        # rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
 
         row = {}
         for expr in exprs:
@@ -1107,11 +1144,17 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 if isinstance(expr, list):
                     key, value = expr
                 elif isinstance(expr, typing.Callable):
-                    key, value = expr()
-                row[key] = value
+                    key, value = expr(frame)
+
+                if isinstance(key, str):
+                    row[key] = value
+                else:
+                    for i in range(len(key)):
+                        row[key[i]] = value[i]
             except Exception:
                 print("when evaluating expr ", expr, " for table ", table_name)
                 raise
+
         row["rr_tick"] = rr_tick
         row["rr_event"] = rr_event
 
@@ -1119,12 +1162,18 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         self._db_cur.execute(query, row)
 
         if rr_event != self._last_saved_event_time:
-            rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
+            resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
+            rr_time = float(resp[resp.rindex(b' ') + 1:])
+
             query = f'INSERT INTO event_times VALUES (?, ?)';
             self._db_cur.execute(query, (rr_event, rr_time))
             self._last_saved_event_time = rr_event
 
         self._db_conn.commit()
+
+        # helpers for "extras" handlers
+        row["__frame"] = frame
+        row["__currthreadptid"] = currthreadptid
 
         return row
 
@@ -1153,14 +1202,21 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         def store_seq_num(ev):
             prev = self._gc_seq_num
-            self._gc_seq_num = int(gdb.parse_and_eval("tc->instance->gc_seq_number"))
+            # self._gc_seq_num = int(gdb.parse_and_eval("tc->instance->gc_seq_number"))
+            self._gc_seq_num = int(ev["__frame"].read_var("tc")["instance"]["gc_seq_number"])
 
             #if self._gc_seq_num not in self._object_movements:
             #    self._object_movements[self._gc_seq_num] = array.array("Q")
 
             if prev is not None and prev // 20 != self._gc_seq_num // 20:
-                rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
-                rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
+                rr_event = ev["rr_event"]
+
+                conn = gdb.connections()[0]
+                assert isinstance(conn, gdb.RemoteTargetConnection)
+
+                resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(ev["__currthreadptid"])))
+                rr_time = float(resp[resp.rindex(b' ') + 1:])
+
                 print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num, " - time ", rr_time, " event: ", rr_event)
                 #for s in self._db["subjects"]:
                 #    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
@@ -1230,6 +1286,17 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         """)
 
         self._db_cur.execute("""
+            create table continuation_events (
+                tc integer,
+                rr_tick integer,
+                rr_event integer,
+                tag integer,
+                is_slice boolean
+            );
+        """)
+
+
+        self._db_cur.execute("""
             create table event_times (
                 rr_event integer,
                 rr_time float
@@ -1277,22 +1344,25 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 self._disabled_breakpoints.append(bp)
 
         cbp.append(SQLRecordingBreakpoint(self, "gcs", "tc rr_tick rr_event gc_seq_number is_full", [
-            EXP.gdb_eval("tc", "tc", int),
-            EXP.gdb_eval("gc_seq_number", "tc->instance->gc_seq_number", int),
-            EXP.gdb_eval("is_full", "tc->instance->gc_full_collect", int),
+            EXP.local_var("tc", "tc", int),
+            EXP.local_fields("tc", ["instance"],
+                             [("gc_seq_number", "gc_seq_number"),
+                              ("is_full", "gc_full_collect")], int),
             ], "run_gc"))
 
         cbp.append(SQLRecordingBreakpoint(self, "compunits", "tc rr_tick rr_event data_addr", [
-            EXP.gdb_eval("tc", "tc", int),
-            EXP.gdb_eval("data_addr", "cu->body.data_start", int),
+            EXP.local_var("tc", "tc", int),
+            EXP.local_field("data_addr", "cu", ["body", "data_start"], int),
             ], "run_comp_unit"))
 
         cbp.append(SQLRecordingBreakpoint(self, "worklist_runs", "tc rr_tick rr_event nursery_alloc nursery_alloc_limit nursery_tospace nursery_fromspace", [
-            EXP.gdb_eval("tc", "tc", int),
-            EXP.gdb_eval("nursery_alloc", "tc->nursery_alloc", int),
-            EXP.gdb_eval("nursery_alloc_limit", "tc->nursery_alloc_limit", int),
-            EXP.gdb_eval("nursery_fromspace", "tc->nursery_fromspace", int),
-            EXP.gdb_eval("nursery_tospace", "tc->nursery_tospace", int),
+            EXP.local_var("tc", "tc", int),
+            EXP.local_fields("tc", [],
+                             [("nursery_alloc", "nursery_alloc"),
+                              ("nursery_alloc_limit", "nursery_alloc_limit"),
+                              ("nursery_fromspace", "nursery_fromspace"),
+                              ("nursery_tospace", "nursery_tospace"),
+              ], int),
             ], "process_worklist")._extra(store_seq_num))
 
         if "notrackgc" not in self.flags:
@@ -1321,18 +1391,34 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         free_speshcode_lineno = gdb.execute("search MVM_free.sc.;", False, True).split("\t")[0]
 
         cbp.append(SQLRecordingBreakpoint(self, "spesh_bytecode", "rr_tick rr_event sf_addr bytecode_addr size", [
-            EXP.gdb_eval("sf_addr", "p->sf", int),
-            EXP.gdb_eval("bytecode_addr", "candidate->body.bytecode", int),
-            EXP.gdb_eval("size", "candidate->body.bytecode_size", int),
+            EXP.local_field("sf_addr", "p", ["sf"], int),
+            EXP.local_fields("candidate", ["body"], [
+                                 ["bytecode_addr", "bytecode"],
+                                 ["size", "bytecode_size"]
+                             ], int),
             ], "src/6model/reprs/MVMSpeshCandidate.c:" + free_speshcode_lineno))
 
         cbp.append(SQLRecordingBreakpoint(self, "staticframes", "rr_tick rr_event bytecode compunit_data_addr sf_addr cuuid name", [
-            EXP.gdb_eval("bytecode", "static_frame->body.bytecode", int),
-            EXP.gdb_eval("compunit_data_addr", "static_frame->body.cu->body.data_start", int),
-            EXP.gdb_eval("sf_addr", "static_frame", int),
-            EXP.gdb_eval("cuuid", "MVM_string_utf8_encode_C_string(tc, static_frame->body.cuuid)", lambda v: v.string()),
-            EXP.gdb_eval("name", "MVM_string_utf8_encode_C_string(tc, static_frame->body.name)", lambda v: v.string()),
+            EXP.local_field("bytecode", "static_frame", ["body", "bytecode"], int),
+            EXP.local_field("compunit_data_addr", "static_frame", ["body", "cu", "body", "data_start"], int),
+            EXP.local_var("sf_addr", "static_frame", int),
+            EXP.local_fields("static_frame", ["body"], [
+                                 ["cuuid", "cuuid"],
+                                 ["name", "name"],
+                             ], mvmstr_to_str),
             ], "MVM_validate_static_frame"))
+
+        cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event tag is_slice", [
+            EXP.local_var("tc", "tc", int),
+            EXP.local_var("tag", "tag", int),
+            lambda _: ["is_slice", 0],
+            ], "MVM_callstack_continuation_slice"))
+
+        cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event tag is_slice", [
+            EXP.local_var("tc", "tc", int),
+            EXP.local_var("tag", "update_tag", int),
+            lambda _: ["is_slice", 1],
+            ], "MVM_callstack_continuation_append"))
 
         #cbp.append(SQLRecordingBreakpoint(self, "sc_code", [
         #    EXP.gdb_eval("sc_addr", "sc->body", int),
@@ -1375,13 +1461,113 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         gdb.execute("c")
 
     def invoke(self, argument, from_tty):
+        global execution_db
         self.flags = set(argument.split(" "))
         self.dont_repeat()
         self.setup()
         try:
             self.run()
         finally:
+            try:
+                gdb.execute("info breakpoints")
+            except:
+                pass
+            try:
+                execution_db = self._db_conn
+                gdb.set_convenience_variable("moar_rrdb_file", self._db_file.name)
+            except Exception as e:
+                print("Could not store the name of the rrdb file in convenience var :(", e)
             self.teardown()
+
+@dataclass
+class TimelineEntry:
+    pos_event: int
+
+    earliest_event: int | None
+    latest_event: int | None
+
+    pos_time: float
+
+    earliest_time: float | None
+    latest_time: float | None
+
+class MoarTimelineCommand(gdb.Command):
+    """Show recent and upcoming events from moar rrdb's execution db"""
+
+    flags : Set[str]
+
+    def __init__(self):
+        super(MoarTimelineCommand, self).__init__("moar timeline", gdb.COMMAND_STATUS)
+
+    def invoke(self, argument, from_tty):
+        global execution_db
+
+        if execution_db is None:
+            filename_maybe = gdb.parse_and_eval("$moar_rrdb_file")
+            # print(f"Can I load db from $moar_rrdb_file? ({filename_maybe})")
+            if str(filename_maybe) and str(filename_maybe) != "void" and Path(filename_maybe.string()).exists():
+                import sqlite3
+                print("Loading previous execution db from ", filename_maybe)
+                execution_db = sqlite3.connect(filename_maybe.string(), autocommit=False)
+            else:
+                print("No execution DB seems to exist. run `moar rrdb` first!")
+                self.dont_repeat()
+                return
+
+        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
+        rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
+
+        try:
+            cur = execution_db.cursor()
+
+            query = """
+                select
+                   igcs.earliest,
+                   eet.rr_time as earliest_time,
+                   let.rr_time as latest_time,
+                   igcs.*
+                from
+                    (select
+                        abs(min(rr_event) - ?) as absdiff,
+                        min(rr_event) as earliest,
+                        max(rr_event) as latest,
+                        gc_seq_number,
+                        is_full
+                    from gcs
+                    where is_full = ?
+                    group by gc_seq_number
+                    order by 1 asc) igcs
+                    left join event_times eet on igcs.earliest = eet.rr_event
+                    left join event_times let on igcs.latest = let.rr_event
+                limit ?;
+            """
+
+
+            timeline_events = []
+            for (want_full, limit) in [(0, 8), (1, 4)]:
+                nearby_gcs = cur.execute(query, (rr_event, want_full, limit)).fetchall()
+                timeline_events.extend(nearby_gcs)
+
+            timeline_events = sorted(timeline_events, key=lambda e: e[0])
+            before = [e for e in timeline_events if e[0] <  rr_event]
+            after  = [e for e in timeline_events if e[0] >= rr_event]
+
+            def gc_event_line(earliest, earliest_time, latest_time, absdiff, _, latest, gc_seq_number, is_full):
+                print(f"{"maj" if is_full else "min"} GC run {gc_seq_number:5d}: {earliest_time:8.3f}s - {latest_time:8.3f}s ({earliest} - {latest})")
+
+            for e in before:
+                gc_event_line(*e)
+
+            print("you are here: ", rr_time, "        ", rr_event, " <-- you are here")
+
+            for e in after:
+                gc_event_line(*e)
+
+        except Exception as ex:
+            print("Failed to get timeline stuff: ", ex)
+
+        finally:
+            cur.close()
 
 #     _             _   _                                                     _
 #    | |__  __ _ __| |_| |_ _ _ __ _ __ ___   __ ___ _ __  _ __  __ _ _ _  __| |___
@@ -1524,7 +1710,7 @@ def string_from_cu(cu, index):
         return mvmstr_to_str(strp.dereference())
 
 def resolve_annotation(sfb, offset):
-    if not (sfb["num_annotations"] > 0 and offset > 0 and offset < sfb["bytecode_size"]):
+    if not (sfb["num_annotations"] >= 0 and offset >= 0 and offset < sfb["bytecode_size"]):
         return (None, None)
 
     ann_offs = 0
@@ -1778,12 +1964,36 @@ class MoarBtCommands(gdb.Command):
 
             csinfo_str = "args=(" + ", ".join(infoparts) + ")"
 
-            name = "''" if name == "" else name
+            # Instead of just outputting "'' at <unknown>:1", make an attempt
+            # to get at least something to differentiate one thing from another
+            outer_str = ""
+            if not name and (fn is None or ln is None):
+                outer_frame = cur_frame.outer
+                print("outer frame is: ", outer_frame)
+                outer_fn, outer_ln = outer_frame.resolve_annotation(0)
+                outer_locstr = ""
+                if outer_fn is not None and outer_ln is not None:
+                    outer_locstr = f" {fn}:{ln}"
+                if outer_frame is not None:
+                    if outer_frame.name is not None and outer_frame.name:
+                        outer_str = f"(nested inside '{outer_frame.name}'{outer_locstr})"
+                    else:
+                        outer_str = f"(nested inside {outer_frame.cuuid}{outer_locstr})"
 
+            name = f"'' ({cur_frame.cuuid})" if name == "" else name
             if fn is not None and ln is not None:
-                print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, fn, ":", ln)
+                locstr = f"{fn}:{ln}"
             else:
-                print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, "<unknown>:1")
+                locstr = "<unknown>:1"
+
+                fn, ln = cur_frame.resolve_annotation(offs=0)
+                if fn is not None and ln is not None:
+                    locstr = f"somewhere after {fn}:{ln}"
+
+            if outer_str:
+                locstr = locstr + " " + outer_str
+
+            print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, locstr)
 
             cur_frame = cur_frame.caller
             stack_idx += 1
@@ -1999,6 +2209,9 @@ def register_commands(objfile):
 
     commands.append(MakeExecutionDatabaseCommand())
     print("command moar rrdb registered")
+
+    commands.append(MoarTimelineCommand())
+    print("command moar timelineregistered")
 
     commands.append(MoarBreakCommands())
     commands.append(MoarBreakInterpRunCommands())

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1801,6 +1801,16 @@ class MoarStackFrame:
         self.related = related
         self.relation = relation
 
+        self._outer = self.ptr["outer"]
+        self._caller = self.ptr["caller"]
+        self._static_info_body = self.ptr["static_info"]["body"]
+
+        self._params = self.ptr["params"]
+        self._arg_info = self._params["arg_info"]
+
+        self._outer_obj = None
+        self._caller_obj = None
+
     @classmethod
     def from_tc(cls, tc : gdb.Value | None = None):
         if tc is None:
@@ -1813,23 +1823,29 @@ class MoarStackFrame:
 
     @property
     def caller(self):
-        caller = self.ptr["caller"]
-        if int(caller) != 0:
-            return MoarStackFrame(caller, self, MoarStackFrame.Relation.CALLEE)
+        if self._caller_obj:
+            return self._caller_obj
+
+        if int(self._caller) != 0:
+            self._caller_obj = MoarStackFrame(self._caller, self, MoarStackFrame.Relation.CALLEE)
+            return self._caller_obj
         else:
             return None
 
     @property
     def outer(self):
-        outer = self.ptr["outer"]
-        if int(outer) != 0:
-            return MoarStackFrame(outer, self, MoarStackFrame.Relation.INNER)
+        if self._outer_obj:
+            return self._outer_obj
+
+        if int(self._outer) != 0:
+            self._outer_obj = MoarStackFrame(self._outer, self, MoarStackFrame.Relation.OUTER)
+            return self._outer_obj
         else:
             return None
 
     @property
     def name(self):
-        sfb = self.ptr["static_info"]["body"]
+        sfb = self._static_info_body
         return mvmstr_to_str(sfb["name"].dereference())
 
     @property
@@ -1842,37 +1858,38 @@ class MoarStackFrame:
 
     @property
     def bytecode_offs(self):
-        sfb = self.ptr["static_info"]["body"]
+        sfb = self._static_info_body
         bc = frame_effective_bytecode(self.ptr)
         return int(self.cur_op) - int(bc)
 
     @property
     def params(self):
-        return self.ptr["params"]
+        return self._params
 
     @property
     def param_vals(self):
-        callsite = self.params["arg_info"]["callsite"]
+        callsite = self._arg_info["callsite"]
         csinfo = parse_callsite(callsite)
 
+        source = self._arg_info["source"]
+        map = self._arg_info["map"]
+
         return [
-            self.params["arg_info"]["source"][
-                self.params["arg_info"]["map"][i]
-            ] for i in range(len(csinfo))]
+            source[map[i]] for i in range(len(csinfo))]
 
     @property
     def cuuid(self):
-        return mvmstr_to_str(self.ptr["static_info"]["body"]["cuuid"])
+        return mvmstr_to_str(self._static_info_body["cuuid"])
 
     @property
     def cufile(self):
-        return mvmstr_to_str(self.ptr["static_info"]["body"]["cu"]["body"]["filename"])
+        return mvmstr_to_str(self._static_info_body["cu"]["body"]["filename"])
 
     def resolve_annotation(self, offs : int | None = None):
         if offs is None:
             offs = self.bytecode_offs
 
-        sfb = self.ptr["static_info"]["body"]
+        sfb = self._static_info_body
 
         return resolve_annotation(sfb, offs)
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -53,6 +53,14 @@ import math
 import random
 #import blessings
 import sys
+import time
+import typing
+import array
+import struct
+import pathlib
+import tempfile
+
+import json
 
 import traceback # debugging
 
@@ -818,6 +826,360 @@ class DiffHeapCommand(gdb.Command):
         assert len(nursery_memory) > max(pos1, pos2)
         nursery_memory[pos2].diff(nursery_memory[pos1])
 
+class AutoResumingBreakpoint(gdb.Breakpoint):
+    def stop(self):
+        self._hit_breakpoint_action()
+        return False # don't actually stop
+
+class PointInTimeRecordingBreakpoint(AutoResumingBreakpoint):
+    def __init__(self, medbc, event, exprs, *args):
+        super(PointInTimeRecordingBreakpoint, self).__init__(*args)
+        self._medbc = medbc # MakeExecutionDatabaseCommand
+        self._event = event
+        self._exprs = exprs
+        self._extras = None
+
+    def _hit_breakpoint_action(self):
+        created_event = self._medbc._register_event(self._event, self._exprs)
+        if self._extras is not None:
+            self._extras(created_event)
+
+    def _extra(self, _the_extra):
+        self._extras = _the_extra
+        return self
+
+
+class ArrayEntryRecordingBreakpoint(AutoResumingBreakpoint):
+    def __init__(self, medbc, table_name, exprs, *args):
+        super(ArrayEntryRecordingBreakpoint, self).__init__(*args)
+        self._medbc = medbc # MakeExecutionDatabaseCommand
+        self._table_name = table_name
+        self._exprs = exprs
+        self._extras = None
+
+    def _hit_breakpoint_action(self):
+        created_event = self._medbc._register_event_array(self._table_name, self._exprs)
+        if self._extras is not None:
+            self._extras(created_event)
+
+    def _extra(self, _the_extra):
+        self._extras = _the_extra
+        return self
+
+
+class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
+    def __init__(self, medbc, *args):
+        super(ObjectMovementRecordingBreakpoint, self).__init__(*args)
+        self._medbc = medbc
+
+    def _hit_breakpoint_action(self):
+        self._medbc._register_object_movement()
+
+execution_db = None
+
+class MakeExecutionDatabaseCommand(gdb.Command):
+    """Run execution from beginning to end, creating a database with interesting events.
+
+    Only makes sense to run inside a "rr replay" session."""
+    def __init__(self):
+        super(MakeExecutionDatabaseCommand, self).__init__("moar-rrdb", gdb.COMMAND_DATA)
+
+    _disabled_breakpoints = None
+    _created_breakpoints = None
+
+    _gc_seq_num = None
+
+    _db = None
+    _object_movements = {}
+
+    class _EXP:
+        tid = lambda _: ["tid", gdb.selected_thread().ptid_string]
+        gdb_eval = lambda _, sub, code, pytype: lambda: [sub, pytype(gdb.parse_and_eval(code))]
+
+    _prev_tl_entry = None
+    _prev_thread = None
+    _prev_thread_str = None
+
+    def _register_event(self, event, exprs):
+        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
+        rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
+        rr_pos = str(rr_tick)
+        expr_data = dict(rre=rr_event, rrt=rr_tick, event=event)
+        for expr in exprs:
+            if isinstance(expr, list):
+                key, value = expr
+            elif isinstance(expr, typing.Callable):
+                key, value = expr()
+            expr_data[key] = value
+
+        before_del = expr_data.copy()
+
+        if expr_data["subject"]:
+            sk_data = self._db["subjects"][expr_data["subject_kind"]]
+            if expr_data["subject"] not in sk_data:
+                sk_data[expr_data["subject"]] = subjdata = dict(events=[])
+            else:
+                subjdata = sk_data[expr_data["subject"]]
+            subjdata["events"].append(before_del)
+
+        #for k in self._prev_tl_entry:
+        #    if k in expr_data and self._prev_tl_entry[k] == expr_data[k]:
+        #        del expr_data[k]
+
+        self._db["timeline"][rr_pos] = expr_data
+        self._prev_tl_entry = before_del
+
+        return before_del
+
+    def _register_event_array(self, table_name, exprs):
+        # rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
+        rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
+
+        table = self._db['subjects'][table_name]
+
+        for expr in exprs:
+            if isinstance(expr, list):
+                key, value = expr
+            elif isinstance(expr, typing.Callable):
+                key, value = expr()
+            table[key].append(value)
+        table["rr_tick"].append(rr_tick)
+
+        return None
+
+    def _register_object_movement(self):
+        t = gdb.selected_thread()
+        if t is self._prev_thread:
+            tid = self._prev_thread_str
+        else:
+            tid = t.ptid_string
+            self._prev_thread = t
+            self._prev_thread_str = tid
+
+        to_addr   = int(gdb.parse_and_eval("(uintptr_t)new_addr"))
+        from_addr = int(gdb.parse_and_eval("(uintptr_t)item"))
+
+        self._object_movements[self._gc_seq_num].append(from_addr)
+        self._object_movements[self._gc_seq_num].append(to_addr)
+
+    def setup(self):
+        def store_seq_num(ev):
+            prev = self._gc_seq_num
+            self._gc_seq_num = int(gdb.parse_and_eval("tc->instance->gc_seq_number"))
+
+            if self._gc_seq_num not in self._object_movements:
+                self._object_movements[self._gc_seq_num] = array.array("Q")
+
+            if prev is not None and prev // 20 != self._gc_seq_num // 20:
+                print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num)
+                for s in self._db["subjects"]:
+                    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
+                if self._gc_seq_num == 60:
+                    gdb.Breakpoint("MVM_frame_dispatch")
+
+        print(time.strftime("%H:%M:%S"), " - starting")
+
+        #sfs_schema = pa.schema([
+        #    ('rr_tick', pa.uint64()),
+        #    ('addr', pa.uint64()),
+        #    ('compunit', pa.uint64()),
+        #    ('bytecode_addr', pa.uint64()),
+        #    ('event', pa.string()),
+        #    ])
+
+        #cus_schema = pa.schema([
+        #    ('rr_event', pa.uint64()),
+        #    ('addr', pa.uint64()),
+        #    ('mapped_addr', pa.uint64()),
+        #    ('event', pa.string()),
+        #    ])
+
+        #moves_schema = pa.schema([
+        #    ('gc_seq_nr', pa.uint32()),
+        #    ('pre_addr', pa.uint64()),
+        #    ('post_addr', pa.uint64()),
+        #    ])
+
+        #calls_schema = pa.schema([
+        #    ('rr_tick', pa.uint64()),
+        #    ('sf_addr', pa.uint64()),
+        #    ('bytecode_addr', pa.uint64()),
+        #    ('tc_addr', pa.uint64()),
+        #])
+
+        cus_tbl = {
+            "tc": array.array('Q'),
+            "rr_tick": array.array('Q'),
+            "data_addr": array.array('Q'),
+        }
+
+        sfs_tbl = {
+            "rr_tick": array.array('Q'),
+            "bytecode": array.array('Q'),
+            "compunit": array.array('Q'),
+            "sf": array.array('Q'),
+            "cuuid": [],
+            "name": [],
+        }
+
+        spesh_bytecode_tbl = {
+            "rr_tick": array.array('Q'),
+            "sf": array.array('Q'),
+            "bytecode": array.array('Q'),
+            "size": array.array('L'),
+        }
+
+        calls_tbl = {
+            "rr_tick": array.array('Q'),
+            "bytecode_addr": array.array('Q'),
+            "frame": array.array('Q'),
+        }
+
+        gcs_tbl = {
+            "tc": array.array('Q'),
+            "rr_tick": array.array('Q'),
+            "gc_seq_number": array.array('L'),
+            "is_full": array.array('B'),
+        }
+
+        worklist_runs_tbl = {
+            "tc": array.array('Q'),
+            "rr_tick": array.array('Q'),
+            "nursery_alloc": array.array('Q'),
+            "nursery_alloc_limit": array.array('Q'),
+            "nursery_fromspace": array.array('Q'),
+            "nursery_tospace": array.array('Q'),
+        }
+
+        print(gcs_tbl)
+
+        EXP = self._EXP()
+        self._db = dict(
+            timeline={},
+            subjects=dict(
+                gcs=gcs_tbl,
+                sfs=sfs_tbl,
+                spesh_bytecode=spesh_bytecode_tbl,
+                calls=calls_tbl,
+                cus=cus_tbl,
+                worklist_runs=worklist_runs_tbl,
+            ),
+            object_movements={},
+        )
+        self._prev_tl_entry = {}
+        self._object_movements = self._db["object_movements"]
+
+        execution_db = self._db
+
+        self._disabled_breakpoints = []
+        self._created_breakpoints = []
+        cbp = self._created_breakpoints
+
+        for bp in gdb.breakpoints():
+            if bp.enabled:
+                bp.enabled = False
+                self._disabled_breakpoints.append(bp)
+
+        cbp.append(ArrayEntryRecordingBreakpoint(self, "gcs", [
+            EXP.gdb_eval("tc", "tc", int),
+            EXP.gdb_eval("gc_seq_number", "tc->instance->gc_seq_number", int),
+            EXP.gdb_eval("is_full", "tc->instance->gc_full_collect", int),
+            ], "run_gc"))
+
+        cbp.append(ArrayEntryRecordingBreakpoint(self, "cus", [
+            EXP.gdb_eval("tc", "tc", int),
+            EXP.gdb_eval("data_addr", "cu->body.data_start", int),
+            ], "run_comp_unit"))
+
+        cbp.append(ArrayEntryRecordingBreakpoint(self, "worklist_runs", [
+            EXP.gdb_eval("tc", "tc", int),
+            EXP.gdb_eval("nursery_alloc", "tc->nursery_alloc", int),
+            EXP.gdb_eval("nursery_alloc_limit", "tc->nursery_alloc_limit", int),
+            EXP.gdb_eval("nursery_fromspace", "tc->nursery_fromspace", int),
+            EXP.gdb_eval("nursery_tospace", "tc->nursery_tospace", int),
+            ], "process_worklist")._extra(store_seq_num))
+
+        gdb.execute("list process_worklist", False, True)
+        forwarder_update_lineno = gdb.execute("search item->sc_forward_u.forwarder = new_addr;", False, True).split("\t")[0]
+
+        cbp.append(ObjectMovementRecordingBreakpoint(self, "src/gc/collect.c:" + forwarder_update_lineno))
+
+        gdb.execute("list MVM_frame_dispatch", False, True)
+        dispatch_trampoline_lineno = gdb.execute("search MVM_jit_code_trampoline(tc);", False, True).split("\t")[0]
+
+        #cbp.append(ArrayEntryRecordingBreakpoint(self, "calls", [
+        #    #EXP.gdb_eval("tc", "tc", int),
+        #    EXP.gdb_eval("bytecode_addr", "chosen_bytecode", int),
+        #    EXP.gdb_eval("frame", "frame", int),
+        #    ], "src/core/frame.c:" + dispatch_trampoline_lineno))
+
+        print("trying to find a line in MVM_frame_move_to_heap")
+        gdb.execute("list MVM_frame_move_to_heap", False, True)
+        get_to_promote_sf_lineno = gdb.execute("search MVMStaticFrame *sf = cur_to_promote->static_info;", False, True).split("\t")[0]
+        print("oh well")
+
+        gdb.execute("list MVM_spesh_candidate_add", False, True)
+        free_speshcode_lineno = gdb.execute("search MVM_free.sc.;", False, True).split("\t")[0]
+
+        cbp.append(ArrayEntryRecordingBreakpoint(self, "spesh_bytecode", [
+            EXP.gdb_eval("sf", "p->sf", int),
+            EXP.gdb_eval("bytecode", "sc->bytecode", int),
+            EXP.gdb_eval("size", "sc->bytecode_size", int),
+            ], "src/6model/reprs/MVMSpeshCandidate.c:" + free_speshcode_lineno))
+
+        cbp.append(ArrayEntryRecordingBreakpoint(self, "sfs", [
+            EXP.gdb_eval("bytecode", "static_frame->body.bytecode", int),
+            EXP.gdb_eval("compunit", "static_frame->body.cu", int),
+            EXP.gdb_eval("sf", "static_frame", int),
+            EXP.gdb_eval("cuuid", "MVM_string_utf8_encode_C_string(tc, static_frame->body.cuuid)", lambda v: v.string()),
+            EXP.gdb_eval("name", "MVM_string_utf8_encode_C_string(tc, static_frame->body.name)", lambda v: v.string()),
+            ], "MVM_validate_static_frame"))
+
+
+        # sf->body.fully_deserialized = 1;
+
+        #cbp.append(PointInTimeRecordingBreakpoint(self, "force_frame_to_heap", [
+        #    EXP.tid,
+        #    ["subject_kind", "frames"],
+        #    EXP.gdb_eval("subject", "cur_to_promote->static_info", int),
+        #    EXP.gdb_eval("frame", "cur_to_promote", int),
+        #    EXP.gdb_eval("frame_new", "promoted", int),
+        #    ], "src/core/frame.c:" + get_to_promote_sf_lineno))
+
+        #cbp.append(ArrayEntryRecordingBreakpoint(self, "calls", [
+        #    EXP.tid,
+        #    ["subject_kind", "frames"],
+        #    EXP.gdb_eval("subject", "returner", int),
+        #    ], "callstack.c:exit_frame"))
+
+    def teardown(self):
+        for bp in self._disabled_breakpoints:
+            bp.enabled = True
+        for bp in self._created_breakpoints:
+            bp.delete()
+
+
+    def run(self):
+        gdb.execute("start")
+        # run to the temporary breakpoint that "start" creates
+        gdb.execute("c")
+        # run the program actually
+        gdb.execute("c")
+
+    def invoke(self, arg, from_tty):
+        self.setup()
+        try:
+            self.run()
+        finally:
+            self.teardown()
+
+        with tempfile.NamedTemporaryFile(mode="wb", prefix="moar_gdb_", suffix="_rrdb.pkl", delete=False) as ntf:
+            import pickle
+            pickle.dump(self._db, ntf)
+            ntf.close()
+
+            print("rrdb pickle file can be found at ", ntf.name)
+
 def str_lookup_function(val):
     if str(val.type) == "MVMString":
         return MVMStringPPrinter(val)
@@ -849,11 +1211,17 @@ def register_commands(objfile):
     print("moar-heap registered")
     commands.append(DiffHeapCommand())
     print("diff-moar-heap registered")
+    commands.append(MakeExecutionDatabaseCommand())
+    print("moar-rrdb registered")
 
 # We have to introduce our classes to gdb so that they can be used
 if __name__ == "__main__":
     the_objfile = gdb.current_objfile()
     if the_objfile is None:
-        the_objfile = gdb.lookup_objfile("libmoar.so")
-    register_printers(the_objfile)
+        try:
+            the_objfile = gdb.lookup_objfile("libmoar.so")
+        except:
+            print("GDB doesn't know about 'libmoar.so' yet; maybe you need to run the program a little until it's loaded.")
+    if the_objfile:
+        register_printers(the_objfile)
     register_commands(the_objfile)

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1731,8 +1731,9 @@ class MoarBtFrameCommand(gdb.Command):
         super(MoarBtFrameCommand, self).__init__("moar bt frame", gdb.COMMAND_STACK)
 
     def invoke(self, argument, from_tty):
+        stack_idx = None
         if argument == "" or argument is None:
-            cur_frame = MoarStackFrame.from_tc(tc)
+            cur_frame = MoarStackFrame.from_tc()
         elif argument[0] == "*":
             evaled = gdb.parse_and_eval(argument[1:])
             cur_frame = MoarStackFrame(evaled, evaled, MoarStackFrame.Relation.MANUAL)
@@ -1746,21 +1747,28 @@ class MoarBtFrameCommand(gdb.Command):
             if cur_frame is None:
                 print(f"Frame with index {evaled} could not be found; stack exhausted after {stack_idx} steps!")
 
-        gdb.set_convenience_variable("mframe", cur_frame.ptr)
-        print(f"var $mframe set to {cur_frame.ptr}")
-
         fn, ln = cur_frame.resolve_annotation()
         infoparts = extract_moar_stack_frame_args(cur_frame)
-
-        csinfo_str = "args=(" + ", ".join(infoparts) + ")"
 
         name = cur_frame.name
         name = "''" if name == "" else name
 
-        if fn is not None and ln is not None:
-            print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, fn, ":", ln)
+        loc = ""
+
+        if fn is None or ln is None:
+            loc = f"{fn} : {ln}"
         else:
-            print(f"#{stack_idx}", cur_frame.ptr, name, csinfo_str, "<unknown>:1")
+            loc = f"<unknown>:1"
+
+        if stack_idx is not None:
+            print(f"Stack Frame #{stack_idx}")
+
+        print(cur_frame.ptr)
+        print(f"Name: {name} {loc}")
+        print("Arguments:")
+        for info in infoparts:
+            print(f"  {info}")
+        print("")
 
         csinfo = parse_callsite(cur_frame.params["arg_info"]["callsite"])
         param_vals = cur_frame.param_vals
@@ -1774,6 +1782,9 @@ class MoarBtFrameCommand(gdb.Command):
             unset_val = gdb.parse_and_eval("$okay_so_hear_me_out_i_need_a_gdb_value_that_is_void_but_not_a_void_pointer_or_anything_and_i_dont_know_how_to_create_it_from_python_so_please_dont_put_anything_in_this_variable_thank_you")
         except:
             print("could not unset obsolete margs convenience vars")
+
+        gdb.set_convenience_variable("mframe", cur_frame.ptr)
+        print(f"var $mframe set to {cur_frame.ptr}")
 
         gdb.set_convenience_variable("margs_cnt", len(csinfo))
         print(f"var $margs_cnt set to {len(csinfo)}")
@@ -1798,7 +1809,7 @@ class MoarBtFrameCommand(gdb.Command):
                     is_obj = True
                     is_concrete = True
 
-                if is_obj:
+                if is_obj and is_concrete:
                     reprname = subpart["st"]["REPR"]["name"].string()
                     if reprname in repr_infos:
                         typ = repr_infos[reprname]["struct"].pointer()

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -2033,12 +2033,13 @@ def extract_moar_stack_frame_args(cur_frame, str_cache = None):
                         subpart = subpart.cast(stoogep_t)["data"].cast(mvmstrp_t)
                         #print(repr(subpart), repr(subpart.type))
                         #print("trying to mvmstr_to_str this:", repr(mvmstr_to_str(subpart)))
-                        if str_cache is not None and int(subpart) in str_cache:
-                            string_of_subpart = str_cache[int(subpart)]
+                        spk = (int(subpart), "arg")
+                        if str_cache is not None and spk in str_cache:
+                            string_of_subpart = str_cache[spk]
                         else:
                             string_of_subpart = "((MVMString *)" + hex(int(subpart)) + ")=" + repr(mvmstr_to_str(subpart, truncate=128))
                             if str_cache is not None:
-                                str_cache[int(subpart)] = string_of_subpart
+                                str_cache[spk] = string_of_subpart
 
                     elif int(subpart["st"]["debug_name"]) != 0:
                         typename = reprname + "#" + subpart["st"]["debug_name"].string()
@@ -2125,7 +2126,7 @@ class MoarBtCommands(gdb.Command):
             else:
                 locstr = "<unknown>:1"
 
-                fn, ln = cur_frame.resolve_annotation(offs=0)
+                fn, ln = cur_frame.resolve_annotation(offs=0, str_cache=str_cache)
                 if fn is not None and ln is not None:
                     locstr = f"somewhere after {fn}:{ln}"
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1943,7 +1943,11 @@ def extract_moar_stack_frame_args(cur_frame, str_cache = None):
         csinfo = parse_callsite(callsite)
         if str_cache is not None:
             str_cache[int(callsite)] = csinfo
-    param_vals = cur_frame.param_vals
+
+    source = cur_frame._arg_info["source"]
+    map = cur_frame._arg_info["map"]
+
+    param_vals = [source[int(map[i])] for i in range(len(csinfo))]
 
     infoparts = []
 
@@ -1957,44 +1961,52 @@ def extract_moar_stack_frame_args(cur_frame, str_cache = None):
 
         #print("adding arg of", typename, argname, repr(subpart))
         if typename == "obj":
-            flags1 = int(subpart["header"]["flags1"])
-            if flags1 & 2: # MVM_CF_STABLE
-                is_obj = False
-                pass
-            elif flags1 & 1: # MVM_CF_TYPE_OBJECT
-                is_obj = True
-                is_concrete = False
-            elif flags1 & 4: # MVM_CF_FRAME
-                is_obj = False
+            if str_cache is not None and (int(subpart), "arg") in str_cache:
+                string_of_subpart = str_cache[(int(subpart), "arg")]
+
             else:
-                is_obj = True
-                is_concrete = True
-
-            if is_obj:
-                if str_cache is not None and int(subpart["st"]) in str_cache:
-                    reprname = str_cache[int(subpart["st"])]
+                flags1 = int(subpart["header"]["flags1"])
+                if flags1 & 2: # MVM_CF_STABLE
+                    is_obj = False
+                    pass
+                elif flags1 & 1: # MVM_CF_TYPE_OBJECT
+                    is_obj = True
+                    is_concrete = False
+                elif flags1 & 4: # MVM_CF_FRAME
+                    is_obj = False
                 else:
-                    reprname = subpart["st"]["REPR"]["name"].string()
-                    if str_cache is not None:
-                        str_cache[int(subpart["st"])] = reprname
+                    is_obj = True
+                    is_concrete = True
 
-                if is_concrete and reprname == "P6str":
-                    #print("casting to p6str? before:")
-                    #print(repr(subpart), repr(subpart.type))
-                    subpart = subpart.cast(stoogep_t)["data"].cast(mvmstrp_t)
-                    #print(repr(subpart), repr(subpart.type))
-                    #print("trying to mvmstr_to_str this:", repr(mvmstr_to_str(subpart)))
-                    if str_cache is not None and int(subpart) in str_cache:
-                        string_of_subpart = str_cache[int(subpart)]
+                if is_obj:
+                    if str_cache is not None and int(subpart["st"]) in str_cache:
+                        reprname = str_cache[int(subpart["st"])]
                     else:
-                        string_of_subpart = "((MVMString *)" + hex(int(subpart)) + ")=" + repr(mvmstr_to_str(subpart, truncate=128))
+                        reprname = subpart["st"]["REPR"]["name"].string()
                         if str_cache is not None:
-                            str_cache[int(subpart)] = string_of_subpart
+                            str_cache[int(subpart["st"])] = reprname
 
-                elif int(subpart["st"]["debug_name"]) != 0:
-                    typename = reprname + "#" + subpart["st"]["debug_name"].string()
-                    if is_concrete:
-                        typename = typename + ".new"
+                    if is_concrete and reprname == "P6str":
+                        #print("casting to p6str? before:")
+                        #print(repr(subpart), repr(subpart.type))
+                        subpart = subpart.cast(stoogep_t)["data"].cast(mvmstrp_t)
+                        #print(repr(subpart), repr(subpart.type))
+                        #print("trying to mvmstr_to_str this:", repr(mvmstr_to_str(subpart)))
+                        if str_cache is not None and int(subpart) in str_cache:
+                            string_of_subpart = str_cache[int(subpart)]
+                        else:
+                            string_of_subpart = "((MVMString *)" + hex(int(subpart)) + ")=" + repr(mvmstr_to_str(subpart, truncate=128))
+                            if str_cache is not None:
+                                str_cache[int(subpart)] = string_of_subpart
+
+                    elif int(subpart["st"]["debug_name"]) != 0:
+                        typename = reprname + "#" + subpart["st"]["debug_name"].string()
+                        if is_concrete:
+                            typename = typename + ".new"
+
+                if str_cache is not None:
+                    str_cache[(int(subpart), "arg")] = string_of_subpart
+
 
         if string_of_subpart is None:
             string_of_subpart = gdb.printing.make_visualizer(subpart).to_string()

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -2082,6 +2082,8 @@ class MoarBtCommands(gdb.Command):
     #     pr.print_stats(1)
 
     def invoke(self, argument, from_tty):
+        flags = set(argument.split(" )"))
+
         str_cache = {}
 
         tc = find_tc()
@@ -2101,9 +2103,12 @@ class MoarBtCommands(gdb.Command):
 
             fn, ln = cur_frame.resolve_annotation(None, str_cache)
 
-            infoparts = extract_moar_stack_frame_args(cur_frame, str_cache)
+            if "noargs" not in flags:
+                infoparts = extract_moar_stack_frame_args(cur_frame, str_cache)
 
-            csinfo_str = "args=(" + ", ".join(infoparts) + ")"
+                csinfo_str = "args=(" + ", ".join(infoparts) + ")"
+            else:
+                csinfo_str = ""
 
             # Instead of just outputting "'' at <unknown>:1", make an attempt
             # to get at least something to differentiate one thing from another

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -20,12 +20,13 @@
 #
 # - A semi-functional pretty-printer for MVMString and MVMString*
 # - A non-working pretty-printer for MVMObject in general
-# - A command "moar-heap" that walks the nursery and gen2 and displays
+# - A command "moar heap" that walks the nursery and gen2 and displays
 #   statistics about the REPRs found in them, as well as a display of
 #   the fragmentation of the gen2 pages.
-# - A command "diff-moar-heap" that diffs (so far only) the two last
+# - A command "moar diff-heap" that diffs (so far only) the two last
 #   snapshots of the nursery, or whatever snapshot number you supply
 #   as the argument.
+# - A group of commands "moar break" for commonly useful breakpoints.
 
 # Here's the TODO list:
 #
@@ -160,6 +161,13 @@ def generate_hilbert(amount):
     return hilbert_coords
 
 hilbert_coords = generate_hilbert(MVM_GEN2_PAGE_ITEMS)
+
+# Declaration of the "moar" command group.
+class MoarCommands(gdb.Command):
+    """Group of commands related to MoarVM."""
+    def __init__(self):
+        super(MoarCommands, self).__init__("moar", gdb.COMMAND_NONE, prefix=True)
+
 
 # Sizes are easier to read if they have .s in them.
 def prettify_size(num):
@@ -770,7 +778,7 @@ class AnalyzeHeapCommand(gdb.Command):
     """Analyze the nursery and gen2 of MoarVM's garbage collector corresponding
     to the current tc, or the tc you pass as the first argument"""
     def __init__(self):
-        super(AnalyzeHeapCommand, self).__init__("moar-heap", gdb.COMMAND_DATA)
+        super(AnalyzeHeapCommand, self).__init__("moar heap", gdb.COMMAND_DATA)
 
     def invoke(self, arg, from_tty):
         tc = gdb.selected_frame().read_var(arg if arg else "tc")
@@ -812,7 +820,7 @@ class AnalyzeHeapCommand(gdb.Command):
 class DiffHeapCommand(gdb.Command):
     """Display the difference between two snapshots of the nursery."""
     def __init__(self):
-        super(DiffHeapCommand, self).__init__("diff-moar-heap", gdb.COMMAND_DATA)
+        super(DiffHeapCommand, self).__init__("moar diff-heap", gdb.COMMAND_DATA)
 
     def invoke(self, arg, from_tty):
         if arg != "":
@@ -825,6 +833,41 @@ class DiffHeapCommand(gdb.Command):
             pos2 = -2
         assert len(nursery_memory) > max(pos1, pos2)
         nursery_memory[pos2].diff(nursery_memory[pos1])
+
+class MoarBreakCommands(gdb.Command):
+    """Group of commands to set breakpoints at useful MoarVM functions."""
+    _break_spec = ""
+    def __init__(self):
+        super(MoarBreakCommands, self).__init__("moar break", gdb.COMMAND_BREAKPOINTS, prefix=True)
+
+    def invoke(self, arg, from_tty):
+        return gdb.Breakpoint(self._break_spec)
+
+class MoarBreakInterpRunCommands(MoarBreakCommands):
+    """Set a breakpoint at MVM_interp_run."""
+    def __init__(self):
+        super(MoarBreakCommands, self).__init__("moar break interp-run", gdb.COMMAND_BREAKPOINTS)
+        self._break_spec = "MVM_interp_run"
+
+class MoarBreakExceptionAdhoc(MoarBreakCommands):
+    """Set a breakpoint at MVM_exception_throw_adhoc."""
+    def __init__(self):
+        super(MoarBreakCommands, self).__init__("moar break exception-adhoc", gdb.COMMAND_BREAKPOINTS)
+        self._break_spec = "MVM_exception_throw_adhoc"
+
+#
+# moar rrdb implementation
+# ========================
+#
+# when running moar under `rr replay` we can make a little database of
+# interestang events, as well as information about objects by their address
+# which could then be used by different commands.
+#
+# The database is currently created as an sqlite3 database which is filled
+# with data from breakpoints automatically set up at "strategic places".
+#
+# As of right now, the data is not utilised by any commands here.
+#
 
 class AutoResumingBreakpoint(gdb.Breakpoint):
     def stop(self):
@@ -848,7 +891,6 @@ class PointInTimeRecordingBreakpoint(AutoResumingBreakpoint):
         self._extras = _the_extra
         return self
 
-
 class ArrayEntryRecordingBreakpoint(AutoResumingBreakpoint):
     def __init__(self, medbc, table_name, exprs, *args):
         super(ArrayEntryRecordingBreakpoint, self).__init__(*args)
@@ -866,6 +908,22 @@ class ArrayEntryRecordingBreakpoint(AutoResumingBreakpoint):
         self._extras = _the_extra
         return self
 
+class SQLRecordingBreakpoint(AutoResumingBreakpoint):
+    def __init__(self, medbc, table_name, exprs, *args):
+        super(SQLRecordingBreakpoint, self).__init__(*args)
+        self._medbc = medbc # MakeExecutionDatabaseCommand
+        self._table_name = table_name
+        self._exprs = exprs
+        self._extras = None
+
+    def _hit_breakpoint_action(self):
+        created_event = self._medbc._register_event_sql(self._table_name, self._exprs)
+        if self._extras is not None:
+            self._extras(created_event)
+
+    def _extra(self, _the_extra):
+        self._extras = _the_extra
+        return self
 
 class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
     def __init__(self, medbc, *args):
@@ -882,7 +940,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
     Only makes sense to run inside a "rr replay" session."""
     def __init__(self):
-        super(MakeExecutionDatabaseCommand, self).__init__("moar-rrdb", gdb.COMMAND_DATA)
+        super(MakeExecutionDatabaseCommand, self).__init__("moar rrdb", gdb.COMMAND_DATA)
 
     _disabled_breakpoints = None
     _created_breakpoints = None
@@ -947,35 +1005,65 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         return None
 
+    def _register_event_sql(self, table_name, exprs):
+        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
+        rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
+        #print(rr_event, rr_tick)
+
+        row = {}
+        for expr in exprs:
+            if isinstance(expr, list):
+                key, value = expr
+            elif isinstance(expr, typing.Callable):
+                key, value = expr()
+            row[key] = value
+        row["rr_tick"] = rr_tick
+        row["rr_event"] = rr_event
+
+        colnames = ', '.join([":" + n for n in row.keys()])
+        query = f"INSERT INTO {table_name} VALUES ({colnames});"
+        #print(query)
+        #print(row)
+        self._db_cur.execute(query, row)
+        self._db_conn.commit()
+
+        return row
+
     def _register_object_movement(self):
-        t = gdb.selected_thread()
-        if t is self._prev_thread:
-            tid = self._prev_thread_str
-        else:
-            tid = t.ptid_string
-            self._prev_thread = t
-            self._prev_thread_str = tid
+        #t = gdb.selected_thread()
+        #if t is self._prev_thread:
+        #    tid = self._prev_thread_str
+        #else:
+        #    tid = t.ptid_string
+        #    self._prev_thread = t
+        #    self._prev_thread_str = tid
 
         to_addr   = int(gdb.parse_and_eval("(uintptr_t)new_addr"))
         from_addr = int(gdb.parse_and_eval("(uintptr_t)item"))
 
-        self._object_movements[self._gc_seq_num].append(from_addr)
-        self._object_movements[self._gc_seq_num].append(to_addr)
+        query = "INSERT INTO object_movements VALUES (?, ?);"
+        self._db_cur.execute(query, (from_addr, to_addr))
+        self._db_conn.commit()
+
+        #self._object_movements[self._gc_seq_num].append(from_addr)
+        #self._object_movements[self._gc_seq_num].append(to_addr)
 
     def setup(self):
+        import sqlite3
+
         def store_seq_num(ev):
             prev = self._gc_seq_num
             self._gc_seq_num = int(gdb.parse_and_eval("tc->instance->gc_seq_number"))
 
-            if self._gc_seq_num not in self._object_movements:
-                self._object_movements[self._gc_seq_num] = array.array("Q")
+            #if self._gc_seq_num not in self._object_movements:
+            #    self._object_movements[self._gc_seq_num] = array.array("Q")
 
             if prev is not None and prev // 20 != self._gc_seq_num // 20:
                 print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num)
-                for s in self._db["subjects"]:
-                    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
-                if self._gc_seq_num == 60:
-                    gdb.Breakpoint("MVM_frame_dispatch")
+                #for s in self._db["subjects"]:
+                #    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
+                #if self._gc_seq_num == 60:
+                #    gdb.Breakpoint("MVM_frame_dispatch")
 
         print(time.strftime("%H:%M:%S"), " - starting")
 
@@ -1007,67 +1095,143 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         #    ('tc_addr', pa.uint64()),
         #])
 
-        cus_tbl = {
-            "tc": array.array('Q'),
-            "rr_tick": array.array('Q'),
-            "data_addr": array.array('Q'),
-        }
+        self._db_file = tempfile.NamedTemporaryFile(prefix="moar-gdb-rrdb-", suffix=".sqlite3", delete=False)
+        self._db_file.close()
+        self._db_conn = sqlite3.connect(self._db_file.name, autocommit=False)
+        self._db_cur = self._db_conn.cursor()
 
-        sfs_tbl = {
-            "rr_tick": array.array('Q'),
-            "bytecode": array.array('Q'),
-            "compunit": array.array('Q'),
-            "sf": array.array('Q'),
-            "cuuid": [],
-            "name": [],
-        }
+        print("sqlite3 file can be found at ", self._db_file.name)
 
-        spesh_bytecode_tbl = {
-            "rr_tick": array.array('Q'),
-            "sf": array.array('Q'),
-            "bytecode": array.array('Q'),
-            "size": array.array('L'),
-        }
+        self._db_cur.execute("""
+            create table compunits (
+                tc integer,
+                rr_tick integer,
+                rr_event integer,
+                data_addr integer
+            );
+        """)
 
-        calls_tbl = {
-            "rr_tick": array.array('Q'),
-            "bytecode_addr": array.array('Q'),
-            "frame": array.array('Q'),
-        }
+        self._db_cur.execute("""
+            create table staticframes (
+                rr_tick integer,
+                rr_event integer,
+                bytecode integer,
+                compunit_data_addr integer,
+                sf_addr integer,
+                cuuid varchar,
+                name varchar
+            );
+        """)
 
-        gcs_tbl = {
-            "tc": array.array('Q'),
-            "rr_tick": array.array('Q'),
-            "gc_seq_number": array.array('L'),
-            "is_full": array.array('B'),
-        }
+        self._db_cur.execute("""
+            create table spesh_bytecode (
+                rr_tick integer,
+                rr_event integer,
+                sf_addr integer,
+                bytecode_addr integer,
+                size integer
+            );
+        """)
 
-        worklist_runs_tbl = {
-            "tc": array.array('Q'),
-            "rr_tick": array.array('Q'),
-            "nursery_alloc": array.array('Q'),
-            "nursery_alloc_limit": array.array('Q'),
-            "nursery_fromspace": array.array('Q'),
-            "nursery_tospace": array.array('Q'),
-        }
+        self._db_cur.execute("""
+            create table gcs (
+                tc integer,
+                rr_tick integer,
+                rr_event integer,
+                gc_seq_number integer,
+                is_full integer
+            );
+        """)
 
-        print(gcs_tbl)
+        self._db_cur.execute("""
+            create table worklist_runs (
+                tc integer,
+                rr_tick integer,
+                rr_event integer,
+                nursery_alloc integer,
+                nursery_alloc_limit integer,
+                nursery_tospace integer,
+                nursery_fromspace integer
+            );
+        """)
+
+        self._db_cur.execute("""
+            create table object_movements (
+                to_addr integer,
+                from_addr integer
+            );
+        """)
+
+        self._db_cur.execute("""
+            create table sc_code (
+                sf_addr integer,
+                sc_addr integer,
+                idx integer
+            );
+        """)
+
+        self._db_conn.commit()
+
+        #vus_tbl = {
+        #    "tc": array.array('Q'),
+        #    "rr_tick": array.array('Q'),
+        #    "data_addr": array.array('Q'),
+        #}
+
+        #sfs_tbl = {
+        #    "rr_tick": array.array('Q'),
+        #    "bytecode": array.array('Q'),
+        #    "compunit": array.array('Q'),
+        #    "sf": array.array('Q'),
+        #    "cuuid": [],
+        #    "name": [],
+        #}
+
+        #spesh_bytecode_tbl = {
+        #    "rr_tick": array.array('Q'),
+        #    "sf": array.array('Q'),
+        #    "bytecode": array.array('Q'),
+        #    "size": array.array('L'),
+        #}
+
+        #calls_tbl = {
+        #    "rr_tick": array.array('Q'),
+        #    "bytecode_addr": array.array('Q'),
+        #    "frame": array.array('Q'),
+        #}
+
+        #gcs_tbl = {
+        #    "tc": array.array('Q'),
+        #    "rr_tick": array.array('Q'),
+        #    "gc_seq_number": array.array('L'),
+        #    "is_full": array.array('B'),
+        #}
+
+        #worklist_runs_tbl = {
+        #    "tc": array.array('Q'),
+        #    "rr_tick": array.array('Q'),
+        #    "nursery_alloc": array.array('Q'),
+        #    "nursery_alloc_limit": array.array('Q'),
+        #    "nursery_fromspace": array.array('Q'),
+        #    "nursery_tospace": array.array('Q'),
+        #}
+
 
         EXP = self._EXP()
         self._db = dict(
             timeline={},
             subjects=dict(
-                gcs=gcs_tbl,
-                sfs=sfs_tbl,
-                spesh_bytecode=spesh_bytecode_tbl,
-                calls=calls_tbl,
-                cus=cus_tbl,
-                worklist_runs=worklist_runs_tbl,
+                gcs=None,
+                sfs=None,
+                spesh_bytecode=None,
+                calls=None,
+                cus=None,
+                worklist_runs=None,
             ),
             object_movements={},
         )
         self._prev_tl_entry = {}
-        self._object_movements = self._db["object_movements"]
+        #self._object_movements = self._db["object_movements"]
 
         execution_db = self._db
 
@@ -1080,18 +1244,18 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 bp.enabled = False
                 self._disabled_breakpoints.append(bp)
 
-        cbp.append(ArrayEntryRecordingBreakpoint(self, "gcs", [
+        cbp.append(SQLRecordingBreakpoint(self, "gcs", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("gc_seq_number", "tc->instance->gc_seq_number", int),
             EXP.gdb_eval("is_full", "tc->instance->gc_full_collect", int),
             ], "run_gc"))
 
-        cbp.append(ArrayEntryRecordingBreakpoint(self, "cus", [
+        cbp.append(SQLRecordingBreakpoint(self, "compunits", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("data_addr", "cu->body.data_start", int),
             ], "run_comp_unit"))
 
-        cbp.append(ArrayEntryRecordingBreakpoint(self, "worklist_runs", [
+        cbp.append(SQLRecordingBreakpoint(self, "worklist_runs", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("nursery_alloc", "tc->nursery_alloc", int),
             EXP.gdb_eval("nursery_alloc_limit", "tc->nursery_alloc_limit", int),
@@ -1104,8 +1268,8 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         cbp.append(ObjectMovementRecordingBreakpoint(self, "src/gc/collect.c:" + forwarder_update_lineno))
 
-        gdb.execute("list MVM_frame_dispatch", False, True)
-        dispatch_trampoline_lineno = gdb.execute("search MVM_jit_code_trampoline(tc);", False, True).split("\t")[0]
+        #gdb.execute("list MVM_frame_dispatch", False, True)
+        #dispatch_trampoline_lineno = gdb.execute("search MVM_jit_code_trampoline(tc);", False, True).split("\t")[0]
 
         #cbp.append(ArrayEntryRecordingBreakpoint(self, "calls", [
         #    #EXP.gdb_eval("tc", "tc", int),
@@ -1113,28 +1277,33 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         #    EXP.gdb_eval("frame", "frame", int),
         #    ], "src/core/frame.c:" + dispatch_trampoline_lineno))
 
-        print("trying to find a line in MVM_frame_move_to_heap")
-        gdb.execute("list MVM_frame_move_to_heap", False, True)
-        get_to_promote_sf_lineno = gdb.execute("search MVMStaticFrame *sf = cur_to_promote->static_info;", False, True).split("\t")[0]
-        print("oh well")
+        #print("trying to find a line in MVM_frame_move_to_heap")
+        #gdb.execute("list MVM_frame_move_to_heap", False, True)
+        #get_to_promote_sf_lineno = gdb.execute("search MVMStaticFrame *sf = cur_to_promote->static_info;", False, True).split("\t")[0]
+        #print("oh well")
 
         gdb.execute("list MVM_spesh_candidate_add", False, True)
         free_speshcode_lineno = gdb.execute("search MVM_free.sc.;", False, True).split("\t")[0]
 
-        cbp.append(ArrayEntryRecordingBreakpoint(self, "spesh_bytecode", [
-            EXP.gdb_eval("sf", "p->sf", int),
-            EXP.gdb_eval("bytecode", "sc->bytecode", int),
+        cbp.append(SQLRecordingBreakpoint(self, "spesh_bytecode", [
+            EXP.gdb_eval("sf_addr", "p->sf", int),
+            EXP.gdb_eval("bytecode_addr", "sc->bytecode", int),
             EXP.gdb_eval("size", "sc->bytecode_size", int),
             ], "src/6model/reprs/MVMSpeshCandidate.c:" + free_speshcode_lineno))
 
-        cbp.append(ArrayEntryRecordingBreakpoint(self, "sfs", [
+        cbp.append(SQLRecordingBreakpoint(self, "staticframes", [
             EXP.gdb_eval("bytecode", "static_frame->body.bytecode", int),
-            EXP.gdb_eval("compunit", "static_frame->body.cu", int),
-            EXP.gdb_eval("sf", "static_frame", int),
+            EXP.gdb_eval("compunit_data_addr", "static_frame->body.cu->body.data_start", int),
+            EXP.gdb_eval("sf_addr", "static_frame", int),
             EXP.gdb_eval("cuuid", "MVM_string_utf8_encode_C_string(tc, static_frame->body.cuuid)", lambda v: v.string()),
             EXP.gdb_eval("name", "MVM_string_utf8_encode_C_string(tc, static_frame->body.name)", lambda v: v.string()),
             ], "MVM_validate_static_frame"))
 
+        #cbp.append(SQLRecordingBreakpoint(self, "sc_code", [
+        #    EXP.gdb_eval("sc_addr", "sc->body", int),
+        #    EXP.gdb_eval("sf_addr", "code->body.static_frame", int),
+        #    EXP.gdb_eval("idx", "idx", int),
+        #    ], "MVM_sc_set_code"))
 
         # sf->body.fully_deserialized = 1;
 
@@ -1173,12 +1342,11 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         finally:
             self.teardown()
 
-        with tempfile.NamedTemporaryFile(mode="wb", prefix="moar_gdb_", suffix="_rrdb.pkl", delete=False) as ntf:
-            import pickle
-            pickle.dump(self._db, ntf)
-            ntf.close()
-
-            print("rrdb pickle file can be found at ", ntf.name)
+        #with tempfile.NamedTemporaryFile(mode="wb", prefix="moar_gdb_", suffix="_rrdb.pkl", delete=False) as ntf:
+        #    import pickle
+        #    pickle.dump(self._db, ntf)
+        #    ntf.close()
+        #    print("rrdb pickle file can be found at ", ntf.name)
 
 def str_lookup_function(val):
     if str(val.type) == "MVMString":
@@ -1207,12 +1375,19 @@ def register_printers(objfile):
 
 commands = []
 def register_commands(objfile):
+    commands.append(MoarCommands())
+
     commands.append(AnalyzeHeapCommand())
-    print("moar-heap registered")
+    print("command moar heap registered")
     commands.append(DiffHeapCommand())
-    print("diff-moar-heap registered")
+    print("command moar diff-heap registered")
     commands.append(MakeExecutionDatabaseCommand())
-    print("moar-rrdb registered")
+    print("command moar rrdb registered")
+
+    commands.append(MoarBreakCommands())
+    commands.append(MoarBreakInterpRunCommands())
+    commands.append(MoarBreakExceptionAdhoc())
+    print("moar break commands registered")
 
 # We have to introduce our classes to gdb so that they can be used
 if __name__ == "__main__":

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1759,7 +1759,7 @@ def resolve_annotation(sfb, offset, str_cache = None):
     ann_offs = 0
 
     p_cur_anno = None
-    for annot in struct.iter_unpack("HHH", entire_buf):
+    for annot in struct.iter_unpack("iii", entire_buf):
         ann_offs = annot[0]
 
         if ann_offs > offset:

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -291,7 +291,10 @@ def init_repr_types_and_structs():
         print(f"... could not register these: {repr_errors}")
 
 def mvmstr_to_str(val, start=0, strlen=None, truncate=5000):
-    stringtyp = str_t_info[int(val['body']['storage_type'])]
+    try:
+        stringtyp = str_t_info[int(val['body']['storage_type'])]
+    except KeyError:
+        return "<invalid string?>"
     if stringtyp in ("blob_32", "blob_ascii", "blob_8", "in_situ_8", "in_situ_32"):
         data = val['body']['storage'][stringtyp]
         pieces = []
@@ -1704,37 +1707,43 @@ def string_from_cu(cu, index):
     strp = cub["strings"][index]
 
     if int(strp) == 0:
-        # not decoded yet, have to do it in here
+        try:
+            # not decoded yet, have to do it in here
 
-        # can hopefully at least find it quickly with the fast table?
-        fast_table_top = cub["string_heap_fast_table_top"]
+            # can hopefully at least find it quickly with the fast table?
+            fast_table_top = cub["string_heap_fast_table_top"]
 
-        # TODO can we safely get this with gdb from dwarf data?
-        bin = index // 16
+            # TODO can we safely get this with gdb from dwarf data?
+            bin = index // 16
 
-        fast_table = cub["string_heap_fast_table"]
+            fast_table = cub["string_heap_fast_table"]
 
-        # don't try to read outside the fast table!
-        if bin > int(fast_table_top):
-            bin = int(fast_table_top)
+            # dont try to read outside the fast table!
+            if bin > int(fast_table_top):
+                bin = int(fast_table_top)
 
-        strheap = cub["string_heap_start"] + fast_table[bin]
-        found_idx = bin * 16
+            strheap = cub["string_heap_start"] + fast_table[bin]
+            found_idx = bin * 16
 
-        while found_idx < index:
-            entrysize = int(int(strheap.cast(uint32p_t).dereference()) // 2)
-            if entrysize & 3:
-                entrysize += 4 - (entrysize & 3)
-            strheap = strheap + (int(entrysize) + 4)
-            found_idx += 1
+            while found_idx < index:
+                entrysize = int(int(strheap.cast(uint32p_t).dereference()) // 2)
+                if entrysize & 3:
+                    entrysize += 4 - (entrysize & 3)
+                strheap = strheap + (int(entrysize) + 4)
+                found_idx += 1
 
-        size_and_flag = int(strheap.cast(uint32p_t).dereference())
-        entrysize = size_and_flag // 2
+            size_and_flag = int(strheap.cast(uint32p_t).dereference())
+            entrysize = size_and_flag // 2
 
-        data = decode_utf8_in_stringheap(strheap + 4, entrysize)
-        return data
+            data = decode_utf8_in_stringheap(strheap + 4, entrysize)
+            return data
+        except gdb.MemoryError as ex:
+            return "<could not get string: " + str(ex) + ">"
     else:
-        return mvmstr_to_str(strp.dereference())
+        try:
+            return mvmstr_to_str(strp.dereference())
+        except gdb.MemoryError as ex:
+            return "<could not get string: " + str(ex) + ">"
 
 def resolve_annotation(sfb, offset, str_cache = None):
     num_anno = sfb["num_annotations"]

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -46,6 +46,7 @@
 # - Offer an HTML rendering of the stats, since gdb insists on printing
 #   a pager header right in between our pretty gen2 graphs most of the time
 
+from collections.abc import Mapping, Sequence, Set
 from enum import Enum
 import gdb
 from collections import defaultdict
@@ -1039,15 +1040,16 @@ class ArrayEntryRecordingBreakpoint(AutoResumingBreakpoint):
         return self
 
 class SQLRecordingBreakpoint(AutoResumingBreakpoint):
-    def __init__(self, medbc, table_name, exprs, *args):
+    def __init__(self, medbc, table_name : str, column_names : str, exprs : Sequence, *args):
         super(SQLRecordingBreakpoint, self).__init__(*args)
         self._medbc = medbc # MakeExecutionDatabaseCommand
         self._table_name = table_name
         self._exprs = exprs
         self._extras = None
+        self._column_expr = ', '.join([":" + n for n in column_names.split(" ")])
 
     def _hit_breakpoint_action(self):
-        created_event = self._medbc._register_event_sql(self._table_name, self._exprs)
+        created_event = self._medbc._register_event_sql(self._table_name, self._column_expr, self._exprs)
         if self._extras is not None:
             self._extras(created_event)
 
@@ -1068,7 +1070,15 @@ execution_db = None
 class MakeExecutionDatabaseCommand(gdb.Command):
     """Run execution from beginning to end, creating a database with interesting events.
 
-    Only makes sense to run inside a "rr replay" session."""
+    Only makes sense to run inside a "rr replay" session.
+
+    Possible arguments:
+
+      - notrackgc      Don't record every object's old and new addresses when doing GC
+    """
+
+    flags : Set[str]
+
     def __init__(self):
         super(MakeExecutionDatabaseCommand, self).__init__("moar rrdb", gdb.COMMAND_DATA)
 
@@ -1085,24 +1095,27 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     _prev_thread = None
     _prev_thread_str = None
 
-    def _register_event_sql(self, table_name, exprs):
+    def _register_event_sql(self, table_name, column_expr, exprs):
         rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
         rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
         rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
 
         row = {}
         for expr in exprs:
-            if isinstance(expr, list):
-                key, value = expr
-            elif isinstance(expr, typing.Callable):
-                key, value = expr()
-            row[key] = value
+            try:
+                if isinstance(expr, list):
+                    key, value = expr
+                elif isinstance(expr, typing.Callable):
+                    key, value = expr()
+                row[key] = value
+            except Exception:
+                print("when evaluating expr ", expr, " for table ", table_name)
+                raise
         row["rr_tick"] = rr_tick
         row["rr_event"] = rr_event
         row["rr_time"] = rr_time
 
-        colnames = ', '.join([":" + n for n in row.keys()])
-        query = f"INSERT INTO {table_name} VALUES ({colnames});"
+        query = f"INSERT INTO {table_name} VALUES ({column_expr});"
         self._db_cur.execute(query, row)
         self._db_conn.commit()
 
@@ -1128,7 +1141,9 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             #    self._object_movements[self._gc_seq_num] = array.array("Q")
 
             if prev is not None and prev // 20 != self._gc_seq_num // 20:
-                print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num)
+                rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
+                rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
+                print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num, " - time ", rr_time, " ticks: ", rr_tick)
                 #for s in self._db["subjects"]:
                 #    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
                 #if self._gc_seq_num == 60:
@@ -1240,18 +1255,18 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 bp.enabled = False
                 self._disabled_breakpoints.append(bp)
 
-        cbp.append(SQLRecordingBreakpoint(self, "gcs", [
+        cbp.append(SQLRecordingBreakpoint(self, "gcs", "tc rr_tick rr_event rr_time gc_seq_number is_full", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("gc_seq_number", "tc->instance->gc_seq_number", int),
             EXP.gdb_eval("is_full", "tc->instance->gc_full_collect", int),
             ], "run_gc"))
 
-        cbp.append(SQLRecordingBreakpoint(self, "compunits", [
+        cbp.append(SQLRecordingBreakpoint(self, "compunits", "tc rr_tick rr_event rr_time data_addr", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("data_addr", "cu->body.data_start", int),
             ], "run_comp_unit"))
 
-        cbp.append(SQLRecordingBreakpoint(self, "worklist_runs", [
+        cbp.append(SQLRecordingBreakpoint(self, "worklist_runs", "tc rr_tick rr_event rr_time nursery_alloc nursery_alloc_limit nursery_tospace nursery_fromspace", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("nursery_alloc", "tc->nursery_alloc", int),
             EXP.gdb_eval("nursery_alloc_limit", "tc->nursery_alloc_limit", int),
@@ -1259,10 +1274,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             EXP.gdb_eval("nursery_tospace", "tc->nursery_tospace", int),
             ], "process_worklist")._extra(store_seq_num))
 
-        gdb.execute("list process_worklist", False, True)
-        forwarder_update_lineno = gdb.execute("search item->sc_forward_u.forwarder = new_addr;", False, True).split("\t")[0]
+        if "notrackgc" not in self.flags:
+            gdb.execute("list process_worklist", False, True)
+            forwarder_update_lineno = gdb.execute("search item->sc_forward_u.forwarder = new_addr;", False, True).split("\t")[0]
 
-        cbp.append(ObjectMovementRecordingBreakpoint(self, "src/gc/collect.c:" + forwarder_update_lineno))
+            cbp.append(ObjectMovementRecordingBreakpoint(self, "src/gc/collect.c:" + forwarder_update_lineno))
+        else:
+            print("notrackgc passed. Will not record every object's old and new address.")
 
         #gdb.execute("list MVM_frame_dispatch", False, True)
         #dispatch_trampoline_lineno = gdb.execute("search MVM_jit_code_trampoline(tc);", False, True).split("\t")[0]
@@ -1281,13 +1299,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         gdb.execute("list MVM_spesh_candidate_add", False, True)
         free_speshcode_lineno = gdb.execute("search MVM_free.sc.;", False, True).split("\t")[0]
 
-        cbp.append(SQLRecordingBreakpoint(self, "spesh_bytecode", [
+        cbp.append(SQLRecordingBreakpoint(self, "spesh_bytecode", "rr_tick rr_event rr_time sf_addr bytecode_addr size", [
             EXP.gdb_eval("sf_addr", "p->sf", int),
-            EXP.gdb_eval("bytecode_addr", "sc->bytecode", int),
-            EXP.gdb_eval("size", "sc->bytecode_size", int),
+            EXP.gdb_eval("bytecode_addr", "candidate->body.bytecode", int),
+            EXP.gdb_eval("size", "candidate->body.bytecode_size", int),
             ], "src/6model/reprs/MVMSpeshCandidate.c:" + free_speshcode_lineno))
 
-        cbp.append(SQLRecordingBreakpoint(self, "staticframes", [
+        cbp.append(SQLRecordingBreakpoint(self, "staticframes", "rr_tick rr_event rr_time bytecode compunit_data_addr sf_addr cuuid name", [
             EXP.gdb_eval("bytecode", "static_frame->body.bytecode", int),
             EXP.gdb_eval("compunit_data_addr", "static_frame->body.cu->body.data_start", int),
             EXP.gdb_eval("sf_addr", "static_frame", int),
@@ -1318,6 +1336,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         #    ], "callstack.c:exit_frame"))
 
     def teardown(self):
+        print("Moar RRDB: Finished running. Tearing down breakpoints.")
         for bp in self._disabled_breakpoints:
             bp.enabled = True
         for bp in self._created_breakpoints:
@@ -1325,13 +1344,18 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
 
     def run(self):
+        print("Moar RRDB: Starting the run: Going back to the start ...")
         gdb.execute("start")
         # run to the temporary breakpoint that "start" creates
+        print("Moar RRDB: Running to temporary start breakpoint")
         gdb.execute("c")
         # run the program actually
+        print("Moar RRDB: Running the program for real ...")
         gdb.execute("c")
 
-    def invoke(self, arg, from_tty):
+    def invoke(self, argument, from_tty):
+        self.flags = set(argument.split(" "))
+        self.dont_repeat()
         self.setup()
         try:
             self.run()

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -947,9 +947,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
     _gc_seq_num = None
 
-    _db = None
-    _object_movements = {}
-
     class _EXP:
         tid = lambda _: ["tid", gdb.selected_thread().ptid_string]
         gdb_eval = lambda _, sub, code, pytype: lambda: [sub, pytype(gdb.parse_and_eval(code))]
@@ -958,57 +955,9 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     _prev_thread = None
     _prev_thread_str = None
 
-    def _register_event(self, event, exprs):
-        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
-        rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
-        rr_pos = str(rr_tick)
-        expr_data = dict(rre=rr_event, rrt=rr_tick, event=event)
-        for expr in exprs:
-            if isinstance(expr, list):
-                key, value = expr
-            elif isinstance(expr, typing.Callable):
-                key, value = expr()
-            expr_data[key] = value
-
-        before_del = expr_data.copy()
-
-        if expr_data["subject"]:
-            sk_data = self._db["subjects"][expr_data["subject_kind"]]
-            if expr_data["subject"] not in sk_data:
-                sk_data[expr_data["subject"]] = subjdata = dict(events=[])
-            else:
-                subjdata = sk_data[expr_data["subject"]]
-            subjdata["events"].append(before_del)
-
-        #for k in self._prev_tl_entry:
-        #    if k in expr_data and self._prev_tl_entry[k] == expr_data[k]:
-        #        del expr_data[k]
-
-        self._db["timeline"][rr_pos] = expr_data
-        self._prev_tl_entry = before_del
-
-        return before_del
-
-    def _register_event_array(self, table_name, exprs):
-        # rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
-        rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
-
-        table = self._db['subjects'][table_name]
-
-        for expr in exprs:
-            if isinstance(expr, list):
-                key, value = expr
-            elif isinstance(expr, typing.Callable):
-                key, value = expr()
-            table[key].append(value)
-        table["rr_tick"].append(rr_tick)
-
-        return None
-
     def _register_event_sql(self, table_name, exprs):
         rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
         rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
-        #print(rr_event, rr_tick)
 
         row = {}
         for expr in exprs:
@@ -1022,22 +971,12 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         colnames = ', '.join([":" + n for n in row.keys()])
         query = f"INSERT INTO {table_name} VALUES ({colnames});"
-        #print(query)
-        #print(row)
         self._db_cur.execute(query, row)
         self._db_conn.commit()
 
         return row
 
     def _register_object_movement(self):
-        #t = gdb.selected_thread()
-        #if t is self._prev_thread:
-        #    tid = self._prev_thread_str
-        #else:
-        #    tid = t.ptid_string
-        #    self._prev_thread = t
-        #    self._prev_thread_str = tid
-
         to_addr   = int(gdb.parse_and_eval("(uintptr_t)new_addr"))
         from_addr = int(gdb.parse_and_eval("(uintptr_t)item"))
 
@@ -1045,8 +984,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         self._db_cur.execute(query, (from_addr, to_addr))
         self._db_conn.commit()
 
-        #self._object_movements[self._gc_seq_num].append(from_addr)
-        #self._object_movements[self._gc_seq_num].append(to_addr)
 
     def setup(self):
         import sqlite3
@@ -1066,34 +1003,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 #    gdb.Breakpoint("MVM_frame_dispatch")
 
         print(time.strftime("%H:%M:%S"), " - starting")
-
-        #sfs_schema = pa.schema([
-        #    ('rr_tick', pa.uint64()),
-        #    ('addr', pa.uint64()),
-        #    ('compunit', pa.uint64()),
-        #    ('bytecode_addr', pa.uint64()),
-        #    ('event', pa.string()),
-        #    ])
-
-        #cus_schema = pa.schema([
-        #    ('rr_event', pa.uint64()),
-        #    ('addr', pa.uint64()),
-        #    ('mapped_addr', pa.uint64()),
-        #    ('event', pa.string()),
-        #    ])
-
-        #moves_schema = pa.schema([
-        #    ('gc_seq_nr', pa.uint32()),
-        #    ('pre_addr', pa.uint64()),
-        #    ('post_addr', pa.uint64()),
-        #    ])
-
-        #calls_schema = pa.schema([
-        #    ('rr_tick', pa.uint64()),
-        #    ('sf_addr', pa.uint64()),
-        #    ('bytecode_addr', pa.uint64()),
-        #    ('tc_addr', pa.uint64()),
-        #])
 
         self._db_file = tempfile.NamedTemporaryFile(prefix="moar-gdb-rrdb-", suffix=".sqlite3", delete=False)
         self._db_file.close()
@@ -1172,68 +1081,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         self._db_conn.commit()
 
-        #vus_tbl = {
-        #    "tc": array.array('Q'),
-        #    "rr_tick": array.array('Q'),
-        #    "data_addr": array.array('Q'),
-        #}
-
-        #sfs_tbl = {
-        #    "rr_tick": array.array('Q'),
-        #    "bytecode": array.array('Q'),
-        #    "compunit": array.array('Q'),
-        #    "sf": array.array('Q'),
-        #    "cuuid": [],
-        #    "name": [],
-        #}
-
-        #spesh_bytecode_tbl = {
-        #    "rr_tick": array.array('Q'),
-        #    "sf": array.array('Q'),
-        #    "bytecode": array.array('Q'),
-        #    "size": array.array('L'),
-        #}
-
-        #calls_tbl = {
-        #    "rr_tick": array.array('Q'),
-        #    "bytecode_addr": array.array('Q'),
-        #    "frame": array.array('Q'),
-        #}
-
-        #gcs_tbl = {
-        #    "tc": array.array('Q'),
-        #    "rr_tick": array.array('Q'),
-        #    "gc_seq_number": array.array('L'),
-        #    "is_full": array.array('B'),
-        #}
-
-        #worklist_runs_tbl = {
-        #    "tc": array.array('Q'),
-        #    "rr_tick": array.array('Q'),
-        #    "nursery_alloc": array.array('Q'),
-        #    "nursery_alloc_limit": array.array('Q'),
-        #    "nursery_fromspace": array.array('Q'),
-        #    "nursery_tospace": array.array('Q'),
-        #}
-
-
         EXP = self._EXP()
-        self._db = dict(
-            timeline={},
-            subjects=dict(
-                gcs=None,
-                sfs=None,
-                spesh_bytecode=None,
-                calls=None,
-                cus=None,
-                worklist_runs=None,
-            ),
-            object_movements={},
-        )
-        self._prev_tl_entry = {}
-        #self._object_movements = self._db["object_movements"]
-
-        execution_db = self._db
 
         self._disabled_breakpoints = []
         self._created_breakpoints = []
@@ -1342,11 +1190,124 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         finally:
             self.teardown()
 
-        #with tempfile.NamedTemporaryFile(mode="wb", prefix="moar_gdb_", suffix="_rrdb.pkl", delete=False) as ntf:
-        #    import pickle
-        #    pickle.dump(self._db, ntf)
-        #    ntf.close()
-        #    print("rrdb pickle file can be found at ", ntf.name)
+def find_tc():
+    frame = gdb.selected_frame()
+    found_tcs = []
+
+    while frame is not None:
+        tc_value = frame.read_var("tc")
+        if tc_value.is_optimized_out:
+            pass
+        elif int(tc_value) < 0xffffff:
+            # sometimes tc is 0x0, sometimes it's a random very low value
+            # this happens when the code is optimized to not have the tc
+            # immediately available at the exact spot we're at.
+            pass
+        else:
+            found_tcs.append(tc_value)
+
+        frame = frame.older()
+
+    #for tc in found_tcs:
+    #    print(" found a TC with value", hex(tc))
+
+    return found_tcs[0]
+
+def frame_effective_bytecode(frame):
+    spesh_cand = frame["spesh_cand"]
+    if int(spesh_cand) != 0:
+        if int(spesh_cand["body"]["jitcode"]) != 0:
+            return spesh_cand["body"]["jitcode"]["bytecode"]
+        return spesh_cand["body"]["bytecode"]
+    return frame["static_info"]["body"]["bytecode"]
+
+def string_from_cu(cu, index):
+    strp = cu["body"]["strings"][index]
+
+    uint32_t = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
+    uint32p_t = uint32_t.pointer()
+
+    if int(strp) == 0:
+        # not decoded yet, have to do it in here
+        strheap = cu["body"]["string_heap_start"]
+        found_idx = 0
+        while found_idx < index:
+            entrysize = int(int(strheap.cast(uint32p_t).dereference()) // 2)
+            if entrysize & 3:
+                entrysize += 4 - (entrysize & 3)
+            strheap = strheap + (int(entrysize) + 4)
+            found_idx += 1
+
+        size_and_flag = int(strheap.cast(uint32p_t).dereference())
+        entrysize = size_and_flag // 2
+
+        data = (strheap + 4).string("utf-8", "backslashreplace", entrysize)
+        return data
+    else:
+        return gdb.printing.make_visualizer(strp.dereference()).to_string()
+
+def resolve_annotation(sfb, offset):
+    if not (sfb["num_annotations"] > 0 and offset > 0 and offset < sfb["bytecode_size"]):
+        return (None, None)
+
+    uint32_t = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
+    uint32p_t = uint32_t.pointer()
+
+    ann_offs = 0
+    cur_anno = sfb["annotations_data"]
+    p_cur_anno = None
+    for i in range(0, sfb["num_annotations"]):
+        ann_offs = int(cur_anno.cast(uint32p_t).dereference())
+
+        if ann_offs > offset:
+            break
+
+        p_cur_anno = cur_anno
+        cur_anno += 12
+
+    if p_cur_anno is not None:
+        cur_anno = p_cur_anno
+
+    fnshi = int((cur_anno + 4).cast(uint32p_t).dereference())
+    ln    = int((cur_anno + 8).cast(uint32p_t).dereference())
+
+    fn = string_from_cu(sfb["cu"], fnshi)
+
+    return (fn, ln)
+
+class MoarBtCommands(gdb.Command):
+    """Commands to look at a moar-level backtrace."""
+    def __init__(self):
+        super(MoarBtCommands, self).__init__("moar bt", gdb.COMMAND_STACK, prefix=True)
+
+    def invoke(self, arg, from_tty):
+        tc = find_tc()
+
+        stack_idx = 0
+
+        cur_frame = tc["cur_frame"]
+        while int(cur_frame) != 0:
+            sfb = cur_frame["static_info"]["body"]
+
+            name = sfb["name"].dereference()
+
+            bc = frame_effective_bytecode(cur_frame)
+
+            if stack_idx == 0:
+                cur_op = tc["interp_cur_op"].dereference()
+            else:
+                cur_op = cur_frame["return_address"]
+
+            offs = int(cur_op) - int(bc)
+            fn, ln = resolve_annotation(sfb, offs)
+            if fn is not None and ln is not None:
+                print(cur_frame, name, fn, ":", ln)
+            else:
+                print(cur_frame, name, "<unknown>:1")
+
+            stack_idx += 1
+            cur_frame = cur_frame["caller"]
+
 
 def str_lookup_function(val):
     if str(val.type) == "MVMString":
@@ -1377,10 +1338,12 @@ commands = []
 def register_commands(objfile):
     commands.append(MoarCommands())
 
-    commands.append(AnalyzeHeapCommand())
-    print("command moar heap registered")
-    commands.append(DiffHeapCommand())
-    print("command moar diff-heap registered")
+    # currently the analyze and diff heap commands don't work
+    #commands.append(AnalyzeHeapCommand())
+    #print("command moar heap registered")
+    #commands.append(DiffHeapCommand())
+    #print("command moar diff-heap registered")
+
     commands.append(MakeExecutionDatabaseCommand())
     print("command moar rrdb registered")
 
@@ -1388,6 +1351,9 @@ def register_commands(objfile):
     commands.append(MoarBreakInterpRunCommands())
     commands.append(MoarBreakExceptionAdhoc())
     print("moar break commands registered")
+
+    commands.append(MoarBtCommands())
+    print("moar bt commands registered")
 
 # We have to introduce our classes to gdb so that they can be used
 if __name__ == "__main__":

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -3,11 +3,9 @@
 # GDB will automatically load this module when you attach to the binary moar.
 # but first you'll have to tell gdb that it's okay to load it. gdb will instruct
 # you on how to do that.
-# If it doesn't, you may need to copy or symlink this script right next to the
-# moar binary in install/bin.
-#
-#     cd /path/to/install/bin
-#     ln -s path/to/moarvm/tools/moar-gdb.py
+# The MoarVM Makefile puts libmoar.so-gdb.py next to the libmoar.so file, which
+# should cause GDB to find it and tell you if you need a setting to make it
+# actually activate.
 
 # If you're developing/extending/changing this script, or if you're getting
 # python exception messages, this command will be very helpful:
@@ -27,6 +25,7 @@
 #   snapshots of the nursery, or whatever snapshot number you supply
 #   as the argument.
 # - A group of commands "moar break" for commonly useful breakpoints.
+# - A command "moar bt" that shows a backtrace including each frame's arguments.
 
 # Here's the TODO list:
 #
@@ -52,16 +51,10 @@ from collections import defaultdict
 from itertools import chain
 import math
 import random
-#import blessings
 import sys
 import time
 import typing
-import array
-import struct
-import pathlib
 import tempfile
-
-import json
 
 import traceback # debugging
 
@@ -180,6 +173,13 @@ def prettify_size(num):
         result = rest + "." + result
     return result[:-1]
 
+#                  _   _                   _     _
+#     _ __ _ _ ___| |_| |_ _  _   _ __ _ _(_)_ _| |_ ___ _ _ ___
+#    | '_ \ '_/ -_)  _|  _| || | | '_ \ '_| | ' \  _/ -_) '_(_-<
+#    | .__/_| \___|\__|\__|\_, | | .__/_| |_|_||_\__\___|_| /__/
+#    |_|                   |__/  |_|
+
+
 def mvmstr_to_str(val, start=0, strlen=None, truncate=5000):
     stringtyp = str_t_info[int(val['body']['storage_type'])]
     if stringtyp in ("blob_32", "blob_ascii", "blob_8", "in_situ_8", "in_situ_32"):
@@ -199,6 +199,7 @@ def mvmstr_to_str(val, start=0, strlen=None, truncate=5000):
         for i in range(graphs):
             pdata = int(data[i])
             if pdata < 0:
+                # XXX synthetics currently not supported
                 pieces.append("\\s{-%x}" % (-pdata))
             else:
                 try:
@@ -212,18 +213,18 @@ def mvmstr_to_str(val, start=0, strlen=None, truncate=5000):
     elif stringtyp == "strands":
         data = val['body']['storage'][stringtyp]
         pieces = []
-        #print(f"building strands with {start=} {strlen=}")
         for p in range(val['body']['num_strands']):
+            # XXX probably a good idea to test thoroughly and see that nothing is off-by-one etc
             strand = data[p]
-            #print("strand ", p, "start", strand['start'], "end", strand['end'])
             graphs_one = int(strand['end']) - int(strand['start'])
             graphs_all = graphs_one
             if int(strand['repetitions']) > 0:
                 graphs_all = graphs_one * (int(strand['repetitions']) + 1)
 
+
+            # current strand is completely before the spot we're starting at
             if graphs_all < start:
                 start -= graphs_all
-                #print("skipping over this strand, start is now ")
                 continue
 
             str_one = mvmstr_to_str(strand['blob_string'])
@@ -252,17 +253,13 @@ class MVMStringPPrinter(object):
         self.val = val
         self.pointer = pointer
 
-    def stringify(self):
-        # stringtyp = str_t_info[int(self.val['body']['storage_type']) & 0b11]
-        return mvmstr_to_str(self.val)
-
     def to_string(self):
         result = self.stringify()
         if result:
             if self.pointer:
-                return "pointer to '" + self.stringify() + "'"
+                return "(MVMString *)'" + mvmstr_to_str(self.val) + "'"
             else:
-                return "'" + self.stringify() + "'"
+                return "(MVMString)'" + mvmstr_to_str(self.val) + "'"
         else:
             return None
 
@@ -291,6 +288,18 @@ class MVMObjectPPrinter(object):
             return "pointer to " + self.stringify()
         else:
             return self.stringify()
+
+#                                                _           _
+#      _ __  ___ _ __  ___ _ _ _  _   __ ___ _ _| |_ ___ _ _| |_
+#     | '  \/ -_) '  \/ _ \ '_| || | / _/ _ \ ' \  _/ -_) ' \  _|
+#     |_|_|_\___|_|_|_\___/_|  \_, | \__\___/_||_\__\___|_||_\__|
+#                              |__/
+#                     _         _
+#      __ _ _ _  __ _| |_  _ __(_)___
+#     / _` | ' \/ _` | | || (_-< (_-<
+#     \__,_|_||_\__,_|_|\_, /__/_/__/
+#                       |__/
+#
 
 def show_histogram(hist, sort="value", multiply=False):
     """In the context of this function, a histogram is a hash from an object
@@ -783,6 +792,12 @@ class HeapData(object):
 
 nursery_memory = []
 
+#                                                                    _
+#     _ __  ___ _ __  ___ _ _ _  _   __ ___ _ __  _ __  __ _ _ _  __| |___
+#    | '  \/ -_) '  \/ _ \ '_| || | / _/ _ \ '  \| '  \/ _` | ' \/ _` (_-<
+#    |_|_|_\___|_|_|_\___/_|  \_, | \__\___/_|_|_|_|_|_\__,_|_||_\__,_/__/
+#                             |__/
+
 class AnalyzeHeapCommand(gdb.Command):
     """Analyze the nursery and gen2 of MoarVM's garbage collector corresponding
     to the current tc, or the tc you pass as the first argument"""
@@ -843,6 +858,13 @@ class DiffHeapCommand(gdb.Command):
         assert len(nursery_memory) > max(pos1, pos2)
         nursery_memory[pos2].diff(nursery_memory[pos1])
 
+#                         _   _                                            _
+#     _____ _____ __ _  _| |_(_)___ _ _    __ ___ _ __  _ __  __ _ _ _  __| |___
+#    / -_) \ / -_) _| || |  _| / _ \ ' \  / _/ _ \ '  \| '  \/ _` | ' \/ _` (_-<
+#    \___/_\_\___\__|\_,_|\__|_\___/_||_| \__\___/_|_|_|_|_|_\__,_|_||_\__,_/__/
+#
+
+
 class MoarBreakCommands(gdb.Command):
     """Group of commands to set breakpoints at useful MoarVM functions."""
     _break_spec = ""
@@ -864,9 +886,11 @@ class MoarBreakExceptionAdhoc(MoarBreakCommands):
         super(MoarBreakCommands, self).__init__("moar break exception-adhoc", gdb.COMMAND_BREAKPOINTS)
         self._break_spec = "MVM_exception_throw_adhoc"
 
+#     __  __             __   ____  __   ___ ___ ___  ___
+#    |  \/  |___  __ _ _ \ \ / /  \/  | | _ \ _ \   \| _ )
+#    | |\/| / _ \/ _` | '_\ V /| |\/| | |   /   / |) | _ \
+#    |_|  |_\___/\__,_|_|  \_/ |_|  |_| |_|_\_|_\___/|___/
 #
-# moar rrdb implementation
-# ========================
 #
 # when running moar under `rr replay` we can make a little database of
 # interestang events, as well as information about objects by their address
@@ -1210,6 +1234,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         finally:
             self.teardown()
 
+#     _             _   _                                                     _
+#    | |__  __ _ __| |_| |_ _ _ __ _ __ ___   __ ___ _ __  _ __  __ _ _ _  __| |___
+#    | '_ \/ _` / _| / /  _| '_/ _` / _/ -_) / _/ _ \ '  \| '  \/ _` | ' \/ _` (_-<
+#    |_.__/\__,_\__|_\_\\__|_| \__,_\__\___| \__\___/_|_|_|_|_|_\__,_|_||_\__,_/__/
+#
+
+
 def find_tc():
     frame = gdb.selected_frame()
     found_tcs = []
@@ -1435,6 +1466,11 @@ class MoarBtCommands(gdb.Command):
             stack_idx += 1
             cur_frame = cur_frame["caller"]
 
+#                  _   _                   _     _
+#     _ __ _ _ ___| |_| |_ _  _   _ __ _ _(_)_ _| |_ ___ _ _ ___
+#    | '_ \ '_/ -_)  _|  _| || | | '_ \ '_| | ' \  _/ -_) '_(_-<
+#    | .__/_| \___|\__|\__|\_, | | .__/_| |_|_||_\__\___|_| /__/
+#    |_|                   |__/  |_|
 
 def str_lookup_function(val):
     if str(val.type) == "MVMString":
@@ -1489,7 +1525,9 @@ if __name__ == "__main__":
         try:
             the_objfile = gdb.lookup_objfile("libmoar.so")
         except:
-            print("GDB doesn't know about 'libmoar.so' yet; maybe you need to run the program a little until it's loaded.")
+            print("GDB doesn't know about 'libmoar.so' yet; maybe you need to run the program a little until it's loaded:")
+            print("    break MVM_interp_run")
+            print("    c")
     if the_objfile:
         register_printers(the_objfile)
     register_commands(the_objfile)

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -56,7 +56,12 @@ import time
 import typing
 import tempfile
 
+import gdb.printing
+
 import traceback # debugging
+
+uint32_t : gdb.Type | None
+uint32p_t : gdb.Type | None
 
 # These are the flags from MVMString's body.flags
 str_t_info = {0: 'blob_32',
@@ -245,7 +250,7 @@ def mvmstr_to_str(val, start=0, strlen=None, truncate=5000):
         else:
             return output
 
-class MVMStringPPrinter(object):
+class MVMStringPPrinter(gdb.printing.PrettyPrinter):
     """Whenever gdb encounters an MVMString or an MVMString*, this class gets
     instantiated and its to_string method tries its best to print out the
     actual contents of the MVMString's storage."""
@@ -254,14 +259,10 @@ class MVMStringPPrinter(object):
         self.pointer = pointer
 
     def to_string(self):
-        result = self.stringify()
-        if result:
-            if self.pointer:
-                return "(MVMString *)'" + mvmstr_to_str(self.val) + "'"
-            else:
-                return "(MVMString)'" + mvmstr_to_str(self.val) + "'"
+        if self.pointer:
+            return "(MVMString *)'" + mvmstr_to_str(self.val) + "'"
         else:
-            return None
+            return "(MVMString)'" + mvmstr_to_str(self.val) + "'"
 
 # currently nonfunctional
 class MVMObjectPPrinter(object):
@@ -871,7 +872,7 @@ class MoarBreakCommands(gdb.Command):
     def __init__(self):
         super(MoarBreakCommands, self).__init__("moar break", gdb.COMMAND_BREAKPOINTS, prefix=True)
 
-    def invoke(self, arg, from_tty):
+    def invoke(self, argument, from_tty):
         return gdb.Breakpoint(self._break_spec)
 
 class MoarBreakInterpRunCommands(MoarBreakCommands):
@@ -991,6 +992,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     def _register_event_sql(self, table_name, exprs):
         rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
         rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
+        rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
 
         row = {}
         for expr in exprs:
@@ -1001,6 +1003,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             row[key] = value
         row["rr_tick"] = rr_tick
         row["rr_event"] = rr_event
+        row["rr_time"] = rr_time
 
         colnames = ', '.join([":" + n for n in row.keys()])
         query = f"INSERT INTO {table_name} VALUES ({colnames});"
@@ -1049,6 +1052,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tc integer,
                 rr_tick integer,
                 rr_event integer,
+                rr_time float,
                 data_addr integer
             );
         """)
@@ -1057,6 +1061,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             create table staticframes (
                 rr_tick integer,
                 rr_event integer,
+                rr_time float,
                 bytecode integer,
                 compunit_data_addr integer,
                 sf_addr integer,
@@ -1069,6 +1074,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             create table spesh_bytecode (
                 rr_tick integer,
                 rr_event integer,
+                rr_time float,
                 sf_addr integer,
                 bytecode_addr integer,
                 size integer
@@ -1080,6 +1086,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tc integer,
                 rr_tick integer,
                 rr_event integer,
+                rr_time float,
                 gc_seq_number integer,
                 is_full integer
             );
@@ -1090,6 +1097,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tc integer,
                 rr_tick integer,
                 rr_event integer,
+                rr_time float,
                 nursery_alloc integer,
                 nursery_alloc_limit integer,
                 nursery_tospace integer,
@@ -1240,27 +1248,98 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 #    |_.__/\__,_\__|_\_\\__|_| \__,_\__\___| \__\___/_|_|_|_|_|_\__,_|_||_\__,_/__/
 #
 
+def can_read(val: gdb.Value):
+    try:
+        val.cast(uint32p_t).dereference()
+    except gdb.MemoryError:
+        return False
+    return True
+
+def can_read_path(val: gdb.Value, *path: str):
+    for step in path:
+        try:
+            val = val[step]
+            try:
+                val.cast(uint32p_t).dereference()
+            except gdb.error as ex:
+                print("harmless gdb error: ", ex)
+        except gdb.MemoryError:
+            return False
+    return True
+
+class EarlyAbortException(Exception):
+    pass
+
+def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
+    # Plausibility check, since arguments in backtraces are sometimes
+    # mangled when they are not explicitly stored in a way the debug
+    # symbols tell us ...
+
+    def deduct(n):
+        nonlocal score
+        score -= n
+        if score < -500:
+            raise EarlyAbortException("score bottomed out")
+
+    try:
+        if not can_read_path(tc, "thread_obj", "body"):
+            deduct(100)
+        else:
+            if int(tc["thread_obj"]["body"]["tc"]) != int(tc):
+                deduct(250)
+            if not (0 <= int(tc["thread_obj"]["body"]["stage"]) <= 6):
+                deduct(100)
+
+        if not can_read_path(tc, "instance", "main_thread"):
+            deduct(100)
+
+        if not can_read(tc["nursery_tospace"]):
+            deduct(200)
+        if not can_read(tc["nursery_alloc"]):
+            deduct(200)
+        if not can_read(tc["nursery_fromspace"]):
+            deduct(25)
+        if not can_read(tc["gen2"]):
+            deduct(100)
+        if int(tc["cur_frame"]) != 0 and not can_read_path(tc, "cur_frame", "static_info"):
+            deduct(150)
+
+    except EarlyAbortException:
+        return -math.inf
+
+    return score
+
 
 def find_tc():
     frame = gdb.selected_frame()
     found_tcs = []
 
+    # First, let's try the thread-local storage value
+    try:
+        tls_tc = gdb.parse_and_eval("MVM_running_threads_context")
+        # If there's no reason to doubt this tc is right, take it immediately
+        if is_tc_plausible(tls_tc) == 0:
+            return tls_tc
+        found_tcs.append(tls_tc)
+    except gdb.GdbError as ex:
+        print("Could not get TC from MVM_running_threads_context: ", ex)
+
+    addrs_seen = set()
+
     while frame is not None:
         tc_value = frame.read_var("tc")
         if tc_value.is_optimized_out:
             pass
-        elif int(tc_value) < 0xffffff:
-            # sometimes tc is 0x0, sometimes it's a random very low value
-            # this happens when the code is optimized to not have the tc
-            # immediately available at the exact spot we're at.
-            pass
         else:
-            found_tcs.append(tc_value)
+            if int(tc_value) not in addrs_seen:
+                found_tcs.append(tc_value)
+                addrs_seen.add(int(tc_value))
 
         frame = frame.older()
 
-    #for tc in found_tcs:
-    #    print(" found a TC with value", hex(tc))
+    tcs_by_score = sorted(found_tcs, lambda ts: is_tc_plausible(ts))
+    for tc in found_tcs:
+       print(" found a TC with value ", hex(tc), " with score ", is_tc_plausible(tc))
 
     return found_tcs[0]
 
@@ -1274,9 +1353,6 @@ def frame_effective_bytecode(frame):
 
 def string_from_cu(cu, index):
     strp = cu["body"]["strings"][index]
-
-    uint32_t = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
-    uint32p_t = uint32_t.pointer()
 
     if int(strp) == 0:
         # not decoded yet, have to do it in here
@@ -1295,14 +1371,11 @@ def string_from_cu(cu, index):
         data = (strheap + 4).string("utf-8", "backslashreplace", entrysize)
         return data
     else:
-        return gdb.printing.make_visualizer(strp.dereference()).stringify()
+        return gdb.printing.make_visualizer(strp.dereference()).to_string()
 
 def resolve_annotation(sfb, offset):
     if not (sfb["num_annotations"] > 0 and offset > 0 and offset < sfb["bytecode_size"]):
         return (None, None)
-
-    uint32_t = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
-    uint32p_t = uint32_t.pointer()
 
     ann_offs = 0
     cur_anno = sfb["annotations_data"]
@@ -1382,6 +1455,11 @@ class MoarBtCommands(gdb.Command):
         mvmstrp_t = mvmstr_t.pointer()
 
         cur_frame = tc["cur_frame"]
+        try:
+            int(cur_frame)
+        except gdb.MemoryError:
+            print("couldn't get cur_frame from the tc ...")
+
         while int(cur_frame) != 0:
             sfb = cur_frame["static_info"]["body"]
 
@@ -1459,12 +1537,17 @@ class MoarBtCommands(gdb.Command):
             csinfo_str = "args=(" + ", ".join(infoparts) + ")"
 
             if fn is not None and ln is not None:
-                print(cur_frame, name, csinfo_str, fn, ":", ln)
+                print(f"#{stack_idx}", cur_frame, name, csinfo_str, fn, ":", ln)
             else:
-                print(cur_frame, name, csinfo_str, "<unknown>:1")
+                print(f"#{stack_idx}", cur_frame, name, csinfo_str, "<unknown>:1")
 
             stack_idx += 1
             cur_frame = cur_frame["caller"]
+
+            try:
+                int(cur_frame)
+            except gdb.MemoryError:
+                print("couldn't get cur_frame from the tc ...")
 
 #                  _   _                   _     _
 #     _ __ _ _ ___| |_| |_ _  _   _ __ _ _(_)_ _| |_ ___ _ _ ___
@@ -1522,6 +1605,12 @@ def register_commands(objfile):
 if __name__ == "__main__":
     the_objfile = gdb.current_objfile()
     if the_objfile is None:
+        try:
+            uint32_t  = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
+            uint32p_t = uint32_t.pointer()
+        except gdb.error as ex:
+            print("Couldn't get MVMuint32 type!?", ex)
+
         try:
             the_objfile = gdb.lookup_objfile("libmoar.so")
         except:

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1088,6 +1088,17 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             );
         """)
 
+        self._db_cur.execute("""
+            create table meta_info (
+                key varchar,
+                value varchar
+            );
+        """)
+
+        self._db_cur.execute("""
+            insert into meta_info VALUES (:key, :value)
+        """, {"key":"info inferiors", "value": gdb.execute("info inferiors", False, True)})
+
         self._db_conn.commit()
 
         EXP = self._EXP()

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1754,12 +1754,14 @@ def resolve_annotation(sfb, offset):
 
     return (fn, ln)
 
-def parse_callsite(cs):
+def parse_callsite(cs : gdb.Value):
     num_flags = cs["flag_count"]
     flags = cs["arg_flags"]
 
     args = []
     name_idx = 0
+
+    arg_names = cs["arg_names"]
 
     for i in range(num_flags):
         flagvar = int(flags[i])
@@ -1769,7 +1771,7 @@ def parse_callsite(cs):
         namestr = None
 
         if flagvar & 32: # MVM_CALLSITE_ARG_NAMED
-            namestr = mvmstr_to_str(cs["arg_names"][name_idx])
+            namestr = mvmstr_to_str(arg_names[name_idx])
             name_idx += 1
 
         typname = ""
@@ -1912,7 +1914,7 @@ class MoarStackFrame:
 
         return resolve_annotation(sfb, offs)
 
-def extract_moar_stack_frame_args(cur_frame):
+def extract_moar_stack_frame_args(cur_frame, str_cache = None):
     # TODO extract to global scope and lookup on init
     stooge_t = gdb.lookup_symbol("MVMObjectStooge")[0].type.strip_typedefs()
     stoogep_t = stooge_t.pointer()
@@ -1920,7 +1922,12 @@ def extract_moar_stack_frame_args(cur_frame):
     mvmstrp_t = mvmstr_t.pointer()
 
     callsite = cur_frame.params["arg_info"]["callsite"]
-    csinfo = parse_callsite(callsite)
+    if str_cache is not None and int(callsite) in str_cache:
+        csinfo = str_cache[int(callsite)]
+    else:
+        csinfo = parse_callsite(callsite)
+        if str_cache is not None:
+            str_cache[int(callsite)] = csinfo
     param_vals = cur_frame.param_vals
 
     infoparts = []
@@ -1949,14 +1956,26 @@ def extract_moar_stack_frame_args(cur_frame):
                 is_concrete = True
 
             if is_obj:
-                reprname = subpart["st"]["REPR"]["name"].string()
-                if reprname == "P6str" and is_concrete:
+                if str_cache is not None and int(subpart["st"]) in str_cache:
+                    reprname = str_cache[int(subpart["st"])]
+                else:
+                    reprname = subpart["st"]["REPR"]["name"].string()
+                    if str_cache is not None:
+                        str_cache[int(subpart["st"])] = reprname
+
+                if is_concrete and reprname == "P6str":
                     #print("casting to p6str? before:")
                     #print(repr(subpart), repr(subpart.type))
                     subpart = subpart.cast(stoogep_t)["data"].cast(mvmstrp_t)
                     #print(repr(subpart), repr(subpart.type))
                     #print("trying to mvmstr_to_str this:", repr(mvmstr_to_str(subpart)))
-                    string_of_subpart = "((MVMString *)" + hex(int(subpart)) + ")=" + repr(mvmstr_to_str(subpart, truncate=128))
+                    if str_cache is not None and int(subpart) in str_cache:
+                        string_of_subpart = str_cache[int(subpart)]
+                    else:
+                        string_of_subpart = "((MVMString *)" + hex(int(subpart)) + ")=" + repr(mvmstr_to_str(subpart, truncate=128))
+                        if str_cache is not None:
+                            str_cache[int(subpart)] = string_of_subpart
+
                 elif int(subpart["st"]["debug_name"]) != 0:
                     typename = reprname + "#" + subpart["st"]["debug_name"].string()
                     if is_concrete:
@@ -1987,6 +2006,8 @@ class MoarBtCommands(gdb.Command):
         mvmstr_t = gdb.lookup_symbol("MVMString")[0].type
         mvmstrp_t = mvmstr_t.pointer()
 
+        str_cache = {}
+
         tc = find_tc()
         cur_frame : MoarStackFrame = MoarStackFrame.from_tc(tc)
 
@@ -1998,7 +2019,7 @@ class MoarBtCommands(gdb.Command):
             name = cur_frame.name
             fn, ln = cur_frame.resolve_annotation()
 
-            infoparts = extract_moar_stack_frame_args(cur_frame)
+            infoparts = extract_moar_stack_frame_args(cur_frame, str_cache)
 
             csinfo_str = "args=(" + ", ".join(infoparts) + ")"
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1649,6 +1649,14 @@ class MoarStackFrame:
                 self.params["arg_info"]["map"][i]
             ] for i in range(len(csinfo))]
 
+    @property
+    def cuuid(self):
+        return mvmstr_to_str(self.ptr["static_info"]["body"]["cuuid"])
+
+    @property
+    def cufile(self):
+        return mvmstr_to_str(self.ptr["static_info"]["body"]["cu"]["body"]["filename"])
+
     def resolve_annotation(self, offs : int | None = None):
         if offs is None:
             offs = self.bytecode_offs
@@ -1775,6 +1783,13 @@ def do_single_frame_command_stuff(cur_frame : MoarStackFrame, stack_idx = None):
 
     print(cur_frame.ptr)
     print(f"Name: {name} {loc}")
+    print(f"Bytecode file: {cur_frame.cufile} ; cuuid {cur_frame.cuuid}")
+    print("")
+    if cur_frame.caller is not None:
+        print(f"Caller: {cur_frame.caller.ptr}")
+    if cur_frame.outer is not None:
+        print(f"Outer: {cur_frame.outer.ptr}")
+
     print("Arguments:")
     for info in infoparts:
         print(f"  {info}")

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1727,7 +1727,7 @@ def string_from_cu(cu, index):
     else:
         return mvmstr_to_str(strp.dereference())
 
-def resolve_annotation(sfb, offset):
+def resolve_annotation(sfb, offset, str_cache = None):
     num_anno = sfb["num_annotations"]
     if not (num_anno >= 0 and offset >= 0 and offset < sfb["bytecode_size"]):
         return (None, None)
@@ -1750,7 +1750,13 @@ def resolve_annotation(sfb, offset):
     fnshi = int((cur_anno + 4).cast(uint32p_t).dereference())
     ln    = int((cur_anno + 8).cast(uint32p_t).dereference())
 
-    fn = string_from_cu(sfb["cu"], fnshi)
+    cu = sfb["cu"]
+    if str_cache is not None and (int(cu), fnshi) in str_cache:
+        fn = str_cache[(int(cu), fnshi)]
+    else:
+        fn = string_from_cu(cu, fnshi)
+        if str_cache is not None:
+            str_cache[(int(cu), fnshi)] = fn
 
     return (fn, ln)
 
@@ -1906,13 +1912,13 @@ class MoarStackFrame:
     def cufile(self):
         return mvmstr_to_str(self._static_info_body["cu"]["body"]["filename"])
 
-    def resolve_annotation(self, offs : int | None = None):
+    def resolve_annotation(self, offs : int | None = None, str_cache = None):
         if offs is None:
             offs = self.bytecode_offs
 
         sfb = self._static_info_body
 
-        return resolve_annotation(sfb, offs)
+        return resolve_annotation(sfb, offs, str_cache)
 
 def extract_moar_stack_frame_args(cur_frame, str_cache = None):
     # TODO extract to global scope and lookup on init
@@ -2016,8 +2022,14 @@ class MoarBtCommands(gdb.Command):
         output = []
 
         while cur_frame is not None:
-            name = cur_frame.name
-            fn, ln = cur_frame.resolve_annotation()
+            static_info = cur_frame.ptr["static_info"]
+            if int(static_info) in str_cache:
+                name = str_cache[int(static_info)]
+            else:
+                name = cur_frame.name
+                str_cache[int(static_info)] = name
+
+            fn, ln = cur_frame.resolve_annotation(None, str_cache)
 
             infoparts = extract_moar_stack_frame_args(cur_frame, str_cache)
 
@@ -2028,7 +2040,7 @@ class MoarBtCommands(gdb.Command):
             outer_str = ""
             if not name and (fn is None or ln is None):
                 outer_frame = cur_frame.outer
-                outer_fn, outer_ln = outer_frame.resolve_annotation(0)
+                outer_fn, outer_ln = outer_frame.resolve_annotation(0, str_cache)
                 outer_locstr = ""
                 if outer_fn is not None and outer_ln is not None:
                     outer_locstr = f" {fn}:{ln}"

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1399,6 +1399,12 @@ def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
             deduct(100)
         if int(tc["cur_frame"]) != 0 and not can_read_path(tc, "cur_frame", "static_info"):
             deduct(150)
+        if int(tc["num_finalize"]) > int(tc["alloc_finalize"]):
+            deduct(50)
+        if int(tc["num_temproots"]) > int(tc["alloc_temproots"]):
+            deduct(50)
+        if not (1024 < int(tc["nursery_fromspace_size"]) <= 4 * 4194304):
+            deduct(50)
 
     except EarlyAbortException:
         return -math.inf
@@ -1725,10 +1731,93 @@ class MoarBtCommands(gdb.Command):
             cur_frame = cur_frame.caller
             stack_idx += 1
 
+
+def do_single_frame_command_stuff(cur_frame : MoarStackFrame, stack_idx = None):
+    fn, ln = cur_frame.resolve_annotation()
+    infoparts = extract_moar_stack_frame_args(cur_frame)
+
+    name = cur_frame.name
+    name = "''" if name == "" else name
+
+    loc = ""
+
+    if fn is None or ln is None:
+        loc = f"{fn} : {ln}"
+    else:
+        loc = f"<unknown>:1"
+
+    if stack_idx is not None:
+        print(f"Stack Frame #{stack_idx}")
+
+    print(cur_frame.ptr)
+    print(f"Name: {name} {loc}")
+    print("Arguments:")
+    for info in infoparts:
+        print(f"  {info}")
+    print("")
+
+    csinfo = parse_callsite(cur_frame.params["arg_info"]["callsite"])
+    param_vals = cur_frame.param_vals
+
+    prev_margs_cnt = 0
+    unset_val = None
+    try:
+        prev_margs_cnt_val = gdb.parse_and_eval("$margs_cnt")
+        if prev_margs_cnt_val.type.name != "void":
+            prev_margs_cnt = int(prev_margs_cnt_val)
+        unset_val = gdb.parse_and_eval("$okay_so_hear_me_out_i_need_a_gdb_value_that_is_void_but_not_a_void_pointer_or_anything_and_i_dont_know_how_to_create_it_from_python_so_please_dont_put_anything_in_this_variable_thank_you")
+    except:
+        print("could not unset obsolete margs convenience vars")
+
+    gdb.set_convenience_variable("mframe", cur_frame.ptr)
+    print(f"var $mframe set to {cur_frame.ptr}")
+
+    gdb.set_convenience_variable("margs_cnt", len(csinfo))
+    print(f"var $margs_cnt set to {len(csinfo)}")
+    for i, csi in enumerate(csinfo):
+        # info = csinfo[i][0]
+        subpart  = csi[1](param_vals[i])
+
+        typename = csi[2][1]
+
+        if typename == "obj":
+            is_obj = False
+            is_concrete = False
+            flags1 = int(subpart["header"]["flags1"])
+            if flags1 & 2: # MVM_CF_STABLE
+                is_obj = False
+            elif flags1 & 1: # MVM_CF_TYPE_OBJECT
+                is_obj = True
+                is_concrete = False
+            elif flags1 & 4: # MVM_CF_FRAME
+                is_obj = False
+            else:
+                is_obj = True
+                is_concrete = True
+
+            if is_obj and is_concrete:
+                reprname = subpart["st"]["REPR"]["name"].string()
+                if reprname in repr_infos:
+                    typ = repr_infos[reprname]["struct"].pointer()
+                    subpart = subpart.cast(typ)
+
+        varname = f"margs_{i}"
+        gdb.set_convenience_variable(varname, subpart)
+        print(f"var ${varname} set to ({subpart.type}) {subpart}")
+
+    try:
+        for i in range(len(csinfo), prev_margs_cnt):
+            varname = f"margs_{i}"
+            gdb.set_convenience_variable(varname, unset_val)
+            print(f"var ${varname} unset")
+    except:
+        print("could not unset obsolete margs convenience vars")
+
+
 class MoarBtFrameCommand(gdb.Command):
     """Get all details of one stack frame on the moarvm stack"""
     def __init__(self):
-        super(MoarBtFrameCommand, self).__init__("moar bt frame", gdb.COMMAND_STACK)
+        super(MoarBtFrameCommand, self).__init__("moar bt frame", gdb.COMMAND_STACK, prefix=True)
 
     def invoke(self, argument, from_tty):
         stack_idx = None
@@ -1747,85 +1836,61 @@ class MoarBtFrameCommand(gdb.Command):
             if cur_frame is None:
                 print(f"Frame with index {evaled} could not be found; stack exhausted after {stack_idx} steps!")
 
-        fn, ln = cur_frame.resolve_annotation()
-        infoparts = extract_moar_stack_frame_args(cur_frame)
+        do_single_frame_command_stuff(cur_frame, stack_idx)
 
-        name = cur_frame.name
-        name = "''" if name == "" else name
 
-        loc = ""
+class MoarBtFrameUpCommand(gdb.Command):
+    """Get all details of the current moar stack frame's caller."""
+    def __init__(self):
+        super(MoarBtFrameUpCommand, self).__init__("moar bt frame up", gdb.COMMAND_STACK)
 
-        if fn is None or ln is None:
-            loc = f"{fn} : {ln}"
+    def invoke(self, argument, from_tty):
+        frame = gdb.parse_and_eval("$mframe")
+        if int(frame) != 0:
+            last_frame = MoarStackFrame(frame, frame, MoarStackFrame.Relation.MANUAL)
+            if last_frame.caller is None:
+                print("Last frame on the stack reached!")
+                self.dont_repeat()
+                return
+
+            do_single_frame_command_stuff(last_frame.caller)
         else:
-            loc = f"<unknown>:1"
+            raise ValueError("Convenience Variable $mframe doesn't seem to exist?")
 
-        if stack_idx is not None:
-            print(f"Stack Frame #{stack_idx}")
+class MoarBtFrameOutCommand(gdb.Command):
+    """Get all details of the current moar stack frame's outer."""
+    def __init__(self):
+        super(MoarBtFrameOutCommand, self).__init__("moar bt frame out", gdb.COMMAND_STACK)
 
-        print(cur_frame.ptr)
-        print(f"Name: {name} {loc}")
-        print("Arguments:")
-        for info in infoparts:
-            print(f"  {info}")
-        print("")
+    def invoke(self, argument, from_tty):
+        frame = gdb.parse_and_eval("$mframe")
+        if int(frame) != 0:
+            last_frame = MoarStackFrame(frame, frame, MoarStackFrame.Relation.MANUAL)
+            if last_frame.outer is None:
+                print("This frame has no more outers!")
+                self.dont_repeat()
+                return
 
-        csinfo = parse_callsite(cur_frame.params["arg_info"]["callsite"])
-        param_vals = cur_frame.param_vals
+            do_single_frame_command_stuff(last_frame.outer)
+        else:
+            raise ValueError("Convenience Variable $mframe doesn't seem to exist?")
 
-        prev_margs_cnt = 0
-        unset_val = None
-        try:
-            prev_margs_cnt_val = gdb.parse_and_eval("$margs_cnt")
-            if prev_margs_cnt_val.type.name != "void":
-                prev_margs_cnt = int(prev_margs_cnt_val)
-            unset_val = gdb.parse_and_eval("$okay_so_hear_me_out_i_need_a_gdb_value_that_is_void_but_not_a_void_pointer_or_anything_and_i_dont_know_how_to_create_it_from_python_so_please_dont_put_anything_in_this_variable_thank_you")
-        except:
-            print("could not unset obsolete margs convenience vars")
+class MoarTCCommand(gdb.Command):
+    """More-or-less reliably get the currently active thread's MVMThreadContext"""
+    def __init__(self):
+        super(MoarTCCommand, self).__init__("moar tc", gdb.COMMAND_STACK)
 
-        gdb.set_convenience_variable("mframe", cur_frame.ptr)
-        print(f"var $mframe set to {cur_frame.ptr}")
-
-        gdb.set_convenience_variable("margs_cnt", len(csinfo))
-        print(f"var $margs_cnt set to {len(csinfo)}")
-        for i, csi in enumerate(csinfo):
-            # info = csinfo[i][0]
-            subpart  = csi[1](param_vals[i])
-
-            typename = csi[2][1]
-
-            if typename == "obj":
-                is_obj = False
-                is_concrete = False
-                flags1 = int(subpart["header"]["flags1"])
-                if flags1 & 2: # MVM_CF_STABLE
-                    is_obj = False
-                elif flags1 & 1: # MVM_CF_TYPE_OBJECT
-                    is_obj = True
-                    is_concrete = False
-                elif flags1 & 4: # MVM_CF_FRAME
-                    is_obj = False
-                else:
-                    is_obj = True
-                    is_concrete = True
-
-                if is_obj and is_concrete:
-                    reprname = subpart["st"]["REPR"]["name"].string()
-                    if reprname in repr_infos:
-                        typ = repr_infos[reprname]["struct"].pointer()
-                        subpart = subpart.cast(typ)
-
-            varname = f"margs_{i}"
-            gdb.set_convenience_variable(varname, subpart)
-            print(f"var ${varname} set to ({subpart.type}) {subpart}")
+    def invoke(self, argument, from_tty):
+        tc = find_tc()
+        histval = gdb.add_history(tc)
 
         try:
-            for i in range(len(csinfo), prev_margs_cnt):
-                varname = f"margs_{i}"
-                gdb.set_convenience_variable(varname, unset_val)
-                print(f"var ${varname} unset")
+            gdb.execute(f"print ${histval}")
         except:
-            print("could not unset obsolete margs convenience vars")
+            pass
+
+        gdb.set_convenience_variable("TC", tc)
+        print(f"var $TC set to ({tc.type}) {tc}")
 
 #                  _   _                   _     _
 #     _ __ _ _ ___| |_| |_ _  _   _ __ _ _(_)_ _| |_ ___ _ _ ___
@@ -1878,7 +1943,12 @@ def register_commands(objfile):
 
     commands.append(MoarBtCommands())
     commands.append(MoarBtFrameCommand())
+    commands.append(MoarBtFrameUpCommand())
+    commands.append(MoarBtFrameOutCommand())
     print("moar bt commands registered")
+
+    commands.append(MoarTCCommand())
+    print("moar TC commands registered")
 
 # We have to introduce our classes to gdb so that they can be used
 if __name__ == "__main__":

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1585,6 +1585,9 @@ class MoarTimelineCommand(gdb.Command):
 #
 
 def can_read(val: gdb.Value):
+    """Attempt to read memory at the value's target address.
+
+    Returns True if it's valid, False otherwise."""
     try:
         val.cast(uint32p_t).dereference()
     except gdb.MemoryError:
@@ -1592,6 +1595,10 @@ def can_read(val: gdb.Value):
     return True
 
 def can_read_path(val: gdb.Value, *path: str):
+    """Given a value, try to follow a path of field accesses in a row.
+
+    Returns True if the final step can be followed, False if any step
+    was not a valid memory access."""
     for step in path:
         try:
             val = val[step]
@@ -1608,6 +1615,11 @@ class EarlyAbortException(Exception):
     pass
 
 def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
+    """Check if a gdb.Value of type MVMThreadContext * is plausible as
+    an actual MVMThreadContext, based on contents and its pointers.
+
+    Returns a plausibility score between 0 (plausible) and negative
+    infinity (definitely not plausible)"""
     # Plausibility check, since arguments in backtraces are sometimes
     # mangled when they are not explicitly stored in a way the debug
     # symbols tell us ...
@@ -1659,6 +1671,8 @@ def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
     return score
 
 def find_tc():
+    """For the selected frame, go through the stack as well as thread
+    local storage to find the most plausible value for the thread's TC"""
     frame = gdb.selected_frame()
     found_tcs = []
 
@@ -1692,6 +1706,7 @@ def find_tc():
     return found_tcs[0]
 
 def frame_effective_bytecode(frame):
+    """Mirrors moar's MVM_frame_effective_bytecode."""
     spesh_cand = frame["spesh_cand"]
     if int(spesh_cand) != 0:
         if int(spesh_cand["body"]["jitcode"]) != 0:
@@ -1700,9 +1715,12 @@ def frame_effective_bytecode(frame):
     return frame["static_info"]["body"]["bytecode"]
 
 def decode_utf8_in_stringheap(val, entrysize):
-    data = val.string("utf-8", "backslashreplace", entrysize)
+    return val.string("utf-8", "backslashreplace", entrysize)
 
 def string_from_cu(cu, index):
+    """Like MVM_cu_string, grab the string at the index from the
+    given MVMCompUnit.""""
+
     cub = cu["body"]
     strp = cub["strings"][index]
 
@@ -1746,6 +1764,7 @@ def string_from_cu(cu, index):
             return "<could not get string: " + str(ex) + ">"
 
 def resolve_annotation(sfb, offset, str_cache = None):
+    """Mirrors moar's MVM_bytecode_resolve_annotation"""
     num_anno = sfb["num_annotations"]
     if num_anno == 0:
         return (None, None)
@@ -1784,6 +1803,16 @@ def resolve_annotation(sfb, offset, str_cache = None):
     return (fn, ln)
 
 def parse_callsite(cs : gdb.Value):
+    """Given an MVMCallsite*, return information about the arguments:
+
+    [name if present, otherwise type name (obj/int/num/str/uint),
+    function to turn a MVMRegister* into the right value,
+    [name of argument or None,
+     type name,
+     flag value,
+     flag value masked to arg type]
+    ]"""
+
     num_flags = cs["flag_count"]
     flags = cs["arg_flags"]
 
@@ -1863,6 +1892,8 @@ class MoarStackFrame:
 
     @classmethod
     def from_tc(cls, tc : gdb.Value | None = None):
+        """Given an MVMThreadContext *, create a MoarStackFrame from
+        its cur_frame"""
         if tc is None:
             tc = find_tc()
 
@@ -1944,6 +1975,8 @@ class MoarStackFrame:
         return resolve_annotation(sfb, offs, str_cache)
 
 def extract_moar_stack_frame_args(cur_frame, str_cache = None):
+    """From a MoarStackFrame, parse the callsite and get a string with
+    information for each of the arguments and its values"""
     callsite = cur_frame.params["arg_info"]["callsite"]
     if str_cache is not None and int(callsite) in str_cache:
         csinfo = str_cache[int(callsite)]
@@ -2032,8 +2065,12 @@ def extract_moar_stack_frame_args(cur_frame, str_cache = None):
 
 class MoarBtCommands(gdb.Command):
     """Commands to look at a moar-level backtrace."""
+
     def __init__(self):
         super(MoarBtCommands, self).__init__("moar bt", gdb.COMMAND_STACK, prefix=True)
+
+    # Uncomment this version of invoke and rename the below one to invoke_
+    # to cProfile running it.
 
     # def invoke(self, argument, from_tty):
     #     import cProfile
@@ -2104,6 +2141,9 @@ class MoarBtCommands(gdb.Command):
 
 
 def do_single_frame_command_stuff(cur_frame : MoarStackFrame, stack_idx = None):
+    """Given a MoarStackFrame, output a load of information about it
+    to the terminal."""
+
     fn, ln = cur_frame.resolve_annotation()
     infoparts = extract_moar_stack_frame_args(cur_frame)
 
@@ -2284,6 +2324,7 @@ def str_lookup_function(val):
 
     return None
 
+# currently unused and probably unoperational
 def mvmobject_lookup_function(val):
     pointer = str(val.type).endswith("*")
     if str(val.type).startswith("MVM"):

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1095,10 +1095,11 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     _prev_thread = None
     _prev_thread_str = None
 
+    _last_saved_event_time = -1
+
     def _register_event_sql(self, table_name, column_expr, exprs):
         rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
         rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
-        rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
 
         row = {}
         for expr in exprs:
@@ -1113,10 +1114,16 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 raise
         row["rr_tick"] = rr_tick
         row["rr_event"] = rr_event
-        row["rr_time"] = rr_time
 
         query = f"INSERT INTO {table_name} VALUES ({column_expr});"
         self._db_cur.execute(query, row)
+
+        if rr_event != self._last_saved_event_time:
+            rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
+            query = f'INSERT INTO event_times VALUES (?, ?)';
+            self._db_cur.execute(query, (rr_event, rr_time))
+            self._last_saved_event_time = rr_event
+
         self._db_conn.commit()
 
         return row
@@ -1133,6 +1140,8 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     def setup(self):
         import sqlite3
 
+        self._last_saved_event_time = -1
+
         def store_seq_num(ev):
             prev = self._gc_seq_num
             self._gc_seq_num = int(gdb.parse_and_eval("tc->instance->gc_seq_number"))
@@ -1141,9 +1150,9 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             #    self._object_movements[self._gc_seq_num] = array.array("Q")
 
             if prev is not None and prev // 20 != self._gc_seq_num // 20:
-                rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
+                rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
                 rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
-                print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num, " - time ", rr_time, " ticks: ", rr_tick)
+                print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num, " - time ", rr_time, " event: ", rr_event)
                 #for s in self._db["subjects"]:
                 #    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
                 #if self._gc_seq_num == 60:
@@ -1163,7 +1172,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tc integer,
                 rr_tick integer,
                 rr_event integer,
-                rr_time float,
                 data_addr integer
             );
         """)
@@ -1172,7 +1180,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             create table staticframes (
                 rr_tick integer,
                 rr_event integer,
-                rr_time float,
                 bytecode integer,
                 compunit_data_addr integer,
                 sf_addr integer,
@@ -1185,7 +1192,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             create table spesh_bytecode (
                 rr_tick integer,
                 rr_event integer,
-                rr_time float,
                 sf_addr integer,
                 bytecode_addr integer,
                 size integer
@@ -1197,7 +1203,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tc integer,
                 rr_tick integer,
                 rr_event integer,
-                rr_time float,
                 gc_seq_number integer,
                 is_full integer
             );
@@ -1208,11 +1213,17 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tc integer,
                 rr_tick integer,
                 rr_event integer,
-                rr_time float,
                 nursery_alloc integer,
                 nursery_alloc_limit integer,
                 nursery_tospace integer,
                 nursery_fromspace integer
+            );
+        """)
+
+        self._db_cur.execute("""
+            create table event_times (
+                rr_event integer,
+                rr_time float
             );
         """)
 
@@ -1255,18 +1266,18 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 bp.enabled = False
                 self._disabled_breakpoints.append(bp)
 
-        cbp.append(SQLRecordingBreakpoint(self, "gcs", "tc rr_tick rr_event rr_time gc_seq_number is_full", [
+        cbp.append(SQLRecordingBreakpoint(self, "gcs", "tc rr_tick rr_event gc_seq_number is_full", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("gc_seq_number", "tc->instance->gc_seq_number", int),
             EXP.gdb_eval("is_full", "tc->instance->gc_full_collect", int),
             ], "run_gc"))
 
-        cbp.append(SQLRecordingBreakpoint(self, "compunits", "tc rr_tick rr_event rr_time data_addr", [
+        cbp.append(SQLRecordingBreakpoint(self, "compunits", "tc rr_tick rr_event data_addr", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("data_addr", "cu->body.data_start", int),
             ], "run_comp_unit"))
 
-        cbp.append(SQLRecordingBreakpoint(self, "worklist_runs", "tc rr_tick rr_event rr_time nursery_alloc nursery_alloc_limit nursery_tospace nursery_fromspace", [
+        cbp.append(SQLRecordingBreakpoint(self, "worklist_runs", "tc rr_tick rr_event nursery_alloc nursery_alloc_limit nursery_tospace nursery_fromspace", [
             EXP.gdb_eval("tc", "tc", int),
             EXP.gdb_eval("nursery_alloc", "tc->nursery_alloc", int),
             EXP.gdb_eval("nursery_alloc_limit", "tc->nursery_alloc_limit", int),
@@ -1299,13 +1310,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         gdb.execute("list MVM_spesh_candidate_add", False, True)
         free_speshcode_lineno = gdb.execute("search MVM_free.sc.;", False, True).split("\t")[0]
 
-        cbp.append(SQLRecordingBreakpoint(self, "spesh_bytecode", "rr_tick rr_event rr_time sf_addr bytecode_addr size", [
+        cbp.append(SQLRecordingBreakpoint(self, "spesh_bytecode", "rr_tick rr_event sf_addr bytecode_addr size", [
             EXP.gdb_eval("sf_addr", "p->sf", int),
             EXP.gdb_eval("bytecode_addr", "candidate->body.bytecode", int),
             EXP.gdb_eval("size", "candidate->body.bytecode_size", int),
             ], "src/6model/reprs/MVMSpeshCandidate.c:" + free_speshcode_lineno))
 
-        cbp.append(SQLRecordingBreakpoint(self, "staticframes", "rr_tick rr_event rr_time bytecode compunit_data_addr sf_addr cuuid name", [
+        cbp.append(SQLRecordingBreakpoint(self, "staticframes", "rr_tick rr_event bytecode compunit_data_addr sf_addr cuuid name", [
             EXP.gdb_eval("bytecode", "static_frame->body.bytecode", int),
             EXP.gdb_eval("compunit_data_addr", "static_frame->body.cu->body.data_start", int),
             EXP.gdb_eval("sf_addr", "static_frame", int),

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -55,6 +55,7 @@ from collections import defaultdict
 from itertools import chain
 import math
 import random
+import struct
 import sys
 import time
 import typing
@@ -1616,10 +1617,13 @@ def is_tc_plausible(tc: gdb.Value, depth : int = 0, score : int = 0):
         if not can_read_path(tc, "thread_obj", "body"):
             deduct(100)
         else:
-            if int(tc["thread_obj"]["body"]["tc"]) != int(tc):
-                deduct(250)
-            if not (0 <= int(tc["thread_obj"]["body"]["stage"]) <= 6):
-                deduct(100)
+            try:
+                if int(tc["thread_obj"]["body"]["tc"]) != int(tc):
+                    deduct(250)
+                if not (0 <= int(tc["thread_obj"]["body"]["stage"]) <= 6):
+                    deduct(100)
+            except gdb.MemoryError:
+                deduct(400)
 
         if not can_read_path(tc, "instance", "main_thread"):
             deduct(100)
@@ -1729,26 +1733,31 @@ def string_from_cu(cu, index):
 
 def resolve_annotation(sfb, offset, str_cache = None):
     num_anno = sfb["num_annotations"]
-    if not (num_anno >= 0 and offset >= 0 and offset < sfb["bytecode_size"]):
+    if num_anno == 0:
         return (None, None)
 
+    if not (offset >= 0 and offset < sfb["bytecode_size"]):
+        return (None, None)
+
+    # read entire annotation data ahead of time
+    entire_buf = gdb.selected_inferior().read_memory(sfb["annotations_data"], 12 * num_anno)
+
     ann_offs = 0
-    cur_anno = sfb["annotations_data"]
+
     p_cur_anno = None
-    for i in range(0, num_anno):
-        ann_offs = int(cur_anno.cast(uint32p_t).dereference())
+    for annot in struct.iter_unpack("HHH", entire_buf):
+        ann_offs = annot[0]
 
         if ann_offs > offset:
             break
 
-        p_cur_anno = cur_anno
-        cur_anno += 12
+        p_cur_anno = annot
 
-    if p_cur_anno is not None:
-        cur_anno = p_cur_anno
+    if p_cur_anno is None:
+        return (None, None)
 
-    fnshi = int((cur_anno + 4).cast(uint32p_t).dereference())
-    ln    = int((cur_anno + 8).cast(uint32p_t).dereference())
+    fnshi = p_cur_anno[1]
+    ln    = p_cur_anno[2]
 
     cu = sfb["cu"]
     if str_cache is not None and (int(cu), fnshi) in str_cache:

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -185,6 +185,101 @@ def prettify_size(num):
 #    | .__/_| \___|\__|\__|\_, | | .__/_| |_|_||_\__\___|_| /__/
 #    |_|                   |__/  |_|
 
+repr_infos = dict()
+
+def _first_found_type(candidates):
+    for c in candidates:
+        try:
+            return (c, gdb.lookup_type(c))
+        except gdb.error:
+            pass
+    raise ValueError(f"None of the candidates {candidates} could be found as a type by gdb")
+
+def init_repr_types_and_structs():
+    c_r_id = 0
+    repr_errors = []
+    def _ri(name : str, structname = None, reprdatastruct = None, repridname = None):
+        nonlocal c_r_id
+        try:
+            structnames = [name]
+            if structname is not None:
+                structnames.append(structname)
+            if not name.startswith("MVM"):
+                structnames.append("MVM" + name)
+            if not name.startswith("P6"):
+                structnames.append("MVM" + name)
+
+            structname, structtype = _first_found_type(structnames)
+
+            info = {
+                "name": name,
+                "reprid": c_r_id,
+                "struct": structtype,
+                "reprops": None, # TODO how best to find all the reprops structs?
+            }
+            if reprdatastruct is None:
+                reprdatastruct = f"{structname}REPRData"
+            if reprdatastruct is not False:
+                try:
+                    info["reprdatastruct"] = gdb.lookup_type(reprdatastruct)
+                except gdb.error:
+                    info["reprdatastruct"] = None
+            repr_infos[name] = info
+        except:
+            repr_errors.append(name)
+        c_r_id += 1
+
+    _ri("MVMString")
+    _ri("VMArray", "MVMArray", "MVMArrayREPRData")
+    _ri("MVMHash")
+    _ri("MVMCFunction")
+    _ri("KnowHOWREPR")
+    _ri("P6opaque")
+    _ri("MVMCode")
+    _ri("MVMOSHandle")
+    _ri("P6int")
+    _ri("P6num")
+    _ri("Uninstantiable")
+    _ri("HashAttrStore")
+    _ri("KnowHOWAttributeREPR")
+    _ri("P6str")
+    _ri("MVMThread")
+    _ri("MVMIter")
+    _ri("MVMContext")
+    _ri("SCRef")
+    _ri("MVMSpeshLog")
+    _ri("P6bigint")
+    _ri("NFA")
+    _ri("MVMException")
+    _ri("MVMStaticFrame")
+    _ri("MVMCompUnit")
+    _ri("MVMDLLSym")
+    _ri("MVMContinuation")
+    _ri("MVMNativeCall")
+    _ri("MVMCPointer")
+    _ri("MVMCStr")
+    _ri("MVMCArray")
+    _ri("MVMCStruct")
+    _ri("ReentrantMutex")
+    _ri("ConditionVariable")
+    _ri("Semaphore")
+    _ri("ConcBlockingQueue")
+    _ri("MVMAsyncTask")
+    _ri("MVMNull")
+    _ri("NativeRef")
+    _ri("MVMCUnion")
+    _ri("MultiDimArray")
+    _ri("MVMCPPStruct")
+    _ri("Decoder")
+    _ri("MVMStaticFrameSpesh")
+    _ri("MVMSpeshCandidate")
+    _ri("MVMCapture")
+    _ri("MVMTracked")
+    _ri("MVMStat")
+
+    print(f"Registered {len(repr_infos)} REPRs.")
+    if len(repr_errors):
+        print(f"... could not register these: {repr_errors}")
 
 def mvmstr_to_str(val, start=0, strlen=None, truncate=5000):
     stringtyp = str_t_info[int(val['body']['storage_type'])]
@@ -1686,9 +1781,32 @@ class MoarBtFrameCommand(gdb.Command):
             # info = csinfo[i][0]
             subpart  = csi[1](param_vals[i])
 
+            typename = csi[2][1]
+
+            if typename == "obj":
+                is_obj = False
+                is_concrete = False
+                flags1 = int(subpart["header"]["flags1"])
+                if flags1 & 2: # MVM_CF_STABLE
+                    is_obj = False
+                elif flags1 & 1: # MVM_CF_TYPE_OBJECT
+                    is_obj = True
+                    is_concrete = False
+                elif flags1 & 4: # MVM_CF_FRAME
+                    is_obj = False
+                else:
+                    is_obj = True
+                    is_concrete = True
+
+                if is_obj:
+                    reprname = subpart["st"]["REPR"]["name"].string()
+                    if reprname in repr_infos:
+                        typ = repr_infos[reprname]["struct"].pointer()
+                        subpart = subpart.cast(typ)
+
             varname = f"margs_{i}"
             gdb.set_convenience_variable(varname, subpart)
-            print(f"var ${varname} set to {subpart}")
+            print(f"var ${varname} set to ({subpart.type}) {subpart}")
 
         try:
             for i in range(len(csinfo), prev_margs_cnt):
@@ -1756,12 +1874,6 @@ if __name__ == "__main__":
     the_objfile = gdb.current_objfile()
     if the_objfile is None:
         try:
-            uint32_t  = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
-            uint32p_t = uint32_t.pointer()
-        except gdb.error as ex:
-            print("Couldn't get MVMuint32 type!?", ex)
-
-        try:
             the_objfile = gdb.lookup_objfile("libmoar.so")
         except:
             print("GDB doesn't know about 'libmoar.so' yet; maybe you need to run the program a little until it's loaded:")
@@ -1770,3 +1882,11 @@ if __name__ == "__main__":
     if the_objfile:
         register_printers(the_objfile)
     register_commands(the_objfile)
+
+    try:
+        uint32_t  = gdb.lookup_symbol("MVMuint32")[0].type.strip_typedefs()
+        uint32p_t = uint32_t.pointer()
+    except gdb.error as ex:
+        print("Couldn't get MVMuint32 type!?", ex)
+
+    init_repr_types_and_structs()

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -48,7 +48,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Mapping, Sequence, Set, Callable
 from enum import Enum
 import gdb
 from collections import defaultdict
@@ -1013,7 +1013,10 @@ class MoarBreakExceptionAdhoc(MoarBreakCommands):
 
 class AutoResumingBreakpoint(gdb.Breakpoint):
     def stop(self):
-        self._hit_breakpoint_action()
+        try:
+            self._hit_breakpoint_action()
+        except Exception:
+            pass
         return False # don't actually stop
 
 class PointInTimeRecordingBreakpoint(AutoResumingBreakpoint):
@@ -1067,6 +1070,16 @@ class SQLRecordingBreakpoint(AutoResumingBreakpoint):
     def _extra(self, _the_extra):
         self._extras = _the_extra
         return self
+
+class SQLRecordingBreakpointWithPrereq(SQLRecordingBreakpoint):
+    prereq : Callable
+    def stop(self):
+        try:
+            if self.prereq():
+                self._hit_breakpoint_action()
+        except Exception as ex:
+            print("error evaluating bp prereq: ", ex)
+        return False
 
 class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
     def __init__(self, medbc, *args):
@@ -1306,6 +1319,14 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             );
         """)
 
+        self._db_cur.execute("""
+            create table nfa_runs(
+                rr_tick integer,
+                rr_event integer,
+                offset integer,
+                string integer
+            );
+        """)
 
         self._db_cur.execute("""
             create table event_times (
@@ -1452,6 +1473,35 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         #    ["subject_kind", "frames"],
         #    EXP.gdb_eval("subject", "returner", int),
         #    ], "callstack.c:exit_frame"))
+
+        conn = gdb.connections()[0]
+        assert isinstance(conn, gdb.RemoteTargetConnection)
+
+        last_event = 0
+        records_this_event = 0
+        def nfa_prereq():
+            nonlocal last_event, records_this_event
+
+            currthreadptid = conn.send_packet("qC")
+            currthreadptid = int(currthreadptid[currthreadptid.rindex(b".") + 1:], 16)
+
+            resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+            rr_event = int(resp[resp.rindex(b' '):])
+
+            if last_event < rr_event or records_this_event < 10:
+                records_this_event += 1
+                last_event = rr_event
+                return True
+
+            return False
+
+        nfa_bp = SQLRecordingBreakpointWithPrereq(self, 'nfa_runs', "rr_tick rr_event offset string", [
+            EXP.local_var('offset', 'offset', int),
+            EXP.local_var('string', 'target', int),
+            ], 'nqp_nfa_run')
+        nfa_bp.prereq = nfa_prereq
+
+        cbp.append(nfa_bp)
 
     def teardown(self):
         print("Moar RRDB: Finished running. Tearing down breakpoints.")

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1719,7 +1719,7 @@ def decode_utf8_in_stringheap(val, entrysize):
 
 def string_from_cu(cu, index):
     """Like MVM_cu_string, grab the string at the index from the
-    given MVMCompUnit.""""
+    given MVMCompUnit."""
 
     cub = cu["body"]
     strp = cub["strings"][index]

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1697,20 +1697,64 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     def _register_object_movement(self):
         # If `trackgc` flag was turned on, store the before and after
         # addresses of any objects moved by the GC
-        to_addr   = int(gdb.parse_and_eval("(uintptr_t)new_addr"))
-        from_addr = int(gdb.parse_and_eval("(uintptr_t)item"))
-        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
+        frame = gdb.selected_frame()
 
-        if self._last_saved_movement_event != rr_event:
-            query = "INSERT INTO object_movements VALUES (?, ?, ?);"
-            self._db_cur.execute(query, (rr_event, from_addr, to_addr))
-            self._db_conn.commit()
-            self._last_saved_movement_event = rr_event
-        else:
-            query = "INSERT INTO object_movements VALUES (null, ?, ?);"
-            self._db_cur.execute(query, (from_addr, to_addr))
-            self._db_conn.commit()
+        conn = gdb.connections()[0]
+        assert isinstance(conn, gdb.RemoteTargetConnection)
 
+        currthreadptid = conn.send_packet("qC")
+        currthreadptid = int(currthreadptid[currthreadptid.rindex(b".") + 1:], 16)
+
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+        rr_event = int(resp[resp.rindex(b' '):])
+
+        scan_ptr  = frame.read_var("tc")["nursery_fromspace"]
+        limit_ptr = frame.read_var('limit')
+        if int(limit_ptr) == int(scan_ptr):
+            return
+
+        nursery_start_addr = int(scan_ptr)
+
+        nursery_memory = gdb.selected_inferior().read_memory(int(scan_ptr), int(limit_ptr) - int(scan_ptr))
+
+        coll_typ = gdb.lookup_type("struct MVMCollectable")
+        coll_typ_sz = coll_typ.sizeof
+        forwarder_valid = int(gdb.lookup_symbol("MVM_CF_FORWARDER_VALID")[0].value())
+
+        # scanned_items = 0
+        # recorded_items = 0
+
+        tuples = []
+
+        scan_idx = 0
+        while scan_idx < len(nursery_memory):
+            item_mem = nursery_memory[scan_idx:scan_idx + coll_typ_sz]
+            item = gdb.Value(item_mem, coll_typ)
+            if int(item["flags2"]) & forwarder_valid:
+                to_addr = int(item["sc_forward_u"]["forwarder"])
+                from_addr = nursery_start_addr + scan_idx
+
+                tuples.append((from_addr, to_addr))
+                # recorded_items += 1
+
+            # scanned_items += 1
+            item_sz = int(item["size"])
+            scan_idx += item_sz
+            if not item_sz:
+                raise ValueError("item with size 0 found?!")
+
+
+        query = "INSERT INTO object_movements VALUES (?, ?, ?, null, null);"
+        self._db_cur.execute(query, (rr_event, nursery_start_addr, int(limit_ptr)))
+
+        if tuples:
+            query = "INSERT INTO object_movements VALUES (null, null, null, ?, ?);"
+            self._db_cur.executemany(query, tuples)
+
+        self._db_conn.commit()
+
+        self._last_saved_movement_event = rr_event
+        # print(f"At event {rr_event}: Scanned {scanned_items:6d} items, recorded {recorded_items:6d} pairs")
 
     def setup(self):
         import sqlite3
@@ -1824,6 +1868,8 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             );
             create table object_movements (
                 rr_event integer,
+                start_addr integer,
+                end_addr integer,
                 to_addr integer,
                 from_addr integer
             );
@@ -1900,10 +1946,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             ], "process_worklist")._extra(store_seq_num))
 
         if "trackgc" in self.flags:
-            gdb.execute("list process_worklist", False, True)
-            forwarder_update_lineno = gdb.execute("search item->sc_forward_u.forwarder = new_addr;", False, True).split("\t")[0]
-
-            cbp.append(ObjectMovementRecordingBreakpoint(self, "src/gc/collect.c:" + forwarder_update_lineno))
+            cbp.append(ObjectMovementRecordingBreakpoint(self, "src/gc/collect.c:MVM_gc_collect_free_nursery_uncopied"))
         else:
             print("trackgc not passed. Will not record every object's old and new address.")
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1206,43 +1206,24 @@ class StackRecorder:
             assert frm[0].address is not None
             assert frm[1].address is not None
             frma = (int(frm[0].address), int(frm[1].address))
-            # try:
-                # print("addr: ", int(frm[0].address), " ", int(frm[1].address))
-            # except:
-                # print(frm)
 
             # Climb the tree of stack pieces
             try:
-                # print("1")
                 found = tree_pointer.piece_cur_ops.index(frma[0])
-                # print("2")
                 stack_piece_index = tree_pointer.pieces[found]
-                # print("3")
                 tree_pointer = self.stack_pieces[stack_piece_index]
-                # print("4")
                 # reused += 1
             except ValueError:
-                # print("5")
                 if frma[0] not in self.sfidx_by_cur_op:
-                    # print("6")
                     sfidx = len(self.sfidx_to_sfaddr)
-                    # print("7")
                     self.sfidx_by_cur_op[frma[0]] = sfidx
-                    # print("8")
                     self.sfidx_to_sfaddr.append(frm[1])
-                    # print(f"Inserted sfidx-to-sfaddr: {sfidx} -> {frma[1]} for cur_op {frma[0]}")
                 else:
-                    # print("9")
                     sfidx = self.sfidx_by_cur_op[frma[0]]
-                # print("10")
                 new_piece = StackRecorder.StackPiece()
-                # print("11")
                 stack_piece_index = len(self.stack_pieces)
-                # print("12")
                 tree_pointer.pieces.append(stack_piece_index)
-                # print("13")
                 self.stack_pieces.append(new_piece)
-                # print("14")
                 tree_pointer.piece_cur_ops.append(frma[0])
 
                 tree_pointer = new_piece
@@ -1256,7 +1237,6 @@ class StackRecorder:
         self.thread_of_sample[rr_event] = tid
 
         # print(f"reused {reused:3d} / {len(frames):3d} | stack pcs: {len(self.stack_pieces):4d} | cur ops: {len(self.sfidx_by_cur_op):4d} | samples {len(self.stack_piece_of_sample)}")
-        # print("bla")
 
     def dump_as_profile_file(self):
         print("... preparing profile json data ...")

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -46,6 +46,7 @@
 # - Offer an HTML rendering of the stats, since gdb insists on printing
 #   a pager header right in between our pretty gen2 graphs most of the time
 
+from sqlite3 import Connection
 from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Mapping, Sequence, Set, Callable
@@ -1089,7 +1090,26 @@ class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
     def _hit_breakpoint_action(self):
         self._medbc._register_object_movement()
 
-execution_db = None
+execution_db : Connection | None = None
+
+def ensure_execution_db() -> Connection:
+    """Try to open an execution db sqlite file if $moar_rrdb_file is set."""
+    global execution_db
+
+    if execution_db is None:
+        filename_maybe = gdb.parse_and_eval("$moar_rrdb_file")
+        # print(f"Can I load db from $moar_rrdb_file? ({filename_maybe})")
+        if str(filename_maybe) and str(filename_maybe) != "void" and Path(filename_maybe.string()).exists():
+            import sqlite3
+            print("Loading previous execution db from ", filename_maybe)
+            execution_db = sqlite3.connect(filename_maybe.string(), autocommit=False)
+            return execution_db
+        else:
+            print("No execution DB seems to exist. run `moar rrdb` first!")
+            print("(Or if you already have one, try `set $moar_rrdb_file = /tmp/...`)")
+            raise Exception("No execution db (from moar rrdb) seems to exist")
+
+    return execution_db
 
 def follow_fields(val : gdb.Value, fields : list[str]):
     for step in fields:
@@ -1117,13 +1137,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     _gc_seq_num = None
 
     class _EXP:
-        tid         = lambda _: lambda _: ["tid", gdb.selected_thread().ptid_string]
-        gdb_eval    = lambda _, sub, code, pytype: lambda _: [sub, pytype(gdb.parse_and_eval(code))]
-        local_var   = lambda _, sub, var_name, pytype: lambda frame: [sub, pytype(frame.read_var(var_name))]
-        local_field = lambda _, sub, var_name, steps, pytype: lambda frame: [sub, pytype(follow_fields(frame.read_var(var_name), steps))]
+        tid         = lambda _: lambda _, _2: ["tid", gdb.selected_thread().ptid_string]
+        gdb_eval    = lambda _, sub, code, pytype: lambda _, _2: [sub, pytype(gdb.parse_and_eval(code))]
+        local_var   = lambda _, sub, var_name, pytype: lambda frame, _: [sub, pytype(frame.read_var(var_name))]
+        local_field = lambda _, sub, var_name, steps, pytype: lambda frame, _: [sub, pytype(follow_fields(frame.read_var(var_name), steps))]
 
         def local_fields(cls, var_name, steps, fields, pytype):
-            def local_fields_impl(frame):
+            def local_fields_impl(frame, _):
                 val = frame.read_var(var_name)
                 for step in steps:
                     val = val[step]
@@ -1156,29 +1176,30 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         frame = gdb.selected_frame()
 
-        # rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
-        # rr_tick = 0
-        # rr_tick  = int(gdb.execute("when-ticks", False, True).replace("Current tick: ", "").replace("\n", ""))
-
         row = {}
+
+        row["rr_tick"] = rr_tick
+        row["rr_event"] = rr_event
+
+        # helpers for "extras" handlers
+        row["__frame"] = frame
+        row["__currthreadptid"] = currthreadptid
+
         for expr in exprs:
             try:
                 if isinstance(expr, list):
                     key, value = expr
                 elif isinstance(expr, typing.Callable):
-                    key, value = expr(frame)
+                    key, value = expr(frame, row)
 
                 if isinstance(key, str):
                     row[key] = value
                 else:
                     for i in range(len(key)):
                         row[key[i]] = value[i]
-            except Exception:
+            except Exception as ex:
                 print("when evaluating expr ", expr, " for table ", table_name)
-                raise
-
-        row["rr_tick"] = rr_tick
-        row["rr_event"] = rr_event
+                print(ex)
 
         query = f"INSERT INTO {table_name} VALUES ({column_expr});"
         self._db_cur.execute(query, row)
@@ -1192,10 +1213,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             self._last_saved_event_time = rr_event
 
         self._db_conn.commit()
-
-        # helpers for "extras" handlers
-        row["__frame"] = frame
-        row["__currthreadptid"] = currthreadptid
 
         return row
 
@@ -1298,6 +1315,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         """)
 
         self._db_cur.execute("""
+            create table gc_ends(
+                rr_tick integer,
+                rr_event integer
+            );
+        """)
+
+        self._db_cur.execute("""
             create table worklist_runs (
                 tc integer,
                 rr_tick integer,
@@ -1332,6 +1356,14 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             create table event_times (
                 rr_event integer,
                 rr_time float
+            );
+        """)
+
+        self._db_cur.execute("""
+            create table threadcontexts (
+                rr_event integer,
+                tc integer,
+                tid integer
             );
         """)
 
@@ -1375,12 +1407,25 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 bp.enabled = False
                 self._disabled_breakpoints.append(bp)
 
+        cbp.append(SQLRecordingBreakpoint(self, "threadcontexts", "rr_event tc tid", [
+            EXP.local_var("tc", "tc", int),
+            lambda _, row: ["tid", row["__currthreadptid"]],
+            ], "src/core/threads.c:thread_initial_invoke"))
+
+
         cbp.append(SQLRecordingBreakpoint(self, "gcs", "tc rr_tick rr_event gc_seq_number is_full", [
             EXP.local_var("tc", "tc", int),
             EXP.local_fields("tc", ["instance"],
                              [("gc_seq_number", "gc_seq_number"),
                               ("is_full", "gc_full_collect")], int),
             ], "run_gc"))
+
+
+        gdb.execute("list finish_gc", False, True)
+        finish_gc_orchestrator_signal_completed_lineno = gdb.execute("search uv_cond_broadcast(&tc->instance->cond_gc_completed);", False, True).split("\t")[0]
+
+        cbp.append(SQLRecordingBreakpoint(self, "gc_ends", "rr_tick rr_event", [
+            ], f"src/gc/orchestrate.c:{finish_gc_orchestrator_signal_completed_lineno}"))
 
         cbp.append(SQLRecordingBreakpoint(self, "compunits", "tc rr_tick rr_event data_addr", [
             EXP.local_var("tc", "tc", int),
@@ -1443,13 +1488,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event tag is_slice", [
             EXP.local_var("tc", "tc", int),
             EXP.local_var("tag", "tag", int),
-            lambda _: ["is_slice", 0],
+            lambda _, _2: ["is_slice", 0],
             ], "MVM_callstack_continuation_slice"))
 
         cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event tag is_slice", [
             EXP.local_var("tc", "tc", int),
             EXP.local_var("tag", "update_tag", int),
-            lambda _: ["is_slice", 1],
+            lambda _, _2: ["is_slice", 1],
             ], "MVM_callstack_continuation_append"))
 
         #cbp.append(SQLRecordingBreakpoint(self, "sc_code", [
@@ -1561,19 +1606,7 @@ class MoarTimelineCommand(gdb.Command):
         super(MoarTimelineCommand, self).__init__("moar timeline", gdb.COMMAND_STATUS)
 
     def invoke(self, argument, from_tty):
-        global execution_db
-
-        if execution_db is None:
-            filename_maybe = gdb.parse_and_eval("$moar_rrdb_file")
-            # print(f"Can I load db from $moar_rrdb_file? ({filename_maybe})")
-            if str(filename_maybe) and str(filename_maybe) != "void" and Path(filename_maybe.string()).exists():
-                import sqlite3
-                print("Loading previous execution db from ", filename_maybe)
-                execution_db = sqlite3.connect(filename_maybe.string(), autocommit=False)
-            else:
-                print("No execution DB seems to exist. run `moar rrdb` first!")
-                self.dont_repeat()
-                return
+        execution_db = ensure_execution_db()
 
         rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
         rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -46,10 +46,12 @@
 # - Offer an HTML rendering of the stats, since gdb insists on printing
 #   a pager header right in between our pretty gen2 graphs most of the time
 
+from symtable import Symbol
+from array import array
 from sqlite3 import Connection
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from collections.abc import Mapping, Sequence, Set, Callable
+from collections.abc import Mapping, Sequence, Set, Callable, Buffer
 from enum import Enum
 import gdb
 from collections import defaultdict
@@ -1090,6 +1092,384 @@ class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
     def _hit_breakpoint_action(self):
         self._medbc._register_object_movement()
 
+class StackRecorder:
+    @dataclass
+    class Func:
+        sfaddr : int
+        bcaddr : int
+
+    @dataclass
+    class StackPiece:
+        # frame  : int
+        pieces        : array = field(default_factory=lambda: array('L'))
+        piece_cur_ops : array = field(default_factory=lambda: array('Q'))
+
+    pid : int
+
+    func_by_sfaddr  : dict[int, int]
+    func_by_index   : list[Func]
+    stack_pieces    : list[StackPiece]
+
+    sfidx_by_cur_op  : dict[int, int]
+    sfidx_to_sfaddr  : list
+
+    stack_piece_of_sample: array
+    thread_of_sample : array
+
+    conn : Connection
+
+    def __init__(self, pid : int, conn : Connection):
+        self.pid = pid
+
+        self.func_by_sfaddr = dict()
+        self.func_by_index = list()
+        self.sfidx_by_cur_op = dict()
+        self.sfidx_to_sfaddr = list()
+
+        self.stack_pieces = [StackRecorder.StackPiece()]
+
+        self.stack_piece_of_sample = array('L')
+        self.thread_of_sample = array('Q')
+
+        self.conn = conn
+
+
+    def insert_stack_pieces(self, frames : Sequence[tuple[gdb.Value, gdb.Value]], rr_event : int, tid : int):
+        tree_pointer = self.stack_pieces[0]
+        stack_piece_index = 0
+
+        reused = 0
+
+        for frm in frames[::-1]:
+            assert frm[0] is not None
+            assert frm[1] is not None
+            assert frm[0].address is not None
+            assert frm[1].address is not None
+            frma = (int(frm[0].address), int(frm[1].address))
+            # try:
+                # print("addr: ", int(frm[0].address), " ", int(frm[1].address))
+            # except:
+                # print(frm)
+
+            try:
+                # print("1")
+                found = tree_pointer.piece_cur_ops.index(frma[0])
+                # print("2")
+                stack_piece_index = tree_pointer.pieces[found]
+                # print("3")
+                tree_pointer = self.stack_pieces[stack_piece_index]
+                # print("4")
+                reused += 1
+            except ValueError:
+                # print("5")
+                if frm[0].address not in self.sfidx_by_cur_op:
+                    # print("6")
+                    sfidx = len(self.sfidx_to_sfaddr)
+                    # print("7")
+                    self.sfidx_by_cur_op[frma[0]] = sfidx
+                    # print("8")
+                    self.sfidx_to_sfaddr.append(frm[1])
+                    # print(f"Inserted sfidx-to-sfaddr: {sfidx} -> {frma[1]} for cur_op {frma[0]}")
+                else:
+                    # print("9")
+                    sfidx = self.sfidx_by_cur_op[frma[0]]
+                # print("10")
+                new_piece = StackRecorder.StackPiece()
+                # print("11")
+                stack_piece_index = len(self.stack_pieces)
+                # print("12")
+                tree_pointer.pieces.append(stack_piece_index)
+                # print("13")
+                self.stack_pieces.append(new_piece)
+                # print("14")
+                tree_pointer.piece_cur_ops.append(frma[0])
+
+                tree_pointer = new_piece
+
+        while rr_event >= len(self.stack_piece_of_sample):
+            self.stack_piece_of_sample.append(0)
+            self.thread_of_sample.append(0)
+        self.stack_piece_of_sample[rr_event] = stack_piece_index
+        self.thread_of_sample[rr_event] = tid
+
+        print(f"done inserting; reused {reused:3d} out of {len(frames):3d}  |  stack pieces: {len(self.stack_pieces):4d}  |  cur ops: {len(self.sfidx_by_cur_op):4d}  |  stack piece of sample {len(self.stack_piece_of_sample)}  |  thread of sample {len(self.thread_of_sample)}")
+        # print("bla")
+
+    def dump_as_profile_file(self):
+        print("... preparing profile json data ...")
+        # For the FrameTable, look up index by address
+        frame_idx_by_cur_op : dict[int, int] = dict()
+        # Frame index to address, reverse of the above
+        cur_ops_for_frame_table : array = array('Q')
+
+        # First, turn the stack tree upside-down, yippie
+        parent_indices = list()
+        index_into_frame_array = array('L')
+
+        # FrameTable
+        # Lookup from frame to func
+        sfidx_to_func_index : dict[int, int] = dict()
+        # one entry per frame, points into the func array
+        index_into_func_array = array('L')
+        category_by_frame_idx = array('b')
+
+        # FuncTable
+        # one entry per func, points into the string array
+        name_indices_by_func = array('L')
+        resource_by_func = array('L')
+
+        # Resources (source files)
+        resource_idx_by_cu_addr : dict[int, int] = dict()
+        resource_name_by_idx = array('L')
+        resource_type_by_idx = array('b')
+
+        string_list = []
+
+        index_into_frame_array.append(0)
+
+        def traverse(index, parent=0):
+            piece : StackRecorder.StackPiece = self.stack_pieces[index]
+
+            # new value. starts out as 0
+            this_index = len(parent_indices)
+            # parent index of null means "root node"
+            parent_indices.append(parent)
+
+            for i in range(len(piece.pieces)):
+                child_piece_index : int = piece.pieces[i]
+                cur_op : int = piece.piece_cur_ops[i]
+
+                category_id = 0
+
+                # Make the new frames array entry as well
+                if cur_op not in frame_idx_by_cur_op:
+                    frame_entry_idx = len(frame_idx_by_cur_op)
+                    frame_idx_by_cur_op[cur_op] = frame_entry_idx
+                    cur_ops_for_frame_table.append(cur_op)
+
+                    # This may be the first time we've seen the sfidx for the
+                    # provided cur_op. If so, create a new entry in the
+                    # tables for FuncTable
+                    sfidx = self.sfidx_by_cur_op[cur_op]
+                    if sfidx not in sfidx_to_func_index:
+                        func_index = len(name_indices_by_func)
+
+                        name_of_frame = "error looking up frame name"
+                        try:
+                            sfaddr = self.sfidx_to_sfaddr[sfidx]
+                            name_of_frame = mvmstr_to_str(sfaddr["name"])
+                        except IndexError:
+                            print(f"Could not get addr at sfidx {sfidx} for addr {cur_op}")
+
+                        try:
+                            stridx = string_list.index(name_of_frame)
+                        except ValueError:
+                            stridx = len(string_list)
+                            string_list.append(name_of_frame)
+
+                        name_indices_by_func.append(stridx)
+                        index_into_func_array.append(func_index)
+                        sfidx_to_func_index[sfidx] = func_index
+
+                        cu_addr = int(sfaddr["cu"])
+                        if cu_addr not in resource_idx_by_cu_addr:
+                            cu_filename_ptr = sfaddr["cu"]["body"]["filename"]
+                            if int(cu_filename_ptr) != 0:
+                                try:
+                                    cu_filename = mvmstr_to_str(cu_filename_ptr)
+                                except:
+                                    cu_filename = "(error getting name)"
+                            else:
+                                cu_filename = "(unknown)"
+
+                            try:
+                                stridx = string_list.index(cu_filename)
+                            except ValueError:
+                                stridx = len(string_list)
+                                string_list.append(cu_filename)
+
+                            resource_idx_by_cu_addr[cu_addr] = len(resource_name_by_idx)
+                            resource_name_by_idx.append(stridx)
+
+                            if "runtime/CORE." in cu_filename:
+                                category_id = 2
+                            elif "share/nqp/lib" in cu_filename:
+                                category_id = 3
+                            elif "perl6/lib" in cu_filename:
+                                category_id = 4
+                            elif 'share/perl6' in cu_filename:
+                                category_id = 5
+                            else:
+                                category_id = 1
+
+                            print(f"added new category id into resource_type_by_idx at index {len(resource_type_by_idx)}")
+                            resource_type_by_idx.append(category_id)
+                        else:
+                            ridx = resource_idx_by_cu_addr[cu_addr]
+                            print(f"looking for category of resource idx {ridx} of cu addr {cu_addr}")
+                            category_id = resource_type_by_idx[ridx]
+
+                        resource_by_func.append(resource_idx_by_cu_addr[cu_addr])
+
+                    else:
+                        func_index = sfidx_to_func_index[sfidx]
+                        index_into_func_array.append(func_index)
+
+                else:
+                    frame_entry_idx = frame_idx_by_cur_op[cur_op]
+
+                    sfidx = self.sfidx_by_cur_op[cur_op]
+                    sfaddr = self.sfidx_to_sfaddr[sfidx]
+                    cu_addr = int(sfaddr["cu"])
+                    ridx = resource_idx_by_cu_addr[cu_addr]
+                    category_id = resource_type_by_idx[ridx]
+
+                category_by_frame_idx.append(category_id)
+                index_into_frame_array.append(frame_entry_idx)
+
+                # the new index child_piece_index is an index into the "old"
+                # stack pieces array. A new index will be created for it inside
+                # the call and the offset is calculated from that new index
+                # and "this_index" being the parent.
+                traverse(child_piece_index, this_index)
+
+        traverse(0, None)
+
+        print("... preparing samples ...")
+
+        all_tids = sorted(set(self.thread_of_sample))
+
+        stacks_per_thread = {tid: array('L') for tid in all_tids}
+        times_per_thread  = {tid: array('d') for tid in all_tids}
+
+        cur = self.conn.cursor();
+        cur.execute("select rr_event, rr_time from event_times;")
+        time_of_event = {e[0]: e[1] for e in cur.fetchall()}
+
+        for idx in range(len(self.thread_of_sample)):
+            tid = self.thread_of_sample[idx]
+            rr_event = idx
+
+            stacks_per_thread[tid].append(self.stack_piece_of_sample[idx])
+
+            times_per_thread[tid].append(time_of_event.get(rr_event, time_of_event.get(rr_event - 1, 0)) * 1000)
+
+
+        def samples_for_thread(tid):
+            return dict(
+                stack=list(stacks_per_thread[tid]),
+                time=list(times_per_thread[tid]),
+                weight=None,
+                weightType="samples",
+                length=len(stacks_per_thread[tid]),
+            )
+
+
+        threads = [dict(
+            processType="default",
+            processStartupTime=0,
+            processShutdownTime=None,
+            registerTime=0,
+            unregisterTime=None,
+            pausedRanges=[],
+            name="Raku frames!",
+            isMainThread=False,
+            pid=self.pid,
+            tid=str(tid) + ".raku",
+            samples=samples_for_thread(tid),
+            markers=dict(
+                data=[],
+                name=[],
+                startTime=[],
+                endTime=[],
+                phase=[],
+                category=[],
+                length=0,
+            ),
+        ) for tid in all_tids]
+
+        if len(index_into_frame_array) != len(parent_indices):
+            print(f"    !!!!  length mismatch for stackTable: {len(index_into_frame_array)} vs {len(parent_indices)}")
+
+        if len(cur_ops_for_frame_table) != len(index_into_func_array):
+            print(f"    !!!!  length mismatch for frameTable: {len(cur_ops_for_frame_table)} vs {len(index_into_func_array)}")
+
+        def cat(name, color):
+            return dict(name=name, color=color, subcategories=["Other"])
+
+        categories = [
+            cat("Other",    "grey"),
+            cat("User",   "yellow"),
+            cat("Core", "lightred"),
+            cat("NQP", "lightblue"),
+            cat("Rakudo", "maroon"),
+            cat("Modules", "green"),
+        ]
+
+        import json
+        print("... serializing data")
+        result = json.dumps(dict(
+            meta=dict(
+                interval=1000,
+                startTime=0,
+                processType=0,
+                product="moarvm rrdb",
+                stackwalk=1,
+                version=24,
+                preprocessedProfileVersion=60,
+                sourceCodeIsNotOnSearchfox=True,
+                markerSchema=[],
+                categories=categories,
+            ),
+            libs=[],
+            shared=dict(
+                stackTable=dict(
+                    frame=list(index_into_frame_array),
+                    prefix=list(parent_indices),
+                    length=len(index_into_frame_array)
+                ),
+                frameTable=dict(
+                    address=list(cur_ops_for_frame_table),
+                    length=len(cur_ops_for_frame_table),
+                    inlineDepth=[0] * len(cur_ops_for_frame_table),
+                    category=list(category_by_frame_idx),
+                    subcategory=[None] * len(cur_ops_for_frame_table),
+                    innerWindowID=[None] * len(cur_ops_for_frame_table),
+                    nativeSymbol=[None] * len(cur_ops_for_frame_table),
+                    line=[None] * len(cur_ops_for_frame_table),
+                    column=[None] * len(cur_ops_for_frame_table),
+                    func=list(index_into_func_array),
+                ),
+                funcTable=dict(
+                    name=list(name_indices_by_func),
+                    isJS=[False] * len(name_indices_by_func),
+                    relevantForJS=[False] * len(name_indices_by_func),
+                    resource=list(resource_by_func),
+                    source=[None] * len(name_indices_by_func),
+                    lineNumber=[None] * len(name_indices_by_func),
+                    columnNumber=[None] * len(name_indices_by_func),
+                    originalLocation=[None] * len(name_indices_by_func),
+                    length=len(name_indices_by_func),
+                ),
+                resourceTable=dict(
+                      length=len(resource_name_by_idx),
+                      lib=[None] * len(resource_name_by_idx),
+                      name=list(resource_name_by_idx),
+                      host=[0] * len(resource_name_by_idx),
+                      type=[0] * len(resource_name_by_idx),
+                ),
+                nativeSymbols=dict(),
+                stringArray=string_list,
+                sources=dict(),
+                sourceLocationTable=dict(),
+            ),
+            threads=threads,
+        ))
+
+        with open("rakudo_profile.json", "w") as f:
+            f.write(result)
+        print(f"Data written to rakudo_profile.json: {len(result)} bytes")
+
 execution_db : Connection | None = None
 
 def ensure_execution_db() -> Connection:
@@ -1130,6 +1510,8 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
     def __init__(self):
         super(MakeExecutionDatabaseCommand, self).__init__("moar rrdb", gdb.COMMAND_DATA)
+
+    stackrec : StackRecorder
 
     _disabled_breakpoints = None
     _created_breakpoints = None
@@ -1202,17 +1584,29 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 print(ex)
 
         query = f"INSERT INTO {table_name} VALUES ({column_expr});"
-        self._db_cur.execute(query, row)
+        try:
+            self._db_cur.execute(query, row)
 
-        if rr_event != self._last_saved_event_time:
-            resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
-            rr_time = float(resp[resp.rindex(b' ') + 1:])
+            if rr_event != self._last_saved_event_time:
+                resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
+                rr_time = float(resp[resp.rindex(b' ') + 1:])
 
-            query = f'INSERT INTO event_times VALUES (?, ?)';
-            self._db_cur.execute(query, (rr_event, rr_time))
-            self._last_saved_event_time = rr_event
+                query = f'INSERT INTO event_times VALUES (?, ?)';
+                self._db_cur.execute(query, (rr_event, rr_time))
+                self._last_saved_event_time = rr_event
 
-        self._db_conn.commit()
+                # Record a stack into the stack tree
+                to_insert = stack_for_stack_piece_inserter()
+                try:
+                    if to_insert:
+                        self.stackrec.insert_stack_pieces(to_insert, rr_event=rr_event, tid=currthreadptid)
+                except Exception as ex:
+                    print("could not insert stack pieces: ", ex)
+                    raise
+
+
+        finally:
+            self._db_conn.commit()
 
         return row
 
@@ -1268,6 +1662,8 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         self._db_file.close()
         self._db_conn = sqlite3.connect(self._db_file.name, autocommit=False, timeout=30)
         self._db_cur = self._db_conn.cursor()
+
+        self.stackrec = StackRecorder(gdb.inferiors()[0].pid, self._db_conn)
 
         print("")
         print("    sqlite3 file can be found at ", self._db_file.name)
@@ -1583,6 +1979,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 gdb.set_convenience_variable("moar_rrdb_file", self._db_file.name)
             except Exception as e:
                 print("Could not store the name of the rrdb file in convenience var :(", e)
+
+            # try:
+            self.stackrec.dump_as_profile_file()
+            # except Exception as ex:
+                # print("Error while trying to dump stackrec profile file :(")
+                # print(ex)
+
             self.teardown()
 
 @dataclass
@@ -2058,6 +2461,16 @@ class MoarStackFrame:
         sfb = self._static_info_body
 
         return resolve_annotation(sfb, offs, str_cache)
+
+def stack_for_stack_piece_inserter() -> Sequence[tuple[gdb.Value, gdb.Value]]:
+    bits = []
+    cur_frame : MoarStackFrame = MoarStackFrame.from_tc()
+
+    while cur_frame is not None:
+        bits.append((cur_frame.cur_op, cur_frame._static_info_body))
+        cur_frame = cur_frame.caller
+
+    return bits
 
 def extract_moar_stack_frame_args(cur_frame, str_cache = None):
     """From a MoarStackFrame, parse the callsite and get a string with

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1844,11 +1844,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
             Also output a short status line every 20 gc runs."""
             prev = self._gc_seq_num
-            # self._gc_seq_num = int(gdb.parse_and_eval("tc->instance->gc_seq_number"))
             self._gc_seq_num = int(ev["__frame"].read_var("tc")["instance"]["gc_seq_number"])
-
-            #if self._gc_seq_num not in self._object_movements:
-            #    self._object_movements[self._gc_seq_num] = array.array("Q")
 
             if prev is not None and prev // 20 != self._gc_seq_num // 20:
                 rr_event = ev["rr_event"]
@@ -1860,10 +1856,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 rr_time = float(resp[resp.rindex(b' ') + 1:])
 
                 print(time.strftime("%H:%M:%S"), f" - reached gc run {self._gc_seq_num:4d} - time {rr_time:7.3f} event: {rr_event}")
-                #for s in self._db["subjects"]:
-                #    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
-                #if self._gc_seq_num == 60:
-                #    gdb.Breakpoint("MVM_frame_dispatch")
 
         print(time.strftime("%H:%M:%S"), " - starting")
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1226,7 +1226,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(ev["__currthreadptid"])))
                 rr_time = float(resp[resp.rindex(b' ') + 1:])
 
-                print(time.strftime("%H:%M:%S"), " - reached gc run ", self._gc_seq_num, " - time ", rr_time, " event: ", rr_event)
+                print(time.strftime("%H:%M:%S"), f" - reached gc run {self._gc_seq_num:4d} - time {rr_time:7.3f} event: {rr_event}")
                 #for s in self._db["subjects"]:
                 #    print("            - ", s, " has ", len(list(self._db["subjects"][s].items())[0][1]), " entries")
                 #if self._gc_seq_num == 60:
@@ -1236,10 +1236,12 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         self._db_file = tempfile.NamedTemporaryFile(prefix="moar-gdb-rrdb-", suffix=".sqlite3", delete=False)
         self._db_file.close()
-        self._db_conn = sqlite3.connect(self._db_file.name, autocommit=False)
+        self._db_conn = sqlite3.connect(self._db_file.name, autocommit=False, timeout=30)
         self._db_cur = self._db_conn.cursor()
 
-        print("sqlite3 file can be found at ", self._db_file.name)
+        print("")
+        print("    sqlite3 file can be found at ", self._db_file.name)
+        print("")
 
         self._db_cur.execute("""
             create table compunits (
@@ -2378,6 +2380,29 @@ def register_commands(objfile):
     commands.append(MoarTCCommand())
     print("moar TC commands registered")
 
+def say_hello():
+    try:
+        if gdb.parse_and_eval('$moarvm_gdb_plugin_banner_shown') == 1:
+            return
+    except:
+        pass
+
+    print(r"""
+ __  __                __     ____  __    ____ ____  ____
+|  \/  | ___   __ _ _ _\ \   / /  \/  |  / ___|  _ \| __ )
+| |\/| |/ _ \ / _` | '__\ \ / /| |\/| | | |  _| | | |  _ \
+| |  | | (_) | (_| | |   \ V / | |  | | | |_| | |_| | |_) |
+|_|  |_|\___/ \__,_|_|    \_/  |_|  |_|  \____|____/|____/
+
+ ____  _             _         _                    _          _
+|  _ \| |_   _  __ _(_)_ __   | |    ___   __ _  __| | ___  __| |
+| |_) | | | | |/ _` | | '_ \  | |   / _ \ / _` |/ _` |/ _ \/ _` |
+|  __/| | |_| | (_| | | | | | | |__| (_) | (_| | (_| |  __/ (_| |
+|_|   |_|\__,_|\__, |_|_| |_| |_____\___/ \__,_|\__,_|\___|\__,_|
+               |___/
+        """)
+    gdb.set_convenience_variable("moarvm_gdb_plugin_banner_shown", 1)
+
 # We have to introduce our classes to gdb so that they can be used
 if __name__ == "__main__":
     the_objfile = gdb.current_objfile()
@@ -2406,3 +2431,5 @@ if __name__ == "__main__":
         print("Couldn't get types!?", ex)
 
     init_repr_types_and_structs()
+
+    say_hello()

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1138,7 +1138,7 @@ class StackRecorder:
         tree_pointer = self.stack_pieces[0]
         stack_piece_index = 0
 
-        reused = 0
+        # reused = 0
 
         for frm in frames[::-1]:
             assert frm[0] is not None
@@ -1159,7 +1159,7 @@ class StackRecorder:
                 # print("3")
                 tree_pointer = self.stack_pieces[stack_piece_index]
                 # print("4")
-                reused += 1
+                # reused += 1
             except ValueError:
                 # print("5")
                 if frm[0].address not in self.sfidx_by_cur_op:
@@ -1192,7 +1192,7 @@ class StackRecorder:
         self.stack_piece_of_sample[rr_event] = stack_piece_index
         self.thread_of_sample[rr_event] = tid
 
-        print(f"done inserting; reused {reused:3d} out of {len(frames):3d}  |  stack pieces: {len(self.stack_pieces):4d}  |  cur ops: {len(self.sfidx_by_cur_op):4d}  |  stack piece of sample {len(self.stack_piece_of_sample)}  |  thread of sample {len(self.thread_of_sample)}")
+        # print(f"reused {reused:3d} / {len(frames):3d} | stack pcs: {len(self.stack_pieces):4d} | cur ops: {len(self.sfidx_by_cur_op):4d} | samples {len(self.stack_piece_of_sample)}")
         # print("bla")
 
     def dump_as_profile_file(self):
@@ -1302,11 +1302,11 @@ class StackRecorder:
                             else:
                                 category_id = 1
 
-                            print(f"added new category id into resource_type_by_idx at index {len(resource_type_by_idx)}")
+                            # print(f"added new category id into resource_type_by_idx at index {len(resource_type_by_idx)}")
                             resource_type_by_idx.append(category_id)
                         else:
                             ridx = resource_idx_by_cu_addr[cu_addr]
-                            print(f"looking for category of resource idx {ridx} of cu addr {cu_addr}")
+                            # print(f"looking for category of resource idx {ridx} of cu addr {cu_addr}")
                             category_id = resource_type_by_idx[ridx]
 
                         resource_by_func.append(resource_idx_by_cu_addr[cu_addr])
@@ -1492,9 +1492,13 @@ def ensure_execution_db() -> Connection:
     return execution_db
 
 def follow_fields(val : gdb.Value, fields : list[str]):
-    for step in fields:
-        val = val[step]
-    return val
+    try:
+        for step in fields:
+            val = val[step]
+        return val
+    except Exception as ex:
+        print(f"error trying to get {fields} ", ex)
+        raise
 
 class MakeExecutionDatabaseCommand(gdb.Command):
     """Run execution from beginning to end, creating a database with interesting events.
@@ -1503,13 +1507,18 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
     Possible arguments:
 
-      - notrackgc      Don't record every object's old and new addresses when doing GC
+      - trackgc      Record every object's old and new addresses when doing GC
+      - deopt        Record whenever any frame hits a deopt one, deopt all, or lazy deopt.
     """
 
+    allowedflags : Set[str] = {"trackgc", "deopt"}
     flags : Set[str]
 
     def __init__(self):
         super(MakeExecutionDatabaseCommand, self).__init__("moar rrdb", gdb.COMMAND_DATA)
+
+    def complete(self, text, word):
+        return [f for f in self.allowedflags if f not in text and (word is None or f.startswith(word))]
 
     stackrec : StackRecorder
 
@@ -1533,7 +1542,11 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 res_vals = []
                 for (colname, fieldname) in fields:
                     res_keys.append(colname)
-                    res_vals.append(pytype(val[fieldname]))
+                    try:
+                        res_vals.append(pytype(val[fieldname]))
+                    except gdb.MemoryError:
+                        # print(f"Could not get value from field {fieldname} in {var_name}.{steps}")
+                        res_vals.append(None)
                 return res_keys, res_vals
             return local_fields_impl
 
@@ -1567,7 +1580,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         row["__frame"] = frame
         row["__currthreadptid"] = currthreadptid
 
-        for expr in exprs:
+        for expr_index, expr in enumerate(exprs):
             try:
                 if isinstance(expr, list):
                     key, value = expr
@@ -1580,12 +1593,15 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                     for i in range(len(key)):
                         row[key[i]] = value[i]
             except Exception as ex:
-                print("when evaluating expr ", expr, " for table ", table_name)
+                print("when evaluating expr ", expr_index, " ", expr, " for table ", table_name)
                 print(ex)
 
         query = f"INSERT INTO {table_name} VALUES ({column_expr});"
         try:
-            self._db_cur.execute(query, row)
+            try:
+                self._db_cur.execute(query, row)
+            except Exception as ex:
+                print("row not entered", ex)
 
             if rr_event != self._last_saved_event_time:
                 resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
@@ -1603,7 +1619,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 except Exception as ex:
                     print("could not insert stack pieces: ", ex)
                     raise
-
 
         finally:
             self._db_conn.commit()
@@ -1711,7 +1726,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         """)
 
         self._db_cur.execute("""
-            create table gc_ends(
+            create table gc_ends (
                 rr_tick integer,
                 rr_event integer
             );
@@ -1740,7 +1755,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         """)
 
         self._db_cur.execute("""
-            create table nfa_runs(
+            create table nfa_runs (
                 rr_tick integer,
                 rr_event integer,
                 offset integer,
@@ -1778,6 +1793,19 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 idx integer
             );
         """)
+
+        self._db_cur.execute("""
+            create table deopt (
+                tc integer,
+                rr_tick integer,
+                rr_event integer,
+                sf_addr integer,
+                cur_op integer,
+                cand_bc_addr integer,
+                deopt_idx integer
+            );
+        """)
+
 
         self._db_cur.execute("""
             create table meta_info (
@@ -1838,13 +1866,55 @@ class MakeExecutionDatabaseCommand(gdb.Command):
               ], int),
             ], "process_worklist")._extra(store_seq_num))
 
-        if "notrackgc" not in self.flags:
+        if "trackgc" in self.flags:
             gdb.execute("list process_worklist", False, True)
             forwarder_update_lineno = gdb.execute("search item->sc_forward_u.forwarder = new_addr;", False, True).split("\t")[0]
 
             cbp.append(ObjectMovementRecordingBreakpoint(self, "src/gc/collect.c:" + forwarder_update_lineno))
         else:
-            print("notrackgc passed. Will not record every object's old and new address.")
+            print("trackgc not passed. Will not record every object's old and new address.")
+
+        if 'deopt' in self.flags:
+            mbc_addr_str = gdb.execute("print/d &MAGIC_BYTECODE", False, True).splitlines()[0]
+            magic_bytecode_addr = int(mbc_addr_str[mbc_addr_str.find(" = ")+3:])
+            def addr_unless_its_magic_bytecode(v : gdb.Value):
+                cur_op_addr = v.dereference()
+                if int(cur_op_addr) == magic_bytecode_addr:
+                    return None
+                else:
+                    return int(cur_op_addr)
+
+            def tryint(v : gdb.Value):
+                try:
+                    return int(v)
+                except gdb.MemoryError:
+                    return None
+
+            cbp.append(SQLRecordingBreakpoint(self, "deopt", "tc rr_tick rr_event sf_addr cand_bc_addr cur_op deopt_idx", [
+                EXP.local_var("tc", "tc", int),
+                EXP.local_field("sf_addr", "tc", ["cur_frame", "static_info"], int),
+                EXP.local_field("cand_bc_addr", "tc", ["cur_frame", "spesh_cand", "body", "bytecode"], tryint),
+                EXP.local_field("cur_op", "tc", ["interp_cur_op"], addr_unless_its_magic_bytecode),
+                ["deopt_idx", None],
+                ], "MVM_spesh_deopt_during_unwind"))
+
+            cbp.append(SQLRecordingBreakpoint(self, "deopt", "tc rr_tick rr_event sf_addr cand_bc_addr cur_op deopt_idx", [
+                EXP.local_var("tc", "tc", int),
+                EXP.local_field("sf_addr", "tc", ["cur_frame", "static_info"], int),
+                EXP.local_field("cand_bc_addr", "tc", ["cur_frame", "spesh_cand", "body", "bytecode"], tryint),
+                EXP.local_field("cur_op", "tc", ["interp_cur_op"], addr_unless_its_magic_bytecode),
+                EXP.local_var("deopt_idx", "deopt_idx", int),
+                ], "MVM_spesh_deopt_one"))
+
+            cbp.append(SQLRecordingBreakpoint(self, "deopt", "tc rr_tick rr_event sf_addr cand_bc_addr cur_op deopt_idx", [
+                EXP.local_var("tc", "tc", int),
+                EXP.local_field("sf_addr", "tc", ["cur_frame", "static_info"], int),
+                EXP.local_field("cand_bc_addr", "tc", ["cur_frame", "spesh_cand", "body", "bytecode"], tryint),
+                EXP.local_field("cur_op", "tc", ["interp_cur_op"], addr_unless_its_magic_bytecode),
+                ["deopt_idx", None],
+                ], "MVM_spesh_deopt_all"))
+        else:
+            print("deoptnot passed. Will not record calls deopt functions.")
 
         #gdb.execute("list MVM_frame_dispatch", False, True)
         #dispatch_trampoline_lineno = gdb.execute("search MVM_jit_code_trampoline(tc);", False, True).split("\t")[0]
@@ -1865,6 +1935,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         cbp.append(SQLRecordingBreakpoint(self, "spesh_bytecode", "rr_tick rr_event sf_addr bytecode_addr size", [
             EXP.local_field("sf_addr", "p", ["sf"], int),
+            EXP.local_var("candidate", "candidate", int),
             EXP.local_fields("candidate", ["body"], [
                                  ["bytecode_addr", "bytecode"],
                                  ["size", "bytecode_size"]
@@ -1971,10 +2042,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             self.run()
         finally:
             try:
-                gdb.execute("info breakpoints")
-            except:
-                pass
-            try:
                 execution_db = self._db_conn
                 gdb.set_convenience_variable("moar_rrdb_file", self._db_file.name)
             except Exception as e:
@@ -1985,6 +2052,11 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             # except Exception as ex:
                 # print("Error while trying to dump stackrec profile file :(")
                 # print(ex)
+
+            print("")
+            print("    sqlite3 file can be found at ", self._db_file.name)
+            print("")
+
 
             self.teardown()
 

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -319,9 +319,18 @@ def mvmstr_to_str(val : gdb.Value, strlen=None, truncate=5000):
         data = val['body']['storage'][stringtyp]
         pieces = []
         graphs = int(val['body']['num_graphs'])
+
+        if graphs == 0:
+            return ""
+
         truncated = 0
 
-        graphs = graphs - start
+        elemtype = data.type.target()
+
+        memory = bytes(gdb.selected_inferior().read_memory(data, elemtype.sizeof * graphs))
+        arraytypecode = "b" if elemtype.sizeof == 1 else "i"
+        gdata = array(arraytypecode, memory)
+
         if strlen is not None and strlen > graphs:
             graphs = strlen
 
@@ -330,7 +339,7 @@ def mvmstr_to_str(val : gdb.Value, strlen=None, truncate=5000):
             graphs = truncate
 
         for i in range(graphs):
-            pdata = int(data[i])
+            pdata = int(gdata[i])
             if pdata < 0:
                 # XXX synthetics currently not supported
                 pieces.append("\\s{-%x}" % (-pdata))
@@ -346,6 +355,8 @@ def mvmstr_to_str(val : gdb.Value, strlen=None, truncate=5000):
     elif stringtyp == "strands":
         data = val['body']['storage'][stringtyp]
         pieces = []
+        start = 0
+
         for p in range(val['body']['num_strands']):
             # XXX probably a good idea to test thoroughly and see that nothing is off-by-one etc
             strand = data[p]
@@ -353,7 +364,6 @@ def mvmstr_to_str(val : gdb.Value, strlen=None, truncate=5000):
             graphs_all = graphs_one
             if int(strand['repetitions']) > 0:
                 graphs_all = graphs_one * (int(strand['repetitions']) + 1)
-
 
             # current strand is completely before the spot we're starting at
             if graphs_all < start:

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1691,9 +1691,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 rr_event integer,
                 data_addr integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table staticframes (
                 rr_tick integer,
                 rr_event integer,
@@ -1703,9 +1700,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 cuuid varchar,
                 name varchar
             );
-        """)
-
-        self._db_cur.execute("""
             create table spesh_bytecode (
                 rr_tick integer,
                 rr_event integer,
@@ -1713,9 +1707,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 bytecode_addr integer,
                 size integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table gcs (
                 tc integer,
                 rr_tick integer,
@@ -1723,16 +1714,10 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 gc_seq_number integer,
                 is_full integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table gc_ends (
                 rr_tick integer,
                 rr_event integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table worklist_runs (
                 tc integer,
                 rr_tick integer,
@@ -1742,9 +1727,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 nursery_tospace integer,
                 nursery_fromspace integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table continuation_events (
                 tc integer,
                 rr_tick integer,
@@ -1752,49 +1734,31 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tag integer,
                 is_slice boolean
             );
-        """)
-
-        self._db_cur.execute("""
             create table nfa_runs (
                 rr_tick integer,
                 rr_event integer,
                 offset integer,
                 string integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table event_times (
                 rr_event integer,
                 rr_time float
             );
-        """)
-
-        self._db_cur.execute("""
             create table threadcontexts (
                 rr_event integer,
                 tc integer,
                 tid integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table object_movements (
                 rr_event integer,
                 to_addr integer,
                 from_addr integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table sc_code (
                 sf_addr integer,
                 sc_addr integer,
                 idx integer
             );
-        """)
-
-        self._db_cur.execute("""
             create table deopt (
                 tc integer,
                 rr_tick integer,
@@ -1804,10 +1768,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 cand_bc_addr integer,
                 deopt_idx integer
             );
-        """)
 
-
-        self._db_cur.execute("""
             create table meta_info (
                 key varchar,
                 value varchar

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -46,7 +46,6 @@
 # - Offer an HTML rendering of the stats, since gdb insists on printing
 #   a pager header right in between our pretty gen2 graphs most of the time
 
-from symtable import Symbol
 from array import array
 from sqlite3 import Connection
 from dataclasses import dataclass, field
@@ -55,7 +54,6 @@ from collections.abc import Mapping, Sequence, Set, Callable, Buffer
 from enum import Enum
 import gdb
 from collections import defaultdict
-from itertools import chain
 import math
 import random
 import struct
@@ -1084,6 +1082,14 @@ class SQLRecordingBreakpointWithPrereq(SQLRecordingBreakpoint):
             print("error evaluating bp prereq: ", ex)
         return False
 
+class EventTimeAndStackBreakpoint(AutoResumingBreakpoint):
+    def __init__(self, medbc, *args):
+        super(EventTimeAndStackBreakpoint, self).__init__(*args)
+        self._medbc = medbc # MakeExecutionDatabaseCommand
+
+    def _hit_breakpoint_action(self):
+        self._medbc._register_event_time_and_stack_only()
+
 class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
     def __init__(self, medbc, *args):
         super(ObjectMovementRecordingBreakpoint, self).__init__(*args)
@@ -1092,7 +1098,17 @@ class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
     def _hit_breakpoint_action(self):
         self._medbc._register_object_movement()
 
+#  ____  _             _      ____                        _
+# / ___|| |_ __ _  ___| | __ |  _ \ ___  ___ ___  _ __ __| | ___ _ __
+# \___ \| __/ _` |/ __| |/ / | |_) / _ \/ __/ _ \| '__/ _` |/ _ \ '__|
+#  ___) | || (_| | (__|   <  |  _ <  __/ (_| (_) | | | (_| |  __/ |
+# |____/ \__\__,_|\___|_|\_\ |_| \_\___|\___\___/|_|  \__,_|\___|_|
+#
 class StackRecorder:
+    """Holds state about stacks of op addresses and their corresponding static
+    frame addresses in order to generate a Firefox Profiler UI compatible
+    file."""
+
     @dataclass
     class Func:
         sfaddr : int
@@ -1106,23 +1122,33 @@ class StackRecorder:
 
     pid : int
 
+    # Lookup dictionary from address of staticframe to index into the arrays of
+    # function properties
     func_by_sfaddr  : dict[int, int]
-    func_by_index   : list[Func]
+
+    # List of "stack pieces", where each has an array of child piece indices
+    # and an array of the cur_op addresses of these child pieces.
     stack_pieces    : list[StackPiece]
 
+    # Direct lookup from `cur_op` to the index of a static frame.
     sfidx_by_cur_op  : dict[int, int]
+    # List of static frame index to static frame object pointer.
     sfidx_to_sfaddr  : list
 
+    # Arrays of sample properties:
+
+    # Each sample's stack piece index
     stack_piece_of_sample: array
+    # Each sample's TID
     thread_of_sample : array
 
+    # sqlite3 database connection for looking up rr_event -> rr_time
     conn : Connection
 
     def __init__(self, pid : int, conn : Connection):
         self.pid = pid
 
         self.func_by_sfaddr = dict()
-        self.func_by_index = list()
         self.sfidx_by_cur_op = dict()
         self.sfidx_to_sfaddr = list()
 
@@ -1151,6 +1177,7 @@ class StackRecorder:
             # except:
                 # print(frm)
 
+            # Climb the tree of stack pieces
             try:
                 # print("1")
                 found = tree_pointer.piece_cur_ops.index(frma[0])
@@ -1162,7 +1189,7 @@ class StackRecorder:
                 # reused += 1
             except ValueError:
                 # print("5")
-                if frm[0].address not in self.sfidx_by_cur_op:
+                if frma[0] not in self.sfidx_by_cur_op:
                     # print("6")
                     sfidx = len(self.sfidx_to_sfaddr)
                     # print("7")
@@ -1189,6 +1216,8 @@ class StackRecorder:
         while rr_event >= len(self.stack_piece_of_sample):
             self.stack_piece_of_sample.append(0)
             self.thread_of_sample.append(0)
+        if self.thread_of_sample[rr_event] != 0:
+            print(f"wtf, thread of sample already had something for {rr_event}")
         self.stack_piece_of_sample[rr_event] = stack_piece_index
         self.thread_of_sample[rr_event] = tid
 
@@ -1314,6 +1343,8 @@ class StackRecorder:
                     else:
                         func_index = sfidx_to_func_index[sfidx]
                         index_into_func_array.append(func_index)
+                        ridx = resource_by_func[func_index]
+                        category_id = resource_type_by_idx[ridx]
 
                 else:
                     frame_entry_idx = frame_idx_by_cur_op[cur_op]
@@ -1338,6 +1369,7 @@ class StackRecorder:
         print("... preparing samples ...")
 
         all_tids = sorted(set(self.thread_of_sample))
+        print(f"   ... got samples for {len(all_tids)} TIDs")
 
         stacks_per_thread = {tid: array('L') for tid in all_tids}
         times_per_thread  = {tid: array('d') for tid in all_tids}
@@ -1346,13 +1378,22 @@ class StackRecorder:
         cur.execute("select rr_event, rr_time from event_times;")
         time_of_event = {e[0]: e[1] for e in cur.fetchall()}
 
+        dropped_samples = 0
         for idx in range(len(self.thread_of_sample)):
             tid = self.thread_of_sample[idx]
+            if tid == 0:
+                continue
+
             rr_event = idx
 
-            stacks_per_thread[tid].append(self.stack_piece_of_sample[idx])
+            try:
+                times_per_thread[tid].append(time_of_event[rr_event] * 1000)
+                stacks_per_thread[tid].append(self.stack_piece_of_sample[idx])
+            except KeyError:
+                dropped_samples += 1
 
-            times_per_thread[tid].append(time_of_event.get(rr_event, time_of_event.get(rr_event - 1, 0)) * 1000)
+        if dropped_samples:
+            print(f"   ... dropped {dropped_samples} out of {len(self.stack_piece_of_sample)} samples; have times for {len(time_of_event)} events")
 
 
         def samples_for_thread(tid):
@@ -1509,9 +1550,10 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
       - trackgc      Record every object's old and new addresses when doing GC
       - deopt        Record whenever any frame hits a deopt one, deopt all, or lazy deopt.
+      - stack        Take stack samples on every event.
     """
 
-    allowedflags : Set[str] = {"trackgc", "deopt"}
+    allowedflags : Set[str] = {"trackgc", "deopt", "stack"}
     flags : Set[str]
 
     def __init__(self):
@@ -1556,6 +1598,45 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
     _last_saved_event_time = -1
 
+    def _insert_time_and_take_stack(self, rr_event, currthreadptid, conn):
+        # If this is the firs time we see this rr_event time,
+        if rr_event > self._last_saved_event_time:
+            # Store the relative elapsed time in `event_times`
+            resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
+            rr_time  = float(resp[resp.rindex(b' ') + 1:])
+
+            query = f'INSERT INTO event_times VALUES (?, ?)';
+            self._db_cur.execute(query, (rr_event, rr_time))
+            self._last_saved_event_time = rr_event
+
+            # If stack sampling was requested, take a sample and put it in
+            # the stack recorder
+            if "stack" in self.flags:
+                # Record a stack into the stack tree
+                to_insert = stack_for_stack_piece_inserter()
+                try:
+                    if to_insert:
+                        self.stackrec.insert_stack_pieces(to_insert, rr_event=rr_event, tid=currthreadptid)
+                except Exception as ex:
+                    print("could not insert stack pieces: ", ex)
+                    raise
+
+    def _register_event_time_and_stack_only(self):
+        conn = gdb.connections()[0]
+        assert isinstance(conn, gdb.RemoteTargetConnection)
+
+        currthreadptid = conn.send_packet("qC")
+        currthreadptid = int(currthreadptid[currthreadptid.rindex(b".") + 1:], 16)
+
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+        rr_event = int(resp[resp.rindex(b' '):])
+
+        try:
+            self._insert_time_and_take_stack(rr_event, currthreadptid, conn)
+
+        finally:
+            self._db_conn.commit()
+
     def _register_event_sql(self, table_name, column_expr, exprs):
         conn = gdb.connections()[0]
         assert isinstance(conn, gdb.RemoteTargetConnection)
@@ -1598,27 +1679,13 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         query = f"INSERT INTO {table_name} VALUES ({column_expr});"
         try:
+            # Insert row into the database
             try:
                 self._db_cur.execute(query, row)
             except Exception as ex:
                 print("row not entered", ex)
 
-            if rr_event != self._last_saved_event_time:
-                resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
-                rr_time = float(resp[resp.rindex(b' ') + 1:])
-
-                query = f'INSERT INTO event_times VALUES (?, ?)';
-                self._db_cur.execute(query, (rr_event, rr_time))
-                self._last_saved_event_time = rr_event
-
-                # Record a stack into the stack tree
-                to_insert = stack_for_stack_piece_inserter()
-                try:
-                    if to_insert:
-                        self.stackrec.insert_stack_pieces(to_insert, rr_event=rr_event, tid=currthreadptid)
-                except Exception as ex:
-                    print("could not insert stack pieces: ", ex)
-                    raise
+            self._insert_time_and_take_stack(rr_event, currthreadptid, conn)
 
         finally:
             self._db_conn.commit()
@@ -1628,6 +1695,8 @@ class MakeExecutionDatabaseCommand(gdb.Command):
     _last_saved_movement_event = -1
 
     def _register_object_movement(self):
+        # If `trackgc` flag was turned on, store the before and after
+        # addresses of any objects moved by the GC
         to_addr   = int(gdb.parse_and_eval("(uintptr_t)new_addr"))
         from_addr = int(gdb.parse_and_eval("(uintptr_t)item"))
         rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
@@ -1649,6 +1718,10 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         self._last_saved_event_time = -1
 
         def store_seq_num(ev):
+            """After `process_worklist`, store the gc_sequence_number from
+            the MVMInstance in the self._gc_seq_num.
+
+            Also output a short status line every 20 gc runs."""
             prev = self._gc_seq_num
             # self._gc_seq_num = int(gdb.parse_and_eval("tc->instance->gc_seq_number"))
             self._gc_seq_num = int(ev["__frame"].read_var("tc")["instance"]["gc_seq_number"])
@@ -1684,7 +1757,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         print("    sqlite3 file can be found at ", self._db_file.name)
         print("")
 
-        self._db_cur.execute("""
+        self._db_cur.executescript("""
             create table compunits (
                 tc integer,
                 rr_tick integer,
@@ -1805,7 +1878,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                               ("is_full", "gc_full_collect")], int),
             ], "run_gc"))
 
-
         gdb.execute("list finish_gc", False, True)
         finish_gc_orchestrator_signal_completed_lineno = gdb.execute("search uv_cond_broadcast(&tc->instance->cond_gc_completed);", False, True).split("\t")[0]
 
@@ -1876,6 +1948,9 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 ], "MVM_spesh_deopt_all"))
         else:
             print("deoptnot passed. Will not record calls deopt functions.")
+
+        if "stack" in self.flags:
+            cbp.append(EventTimeAndStackBreakpoint(self, "syscall_hook_internal"))
 
         #gdb.execute("list MVM_frame_dispatch", False, True)
         #dispatch_trampoline_lineno = gdb.execute("search MVM_jit_code_trampoline(tc);", False, True).split("\t")[0]
@@ -2009,7 +2084,9 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 print("Could not store the name of the rrdb file in convenience var :(", e)
 
             # try:
-            self.stackrec.dump_as_profile_file()
+            if "stack" in self.flags:
+                self.stackrec.dump_as_profile_file()
+
             # except Exception as ex:
                 # print("Error while trying to dump stackrec profile file :(")
                 # print(ex)
@@ -2033,19 +2110,203 @@ class TimelineEntry:
     earliest_time: float | None
     latest_time: float | None
 
+class InvokeReturnTimelineRecordingBreakpoint(gdb.Breakpoint):
+    def __init__(self, conn, starting_event, relevant_ptid, mtlc, tc, what, *args):
+        super(InvokeReturnTimelineRecordingBreakpoint, self).__init__(*args)
+        self.conn = conn
+        assert isinstance(conn, gdb.RemoteTargetConnection)
+        self.relevant_ptid = relevant_ptid
+        self.starting_event = starting_event
+        self.mtlc = mtlc
+        self.tc = tc
+        self.what = what
+
+    def stop(self):
+        try:
+            return self.do_stop()
+        except Exception as ex:
+            print("in breakpoint stop impl: ", ex)
+        return True
+
+    def do_stop(self):
+        currthreadptid = self.conn.send_packet("qC")
+        currthreadptid = int(currthreadptid[currthreadptid.rindex(b".") + 1:], 16)
+
+        if currthreadptid != self.relevant_ptid:
+            print(f"Left current thread for breakpoint {self.location}")
+            return True
+
+        resp     = bytes.fromhex(self.conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+        rr_event = int(resp[resp.rindex(b' '):])
+
+        if not (self.starting_event - 2 <= rr_event <= self.starting_event + 2):
+        # if self.starting_event != rr_event:
+            print(f"Left current event for breakpoint {self.location}: {self.starting_event} vs {rr_event}")
+            return True
+
+        resp     = bytes.fromhex(self.conn.send_packet('qRRCmd:when-ticks:' + str(currthreadptid)))
+        rr_tick  = int(resp[resp.rindex(b' '):])
+
+        stack_depth = 0
+
+        funcname = None
+
+        if self.what == "invoke":
+            stack_depth += 1
+            invoked_sfb = gdb.selected_frame().read_var("code")["body"]["sf"]["body"]
+
+            funcname = mvmstr_to_str(invoked_sfb["name"])
+            if funcname == "":
+                funcname = f"({mvmstr_to_str(invoked_sfb["cuuid"])})"
+
+        cur_frame = MoarStackFrame.from_tc(self.tc)
+        if cur_frame is not None:
+            if funcname is None:
+                funcname = cur_frame.name
+                if funcname == "":
+                    funcname = f"({cur_frame.cuuid})"
+
+            while cur_frame is not None:
+                cur_frame = cur_frame.caller
+                stack_depth += 1
+        else:
+            if funcname is None:
+                funcname = "???"
+
+        self.mtlc.register_timeline_breakpoint(rr_event, rr_tick, self.what, funcname, stack_depth)
+
+        return False
+
+# class ContinuationEventTimelineRecordingBreakpoint(gdb.Breakpoint):
+#     def __init__(self, conn, starting_event, relevant_ptid, mtlc, tc, what, *args):
+#         super(ContinuationEventTimelineRecordingBreakpoint, self).__init__(*args)
+#         self.conn = conn
+#         assert isinstance(conn, gdb.RemoteTargetConnection)
+#         self.relevant_ptid = relevant_ptid
+#         self.starting_event = starting_event
+#         self.mtlc = mtlc
+#         self.tc = tc
+#         self.what = what
+
+#     def stop(self):
+#         try:
+#             return self.do_stop()
+#         except Exception as ex:
+#             print("in breakpoint stop impl: ", ex)
+#         return True
+
+#     def do_stop(self):
+#         currthreadptid = self.conn.send_packet("qC")
+#         currthreadptid = int(currthreadptid[currthreadptid.rindex(b".") + 1:], 16)
+
+#         if currthreadptid != self.relevant_ptid:
+#             print(f"Left current thread for breakpoint {self.location}")
+#             return True
+
+#         resp     = bytes.fromhex(self.conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+#         rr_event = int(resp[resp.rindex(b' '):])
+
+#         # if not (self.starting_event - 2 <= rr_event <= self.starting_event + 2):
+#         if self.starting_event != rr_event:
+#             print(f"Left current event for breakpoint {self.location}: {self.starting_event} vs {rr_event}")
+#             return True
+
+#         resp     = bytes.fromhex(self.conn.send_packet('qRRCmd:when-ticks:' + str(currthreadptid)))
+#         rr_tick  = int(resp[resp.rindex(b' '):])
+
+#         self.mtlc.register_timeline_breakpoint(rr_event, rr_tick, self.what, None, None)
+
+#         return False
+
+
 class MoarTimelineCommand(gdb.Command):
-    """Show recent and upcoming events from moar rrdb's execution db"""
+    """Show recent and upcoming events from moar rrdb's execution db
+
+    You can pass a number as the only argument to get more or fewer lines
+    around the current time, otherwise you get up to 18.."""
 
     flags : Set[str]
 
     def __init__(self):
         super(MoarTimelineCommand, self).__init__("moar timeline", gdb.COMMAND_STATUS)
 
+    def register_timeline_breakpoint(self, event, tick, thing, func, depth):
+        # print(f"registering timeline event: {event=} {tick=} {thing=} {func=} {depth=}")
+        self.found_entries.append((event, tick, thing, func, depth))
+
     def invoke(self, argument, from_tty):
+        pagination_before = gdb.execute("show pagination", False, True) == "State of pagination is on.\n"
+        gdb.execute("set pagination off", False, False)
+        try:
+            self.do_invoke(argument, from_tty)
+        finally:
+            if pagination_before:
+                gdb.execute("set pagination on", False, True)
+
+    def do_invoke(self, argument : str, from_tty):
+        if argument and argument.isdecimal():
+            event_limit = int(argument)
+            print(f"using {argument=} as the limit ({event_limit=})")
+        else:
+            event_limit = 18
+
+        conn = gdb.connections()[0]
+        assert isinstance(conn, gdb.RemoteTargetConnection)
+
+        tc = find_tc()
+
         execution_db = ensure_execution_db()
 
-        rr_event = int(gdb.execute("when", False, True).replace("Completed event: ", "").replace("\n", ""))
-        rr_time  = float(gdb.execute("elapsed-time", False, True).replace("Elapsed Time (s): ", "").replace("\n", ""))
+        self.found_entries = []
+
+        currthreadptid = conn.send_packet("qC")
+        currthreadptid = int(currthreadptid[currthreadptid.rindex(b".") + 1:], 16)
+
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+        rr_event = int(resp[resp.rindex(b' '):])
+
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when-ticks:' + str(currthreadptid)))
+        rr_tick  = int(resp[resp.rindex(b' '):])
+
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
+        rr_time  = float(resp[resp.rindex(b' ') + 1:])
+
+        chkp_res = gdb.execute("checkpoint", False, True)
+        chkp_id = chkp_res[len("Checkpoint "):chkp_res.find(" at ")]
+
+        try:
+            return_bp = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "return", "MVM_frame_try_return")
+            invoke_bp = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "invoke", "MVM_frame_dispatch")
+
+            # cont_contr_bp  = ContinuationEventTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_control", "MVM_continuation_control")
+            # cont_invoke_bp = ContinuationEventTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_invoke", "MVM_continuation_invoke")
+            cont_contr_bp  = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_control", "MVM_continuation_control")
+            cont_invoke_bp = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_invoke", "MVM_continuation_invoke")
+
+            gdb.execute(f"run {rr_event - 1}")
+
+            resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+            effective_rr_event = int(resp[resp.rindex(b' '):])
+            if effective_rr_event != rr_event - 1:
+                print(f"... Wanted to go to event {rr_event} so issued `run {rr_event - 1}`` but ended up on {effective_rr_event} instead...")
+                gdb.execute(f"run {rr_event - 2}")
+
+                resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
+                effective_rr_event = int(resp[resp.rindex(b' '):])
+                print(f"... Wanted to go to event {rr_event} so issued `run {rr_event - 2}`` but ended up on {effective_rr_event} instead...")
+
+            gdb.execute("continue")
+            gdb.execute(f"restart {chkp_id}")
+            gdb.execute(f"delete checkpoint {chkp_id}")
+        except Exception as ex:
+            print("Error trying to get invokes and returns for current event: ", ex)
+        finally:
+            return_bp.delete()
+            invoke_bp.delete()
+            cont_contr_bp.delete()
+            cont_invoke_bp.delete()
+
+        found_entries = [e for e in self.found_entries if e[0] == rr_event]
 
         try:
             cur = execution_db.cursor()
@@ -2088,7 +2349,94 @@ class MoarTimelineCommand(gdb.Command):
             for e in before:
                 gc_event_line(*e)
 
+            frame_events_before = [e for e in found_entries if e[1] < rr_tick]
+            frame_events_after  = [e for e in found_entries if e[1] >= rr_tick]
+
+            total_frame_events_before = len(frame_events_before)
+            total_frame_events_after  = len(frame_events_after)
+
+            few_frame_events_before = frame_events_before[-event_limit:]
+            few_frame_events_after  = frame_events_after [:event_limit]
+
+            if found_entries:
+                total_min_stack_depth = min([e[4] for e in found_entries])
+                min_stack_depth = min([e[4] for e in few_frame_events_before + few_frame_events_after])
+
+                lowest_depth_before = [e for e in frame_events_before if e[4] == total_min_stack_depth]
+                lowest_depth_after  = [e for e in frame_events_after  if e[4] == total_min_stack_depth]
+
+
+            # XXX: This grew organically and really, really, really wants a
+            # full rewrite ...
+            prev_invoke_event_line = (None, None, None, None, None)
+            def invoke_event_line(event, tick, thing, func, depth):
+                nonlocal prev_invoke_event_line
+                if prev_invoke_event_line[2] == "c.ctrl" and thing != "c.ctrl":
+                    # print(f"{event=} {tick=} {thing=} {func=} {depth=} prev: {prev_invoke_event_line=}")
+                    new_prev_line = list(prev_invoke_event_line)
+                    # new_prev_line[2] = "c.ctrl"
+                    # new_prev_line[4] = prev_invoke_event_line[4]
+                    old_prev_invoke_event_line = prev_invoke_event_line
+                    prev_invoke_event_line = tuple(new_prev_line)
+                    new_prev_line[4] = depth
+                    invoke_event_line(*new_prev_line)
+                    prev_invoke_event_line = old_prev_invoke_event_line
+
+                if thing == "invoke":
+                    lastmarker = "├─┬"
+                    # lastmarker = "├─┮"
+                elif thing == "return":
+                    lastmarker = "├─╯"
+                elif thing == "cont_control":
+                    lastmarker = f"control: prev depth {prev_invoke_event_line[4]} vs {depth}"
+                    thing   = "c.ctrl"
+                    # Terrible, terrible hack to attempt to print the line
+                    # again when we have the next line available, where we
+                    # can take the correct depth number
+                    prev_invoke_event_line = (event, tick, thing, func, depth)
+                    return
+                elif thing == "cont_invoke":
+                    lastmarker = f"invoke:  prev depth {prev_invoke_event_line[4]} vs {depth}"
+                    thing   = "c.invk"
+                elif thing == "c.ctrl":
+                    # print(f"making lastmarker: {event=} {tick=} {thing=} {func=} {depth=} prev: {prev_invoke_event_line=}")
+                    lastmarker = "├─" + "┴─" * (prev_invoke_event_line[4] - depth) + "╯"
+                else:
+                    lastmarker = "??? " + thing
+
+                if thing == "return" and func == prev_invoke_event_line[3] and depth == prev_invoke_event_line[4]:
+                    func_output = ""
+                else:
+                    func_output = " " + func
+
+                if depth >= min_stack_depth:
+                    depthmarker = "┊" * (min_stack_depth - total_min_stack_depth) + " " + "│ " * (depth - min_stack_depth) + lastmarker
+                else:
+                    depthmarker = "┊" * (depth - total_min_stack_depth)
+                print(f"{thing}:  {event:6d}.{tick:11d}  - {depthmarker}{func_output}")
+                prev_invoke_event_line = (event, tick, thing, func, depth)
+
+            if total_frame_events_before > len(few_frame_events_before):
+                print(f"{total_frame_events_before - len(few_frame_events_before)} invoke/return events omitted")
+
+            if found_entries and total_min_stack_depth != min_stack_depth and lowest_depth_before:
+                invoke_event_line(*lowest_depth_before[-1])
+                print("...")
+
+            for e in few_frame_events_before:
+                invoke_event_line(*e)
+
             print("you are here: ", rr_time, "        ", rr_event, " <-- you are here")
+
+            for e in few_frame_events_after:
+                invoke_event_line(*e)
+
+            if found_entries and total_min_stack_depth != min_stack_depth and lowest_depth_after:
+                print("...")
+                invoke_event_line(*lowest_depth_after[0])
+
+            if total_frame_events_after > len(few_frame_events_after):
+                print(f"{total_frame_events_after - len(few_frame_events_after)} invoke/return events omitted")
 
             for e in after:
                 gc_event_line(*e)
@@ -2412,7 +2760,7 @@ class MoarStackFrame:
         self._caller_obj = None
 
     @classmethod
-    def from_tc(cls, tc : gdb.Value | None = None):
+    def from_tc(cls, tc : gdb.Value | None = None) -> MoarStackFrame | None:
         """Given an MVMThreadContext *, create a MoarStackFrame from
         its cur_frame"""
         if tc is None:
@@ -2912,6 +3260,7 @@ def register_commands(objfile):
 def say_hello():
     try:
         if gdb.parse_and_eval('$moarvm_gdb_plugin_banner_shown') == 1:
+            print("MoarVM GDB Plugin re-loaded")
             return
     except:
         pass

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -126,6 +126,10 @@ array_storage_types = [
         'u64', 'u32', 'u16', 'u8'
         ]
 
+
+def array_code_for_bytesize(bytesize):
+    return [c for c in "BHILQ" if array(c).itemsize == bytesize][0]
+
 # These are used to display the hilbert curves extra-prettily.
 halfblocks = u"█▀▄ ░▒▓"
 
@@ -1725,8 +1729,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         return row
 
-    _last_saved_movement_event = -1
-
     def _register_object_movement(self):
         # If `trackgc` flag was turned on, store the before and after
         # addresses of any objects moved by the GC
@@ -1740,6 +1742,8 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
         resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
         rr_event = int(resp[resp.rindex(b' '):])
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when-ticks:' + str(currthreadptid)))
+        rr_tick  = int(resp[resp.rindex(b' '):])
 
         scan_ptr  = frame.read_var("tc")["nursery_fromspace"]
         limit_ptr = frame.read_var('limit')
@@ -1758,16 +1762,37 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         # recorded_items = 0
 
         tuples = []
+        froms = []
+        tos = []
+
+        min_to = math.inf
+        max_to = 0
+
+        largest_from_step = 0
 
         scan_idx = 0
+        prev_scan_idx = 0
         while scan_idx < len(nursery_memory):
             item_mem = nursery_memory[scan_idx:scan_idx + coll_typ_sz]
             item = gdb.Value(item_mem, coll_typ)
             if int(item["flags2"]) & forwarder_valid:
                 to_addr = int(item["sc_forward_u"]["forwarder"])
-                from_addr = nursery_start_addr + scan_idx
+                # from_addr = nursery_start_addr + scan_idx
 
-                tuples.append((from_addr, to_addr))
+                step_size = scan_idx - prev_scan_idx
+                froms.append(step_size)
+                prev_scan_idx = scan_idx
+
+                if step_size > largest_from_step:
+                    largest_from_step = step_size
+
+                tos.append(to_addr)
+                if to_addr < min_to:
+                    min_to = to_addr
+                if to_addr > max_to:
+                    max_to = to_addr
+
+                # tuples.append((to_addr, from_addr))
                 # recorded_items += 1
 
             # scanned_items += 1
@@ -1776,18 +1801,37 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             if not item_sz:
                 raise ValueError("item with size 0 found?!")
 
+        if tos:
+            tos = [to - min_to for to in tos]
+            array_bytesize = 8
+            if max_to - min_to < 0xff:
+                array_bytesize = 1
+            elif max_to - min_to < 0xffff:
+                array_bytesize = 2
+            elif max_to - min_to < 0xffffffff:
+                array_bytesize = 4
 
-        query = "INSERT INTO object_movements VALUES (?, ?, ?, null, null);"
-        self._db_cur.execute(query, (rr_event, nursery_start_addr, int(limit_ptr)))
+            tos_array = array(array_code_for_bytesize(array_bytesize), tos)
 
-        if tuples:
-            query = "INSERT INTO object_movements VALUES (null, null, null, ?, ?);"
-            self._db_cur.executemany(query, tuples)
+            array_bytesize = 8
+            if largest_from_step < 0xff:
+                array_bytesize = 1
+            elif largest_from_step < 0xffff:
+                array_bytesize = 2
+            elif largest_from_step < 0xffffffff:
+                array_bytesize = 4
 
-        self._db_conn.commit()
+            froms_array = array(array_code_for_bytesize(array_bytesize), froms)
 
-        self._last_saved_movement_event = rr_event
-        # print(f"At event {rr_event}: Scanned {scanned_items:6d} items, recorded {recorded_items:6d} pairs")
+            query = "INSERT INTO object_movements VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"
+            self._db_cur.execute(query, (
+                 rr_event, rr_tick,
+                 nursery_start_addr, int(limit_ptr),
+                 froms_array.itemsize, froms_array,
+                 min_to, max_to, tos_array.itemsize, tos_array
+            ))
+
+            self._db_conn.commit()
 
     def setup(self):
         import sqlite3
@@ -1913,10 +1957,15 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             );
             create table object_movements (
                 rr_event integer,
-                start_addr integer,
-                end_addr integer,
-                to_addr integer,
-                from_addr integer
+                rr_tick integer,
+                scan_start_addr integer,
+                scan_end_addr integer,
+                from_address_array_bytesize integer,
+                from_address_steps blob,
+                to_addr_offset integer,
+                to_addr_maximum integer,
+                to_address_array_bytesize integer,
+                to_addresses blob
             );
             create table sc_code (
                 sf_addr integer,

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -305,7 +305,12 @@ def init_repr_types_and_structs():
     if len(repr_errors):
         print(f"... could not register these: {repr_errors}")
 
-def mvmstr_to_str(val, start=0, strlen=None, truncate=5000):
+def mvmstr_to_str(val : gdb.Value, strlen=None, truncate=5000):
+    its_st   = val["common"]["st"]
+    its_repr = its_st["REPR"]
+    reprid   = its_repr["ID"]
+    if reprid != repr_infos["MVMString"]["reprid"]:
+        return "<not a string: " + its_repr["name"].string() + " " + its_st["debug_name"].string() + ">"
     try:
         stringtyp = str_t_info[int(val['body']['storage_type'])]
     except KeyError:

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -16,24 +16,38 @@
 #
 # So far, there's:
 #
-# - A semi-functional pretty-printer for MVMString and MVMString*
-# - A non-working pretty-printer for MVMObject in general
+# - An almost complete pretty-printer for MVMString and MVMString*
+# - A group of commands "moar break" for commonly useful breakpoints.
+# - A command "moar bt" that shows a backtrace including each frame's arguments.
+# - Commands `moar frame N` that lets you get a frame by index on the current
+#   stack, `moar frame up` that lets you move to the last frame's caller, or
+#   `moar frame out` that lets you move to the last frame's outer.
+# - A command `moar tc` that works out the address of the current thread's
+#   MVMThreadContext without getting confused by the occasionally wrong
+#   values you see in gdb's backtrace command.
+#
+# There are some things in the code that are incomplete or not working:
+# - A pretty-printer for MVMObject in general
 # - A command "moar heap" that walks the nursery and gen2 and displays
 #   statistics about the REPRs found in them, as well as a display of
 #   the fragmentation of the gen2 pages.
-# - A command "moar diff-heap" that diffs (so far only) the two last
-#   snapshots of the nursery, or whatever snapshot number you supply
-#   as the argument.
-# - A group of commands "moar break" for commonly useful breakpoints.
-# - A command "moar bt" that shows a backtrace including each frame's arguments.
+#
+#
+# If you're in a replay session with rr (rr-project.org), there are some
+# additional features you can take advantage of:
+#
+# - `moar rrdb` runs the program from start to finish while recording
+#   information from certain interesting events, storing them in a sqlite3
+#   database file. Flags to add more potentially expensive data collection
+#   exist. See `help moar rrdb` for more info.
+# - `moar timeline` shows things that have happened or will happen around
+#   your current position in the replay, including minor and major GC runs
+#   as well as frame invokes and returns during the same rr event (`when`).
+#
 
 # Here's the TODO list:
 #
-# - Figure out if the string pretty-printer is hosed wrt. ropes or if
-#   it's something wrong with MaarVM's ropes in general.
 # - Implement diffing for the gen2 in some sensible manner
-# - The backtrace should also display a backtrace of the interpreter
-#   state. That's relatively easy, as you can just dump_backtrace(tc).
 # - Give the object prety printer a children method that figures
 #   stuff out about attributes of a P6opaque, or CStruct.
 # - Let VMArray and MVMHash be displayed with the right display_hint
@@ -3160,10 +3174,10 @@ def do_single_frame_command_stuff(cur_frame : MoarStackFrame, stack_idx = None):
         print("could not unset obsolete margs convenience vars")
 
 
-class MoarBtFrameCommand(gdb.Command):
+class MoarFrameCommands(gdb.Command):
     """Get all details of one stack frame on the moarvm stack"""
     def __init__(self):
-        super(MoarBtFrameCommand, self).__init__("moar bt frame", gdb.COMMAND_STACK, prefix=True)
+        super(MoarFrameCommands, self).__init__("moar frame", gdb.COMMAND_STACK, prefix=True)
 
     def invoke(self, argument, from_tty):
         stack_idx = None
@@ -3185,10 +3199,10 @@ class MoarBtFrameCommand(gdb.Command):
         do_single_frame_command_stuff(cur_frame, stack_idx)
 
 
-class MoarBtFrameUpCommand(gdb.Command):
+class MoarFrameUpCommand(gdb.Command):
     """Get all details of the current moar stack frame's caller."""
     def __init__(self):
-        super(MoarBtFrameUpCommand, self).__init__("moar bt frame up", gdb.COMMAND_STACK)
+        super(MoarFrameUpCommand, self).__init__("moar frame up", gdb.COMMAND_STACK)
 
     def invoke(self, argument, from_tty):
         frame = gdb.parse_and_eval("$mframe")
@@ -3203,10 +3217,10 @@ class MoarBtFrameUpCommand(gdb.Command):
         else:
             raise ValueError("Convenience Variable $mframe doesn't seem to exist?")
 
-class MoarBtFrameOutCommand(gdb.Command):
+class MoarFrameOutCommand(gdb.Command):
     """Get all details of the current moar stack frame's outer."""
     def __init__(self):
-        super(MoarBtFrameOutCommand, self).__init__("moar bt frame out", gdb.COMMAND_STACK)
+        super(MoarFrameOutCommand, self).__init__("moar frame out", gdb.COMMAND_STACK)
 
     def invoke(self, argument, from_tty):
         frame = gdb.parse_and_eval("$mframe")
@@ -3284,7 +3298,7 @@ def register_commands(objfile):
     print("command moar rrdb registered")
 
     commands.append(MoarTimelineCommand())
-    print("command moar timelineregistered")
+    print("command moar timeline registered")
 
     commands.append(MoarBreakCommands())
     commands.append(MoarBreakInterpRunCommands())
@@ -3292,10 +3306,12 @@ def register_commands(objfile):
     print("moar break commands registered")
 
     commands.append(MoarBtCommands())
-    commands.append(MoarBtFrameCommand())
-    commands.append(MoarBtFrameUpCommand())
-    commands.append(MoarBtFrameOutCommand())
-    print("moar bt commands registered")
+    print("moar bt command registered")
+
+    commands.append(MoarFrameCommands())
+    commands.append(MoarFrameUpCommand())
+    commands.append(MoarFrameOutCommand())
+    print("moar frame commands registered")
 
     commands.append(MoarTCCommand())
     print("moar TC commands registered")

--- a/tools/libmoar.so-gdb.py
+++ b/tools/libmoar.so-gdb.py
@@ -1030,13 +1030,14 @@ class AutoResumingBreakpoint(gdb.Breakpoint):
     def stop(self):
         try:
             self._hit_breakpoint_action()
-        except Exception:
-            pass
+        except Exception as ex:
+            print(f"exception while evaluating {self}: ", ex)
+            raise
         return False # don't actually stop
 
 class PointInTimeRecordingBreakpoint(AutoResumingBreakpoint):
-    def __init__(self, medbc, event, exprs, *args):
-        super(PointInTimeRecordingBreakpoint, self).__init__(*args)
+    def __init__(self, medbc, event, exprs, *args, **kwargs):
+        super(PointInTimeRecordingBreakpoint, self).__init__(*args, internal=True, **kwargs)
         self._medbc = medbc # MakeExecutionDatabaseCommand
         self._event = event
         self._exprs = exprs
@@ -1052,8 +1053,8 @@ class PointInTimeRecordingBreakpoint(AutoResumingBreakpoint):
         return self
 
 class ArrayEntryRecordingBreakpoint(AutoResumingBreakpoint):
-    def __init__(self, medbc, table_name, exprs, *args):
-        super(ArrayEntryRecordingBreakpoint, self).__init__(*args)
+    def __init__(self, medbc, table_name, exprs, *args, **kwargs):
+        super(ArrayEntryRecordingBreakpoint, self).__init__(*args, internal=True, **kwargs)
         self._medbc = medbc # MakeExecutionDatabaseCommand
         self._table_name = table_name
         self._exprs = exprs
@@ -1069,8 +1070,8 @@ class ArrayEntryRecordingBreakpoint(AutoResumingBreakpoint):
         return self
 
 class SQLRecordingBreakpoint(AutoResumingBreakpoint):
-    def __init__(self, medbc, table_name : str, column_names : str, exprs : Sequence, *args):
-        super(SQLRecordingBreakpoint, self).__init__(*args)
+    def __init__(self, medbc, table_name : str, column_names : str, exprs : Sequence, *args, **kwargs):
+        super(SQLRecordingBreakpoint, self).__init__(*args, internal=True, **kwargs)
         self._medbc = medbc # MakeExecutionDatabaseCommand
         self._table_name = table_name
         self._exprs = exprs
@@ -1097,16 +1098,16 @@ class SQLRecordingBreakpointWithPrereq(SQLRecordingBreakpoint):
         return False
 
 class EventTimeAndStackBreakpoint(AutoResumingBreakpoint):
-    def __init__(self, medbc, *args):
-        super(EventTimeAndStackBreakpoint, self).__init__(*args)
+    def __init__(self, medbc, *args, **kwargs):
+        super(EventTimeAndStackBreakpoint, self).__init__(*args, internal=True, **kwargs)
         self._medbc = medbc # MakeExecutionDatabaseCommand
 
     def _hit_breakpoint_action(self):
         self._medbc._register_event_time_and_stack_only()
 
 class ObjectMovementRecordingBreakpoint(AutoResumingBreakpoint):
-    def __init__(self, medbc, *args):
-        super(ObjectMovementRecordingBreakpoint, self).__init__(*args)
+    def __init__(self, medbc, *args, **kwargs):
+        super(ObjectMovementRecordingBreakpoint, self).__init__(*args, internal=True, **kwargs)
         self._medbc = medbc
 
     def _hit_breakpoint_action(self):
@@ -1612,15 +1613,15 @@ class MakeExecutionDatabaseCommand(gdb.Command):
 
     _last_saved_event_time = -1
 
-    def _insert_time_and_take_stack(self, rr_event, currthreadptid, conn):
+    def _insert_time_and_take_stack(self, rr_event, rr_tick, currthreadptid, conn):
         # If this is the firs time we see this rr_event time,
         if rr_event > self._last_saved_event_time:
             # Store the relative elapsed time in `event_times`
             resp     = bytes.fromhex(conn.send_packet('qRRCmd:elapsed-time:' + str(currthreadptid)))
             rr_time  = float(resp[resp.rindex(b' ') + 1:])
 
-            query = f'INSERT INTO event_times VALUES (?, ?)';
-            self._db_cur.execute(query, (rr_event, rr_time))
+            query = f'INSERT INTO event_times VALUES (?, ?, ?, ?)';
+            self._db_cur.execute(query, (rr_event, rr_time, rr_tick, currthreadptid))
             self._last_saved_event_time = rr_event
 
             # If stack sampling was requested, take a sample and put it in
@@ -1645,8 +1646,11 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         resp     = bytes.fromhex(conn.send_packet('qRRCmd:when:' + str(currthreadptid)))
         rr_event = int(resp[resp.rindex(b' '):])
 
+        resp     = bytes.fromhex(conn.send_packet('qRRCmd:when-ticks:' + str(currthreadptid)))
+        rr_tick  = int(resp[resp.rindex(b' '):])
+
         try:
-            self._insert_time_and_take_stack(rr_event, currthreadptid, conn)
+            self._insert_time_and_take_stack(rr_event, rr_tick, currthreadptid, conn)
 
         finally:
             self._db_conn.commit()
@@ -1699,7 +1703,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             except Exception as ex:
                 print("row not entered", ex)
 
-            self._insert_time_and_take_stack(rr_event, currthreadptid, conn)
+            self._insert_time_and_take_stack(rr_event, rr_tick, currthreadptid, conn)
 
         finally:
             self._db_conn.commit()
@@ -1809,7 +1813,15 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         self._db_conn = sqlite3.connect(self._db_file.name, autocommit=False, timeout=30)
         self._db_cur = self._db_conn.cursor()
 
+        conn = gdb.connections()[0]
+        assert isinstance(conn, gdb.RemoteTargetConnection)
+
         self.stackrec = StackRecorder(gdb.inferiors()[0].pid, self._db_conn)
+
+        def get_rr_tid(frame_, row):
+            resp   = bytes.fromhex(conn.send_packet('qRRCmd:when-tid:' + str(row["__currthreadptid"])))
+            rr_tid = int(resp[resp.rindex(b' '):])
+            return ["rr_tid", rr_tid]
 
         print("")
         print("    sqlite3 file can be found at ", self._db_file.name)
@@ -1862,7 +1874,7 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 tc integer,
                 rr_tick integer,
                 rr_event integer,
-                tag integer,
+                callstack_region integer,
                 is_slice boolean
             );
             create table nfa_runs (
@@ -1873,12 +1885,16 @@ class MakeExecutionDatabaseCommand(gdb.Command):
             );
             create table event_times (
                 rr_event integer,
-                rr_time float
+                rr_time float,
+                rr_tick integer,
+                rr_tid integer
             );
             create table threadcontexts (
                 rr_event integer,
                 tc integer,
-                tid integer
+                gdb_tid integer,
+                rr_tid integer,
+                exited_event integer
             );
             create table object_movements (
                 rr_event integer,
@@ -1925,9 +1941,11 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                 bp.enabled = False
                 self._disabled_breakpoints.append(bp)
 
-        cbp.append(SQLRecordingBreakpoint(self, "threadcontexts", "rr_event tc tid", [
+        cbp.append(SQLRecordingBreakpoint(self, "threadcontexts", "rr_event tc gdb_tid rr_tid exited_event", [
             EXP.local_var("tc", "tc", int),
-            lambda _, row: ["tid", row["__currthreadptid"]],
+            lambda _, row: ["gdb_tid", row["__currthreadptid"]],
+            get_rr_tid,
+            ["exited_event", None],
             ], "src/core/threads.c:thread_initial_invoke"))
 
 
@@ -2045,15 +2063,16 @@ class MakeExecutionDatabaseCommand(gdb.Command):
                              ], mvmstr_to_str),
             ], "MVM_validate_static_frame"))
 
-        cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event tag is_slice", [
+
+        cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event callstack_top is_slice", [
             EXP.local_var("tc", "tc", int),
-            EXP.local_var("tag", "tag", int),
+            EXP.local_field("callstack_top", "tc", ["stack_top"], int),
             lambda _, _2: ["is_slice", 0],
             ], "MVM_callstack_continuation_slice"))
 
-        cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event tag is_slice", [
+        cbp.append(SQLRecordingBreakpoint(self, "continuation_events", "tc rr_tick rr_event callstack_top is_slice", [
             EXP.local_var("tc", "tc", int),
-            EXP.local_var("tag", "update_tag", int),
+            EXP.local_var("callstack_top", "stack_top", int),
             lambda _, _2: ["is_slice", 1],
             ], "MVM_callstack_continuation_append"))
 
@@ -2078,9 +2097,6 @@ class MakeExecutionDatabaseCommand(gdb.Command):
         #    ["subject_kind", "frames"],
         #    EXP.gdb_eval("subject", "returner", int),
         #    ], "callstack.c:exit_frame"))
-
-        conn = gdb.connections()[0]
-        assert isinstance(conn, gdb.RemoteTargetConnection)
 
         last_event = 0
         records_this_event = 0
@@ -2337,8 +2353,9 @@ class MoarTimelineCommand(gdb.Command):
 
             # cont_contr_bp  = ContinuationEventTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_control", "MVM_continuation_control")
             # cont_invoke_bp = ContinuationEventTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_invoke", "MVM_continuation_invoke")
-            cont_contr_bp  = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_control", "MVM_continuation_control")
-            cont_invoke_bp = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_invoke", "MVM_continuation_invoke")
+
+            # cont_contr_bp  = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_control", "MVM_continuation_control")
+            # cont_invoke_bp = InvokeReturnTimelineRecordingBreakpoint(conn, rr_event, currthreadptid, self, tc, "cont_invoke", "MVM_continuation_invoke")
 
             gdb.execute(f"run {rr_event - 1}")
 
@@ -2360,15 +2377,15 @@ class MoarTimelineCommand(gdb.Command):
         finally:
             return_bp.delete()
             invoke_bp.delete()
-            cont_contr_bp.delete()
-            cont_invoke_bp.delete()
+            # cont_contr_bp.delete()
+            # cont_invoke_bp.delete()
 
         found_entries = [e for e in self.found_entries if e[0] == rr_event]
 
         try:
             cur = execution_db.cursor()
 
-            query = """
+            gcs_query = """
                 select
                    igcs.earliest,
                    eet.rr_time as earliest_time,
@@ -2390,11 +2407,77 @@ class MoarTimelineCommand(gdb.Command):
                 limit ?;
             """
 
+            continuation_query = """
+            select
+              abs(min(start_rr_event - :now_rr_event, end_rr_event - :now_rr_event)) as eventdiff,
+              start_tc,
+              end_tc,
+              start_rr_event,
+              end_rr_event,
+              start_tick,
+              end_tick
+            from
+              (SELECT
+                st.tc AS start_tc,
+                ed.tc AS end_tc,
+                st.rr_event AS start_rr_event,
+                ed.rr_event AS end_rr_event,
+                st.rr_tick AS start_tick,
+                ed.rr_tick AS end_tick,
+                rank() over w as rank
+              FROM
+                continuation_events st
+                INNER JOIN continuation_events ed
+                  ON st.callstack_region = ed.callstack_region
+                  AND (
+                      st.rr_event < ed.rr_event
+                      OR (
+                        st.rr_event = ed.rr_event
+                        AND st.tc = ed.tc
+                        AND st.rr_tick < ed.rr_tick
+                      )
+                  )
+              WHERE
+                st.is_slice = 0
+                AND ed.is_slice = 1
+              WINDOW
+                w AS (
+                    PARTITION BY
+                      st.rr_event,
+                      st.rr_tick,
+                      st.callstack_region,
+                      ed.callstack_region
+                    ORDER BY
+                      st.rr_event ASC,
+                      st.rr_tick ASC,
+                      ed.rr_event ASC,
+                      ed.rr_tick ASC
+                )
+              )
+              where rank = 1
+                and (start_tc = :now_tc
+                     or end_tc = :now_tc)
+              order by 1,2
+              limit :limit;
+            """
+
+                # and start_rr_event = :now_rr_event
 
             timeline_events = []
             for (want_full, limit) in [(0, 8), (1, 4)]:
-                nearby_gcs = cur.execute(query, (rr_event, want_full, limit)).fetchall()
+                nearby_gcs = cur.execute(gcs_query, (rr_event, want_full, limit)).fetchall()
                 timeline_events.extend(nearby_gcs)
+
+            print(f"nearby continuation events: {rr_event=} {rr_tick=} tc={int(tc)} {limit=}")
+            nearby_continuation_events = cur.execute(continuation_query, dict(
+                now_rr_event=rr_event,
+                now_rr_tick=rr_tick,
+                now_tc=int(tc),
+                limit=limit
+            ))
+            cont_events = [e for e in nearby_continuation_events.fetchall()]
+            print(cont_events)
+            cont_events = sorted(cont_events, key=lambda e: (e[2], e[3]))
 
             timeline_events = sorted(timeline_events, key=lambda e: e[0])
             before = [e for e in timeline_events if e[0] <  rr_event]
@@ -2479,6 +2562,9 @@ class MoarTimelineCommand(gdb.Command):
             if found_entries and total_min_stack_depth != min_stack_depth and lowest_depth_before:
                 invoke_event_line(*lowest_depth_before[-1])
                 print("...")
+
+            for e in cont_events:
+                print(e)
 
             for e in few_frame_events_before:
                 invoke_event_line(*e)
@@ -3175,7 +3261,11 @@ def do_single_frame_command_stuff(cur_frame : MoarStackFrame, stack_idx = None):
 
 
 class MoarFrameCommands(gdb.Command):
-    """Get all details of one stack frame on the moarvm stack"""
+    """Get all details of one stack frame on the moarvm stack.
+
+    Pass a pointer starting with * to use inspect a frame explicitly, pass no
+    argument to get the current frame, or a number to get the nth frame on
+    the stack."""
     def __init__(self):
         super(MoarFrameCommands, self).__init__("moar frame", gdb.COMMAND_STACK, prefix=True)
 


### PR DESCRIPTION
* Robustness improvements for string pretty printer
* `moar bt`: Robust command to get a backtrace that also works in postmortem mode
* `moar tc`: Robust command to get the current thread's `MVMThreadContext *`
* `moar frame`, `moar frame {up,out}` Commands to look at individual frames and their arguments, and move to a given frame's caller or outer. [Example output of `moar frame` and `moar bt`](https://gist.github.com/timo/20b8e7f029b21581997f151be3bdce7f).

When running an `rr replay`, there's some extra functionality available:

* `moar rrdb` runs the recording and stores information about interesting / important events in an sqlite3 database
  * also adding `trackgc` records before and after addresses of objects moved during GC runs
  * also adding `stack` will store a stack trace at every rr event (roughly every time a syscall or signal happens, or the scheduler switched threads)
  * also adding `deopt` records deopt events
  * Not much in the plugin actually uses the recorded data by itself, but querying the database by hand with the `sqlite3` CLI is possible.
* `moar timeline` shows the current location in the replay in the context of GC runs and a sampling of calls to and returns from routines, with the tick numbers you can use to jump to the exact moment. [Here's some example output with the amount of events to display cranked up](https://gist.githubusercontent.com/timo/423eac9a06f26120ee8331e720ee16f6/raw/c0a368b5a7e9cb0ec12388df606529d2d776add1/gistfile1.txt).

Lots of "next steps" that can make especially stuff when running in rr a lot better are on my mind, but for now I really want to get all the improvements of the script in general into a release.