### PR TITLE
Add VM-based CI that builds and tests on DragonFly BSD

### DIFF
--- a/.github/workflows/test_other_platforms.yml
+++ b/.github/workflows/test_other_platforms.yml
@@ -1,0 +1,95 @@
+name: Test on other platforms
+
+# Build MoarVM and run the NQP test suite on operating systems that GitHub
+# does not provide hosted runners for. The OS runs in a VM on top of an
+# ubuntu-latest runner, so this workflow is independent of the Azure Pipelines
+# matrix and does not delay it.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  dragonflybsd:
+    name: DragonFly BSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout MoarVM
+        uses: actions/checkout@v7
+        with:
+          path: MoarVM
+          submodules: recursive
+          # Configure.pl takes the version from `git describe --tags`, and NQP
+          # refuses to build against a MoarVM older than the revision pinned in
+          # its tools/templates/MOAR_REVISION, so both the history and the tags
+          # are needed.
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Checkout NQP
+        uses: actions/checkout@v7
+        with:
+          repository: Raku/nqp
+          path: nqp
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Build and test in DragonFly BSD
+        uses: vmactions/dragonflybsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          cache-after-prepare: true
+          prepare: |
+            pkg install -y perl5 gmake git
+          run: |
+            set -e
+
+            # The work tree is synced in from the runner, so inside the VM it
+            # is owned by a different uid than the one running the build.
+            # Without this, `git describe` and the submodule sync that
+            # Configure.pl runs both fail with "detected dubious ownership".
+            git config --global --add safe.directory '*'
+
+            echo "===== toolchain ====="
+            uname -a
+            perl -v | sed -n '2p'
+            cc --version | sed -n '1p'
+            git --version
+
+            JOBS=`sysctl -n hw.ncpu`
+
+            # --toolchain=gnu because the "bsd" toolchain that build/setup.pm
+            # selects here generates object rules that use `$*.c`, and BSD make
+            # expands `$*` without the directory part, so every compile fails
+            # with "no such file or directory: 'args.c'".
+            #
+            # No -j on the MoarVM build: the vendored dyncall build shells out
+            # to the base system make, which rejects the bare -j that GNU make
+            # puts into MAKEFLAGS for its job server.
+            echo "===== build MoarVM ====="
+            cd MoarVM
+            perl Configure.pl --toolchain=gnu --prefix=../install
+            gmake install
+            ../install/bin/moar --version
+
+            # NQP::Config picks its own make and generates a matching Makefile,
+            # so let NQP's Configure.pl drive the build.
+            echo "===== build NQP ====="
+            cd ../nqp
+            perl Configure.pl --backends=moar --prefix=../install --make-install
+
+            echo "===== test NQP ====="
+            prove -j$JOBS -r -e ../install/bin/nqp \
+              t/nqp t/hll t/qregex t/p5regex t/qast t/moar \
+              t/serialization t/nativecall t/concurrency

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ contain the third party libraries needed to successfully build MoarVM.
 
 ## Build It
 [![Build Status](https://dev.azure.com/MoarVM/MoarVM/_apis/build/status/MoarVM.MoarVM?branchName=master)](https://dev.azure.com/MoarVM/MoarVM/_build/latest?definitionId=1&branchName=master)
+[![Test on other platforms](https://github.com/MoarVM/MoarVM/actions/workflows/test_other_platforms.yml/badge.svg)](https://github.com/MoarVM/MoarVM/actions/workflows/test_other_platforms.yml)
 
 Building and installing the VM itself takes just:
 


### PR DESCRIPTION
Closes #1418

#1418 asked for a drop-in test build on FreeBSD and other operating systems using
the vmactions VMs. This adds that workflow as a separate file, so it neither
interferes with nor delays the Azure Pipelines matrix.

### What the job does

It runs the guest OS in a VM on an `ubuntu-latest` runner, builds MoarVM, then
builds NQP against it and runs the NQP test suite -- MoarVM has no test suite of its
own (`make test` just prints `build/test.txt`).

Verification run on the exact head of this branch:
https://github.com/neilpang/MoarVM/actions/runs/30349845037 -- 371 compiles,
`This is MoarVM version 2026.07-7-ge82d6372a built with JIT support`,
`Files=145, Tests=13476 ... Result: PASS`. The job takes about 5 minutes end to end.

Two things in the job need explaining:

* **`--toolchain=gnu`.** `build/setup.pm` maps the BSDs to the `bsd` toolchain, but
  the Makefile that generates cannot be built by BSD make: the object rules use
  `$*.c`, and BSD make expands `$*` to the file name *without its directory*, so
  every compile fails with `clang: error: no such file or directory: 'args.c'`
  ([run](https://github.com/neilpang/MoarVM/actions/runs/30347040198)). If you would
  rather have the native `make` path work, the fix is in the `$*.c` occurrences in
  `build/Makefile.in`; happy to send that separately.
* **no `-j` on the MoarVM build.** The vendored dyncall build shells out to the base
  system make, which rejects the bare `-j` that GNU make puts into `MAKEFLAGS` for
  its job server: `make[1]: illegal argument to -j -- must be positive integer!`

### Why only DragonFly BSD

I tried FreeBSD, OpenBSD, NetBSD and Solaris as well. Each is blocked by a real
portability break rather than by CI configuration, so I left those jobs out instead
of landing a red workflow.

**FreeBSD** -- `3rdparty/libuv` (pinned at `MoarVM/libuv@dcd3a3f`, the head of
`1-50-0-with-pty`) has:

```c
#if defined(__DragonFly__) || defined(__FreeBSD__) || \
    defined(__NetBSD__) || defined(__OpenBSD__)
#include <util.h>
#endif
```

FreeBSD has no `<util.h>` -- `openpty(3)` is declared in `<libutil.h>` and lives in
`-lutil`. Confirmed absent on 13.5, 14.3 and 15.1, with `libutil.h` present on each:
[run](https://github.com/neilpang/MoarVM/actions/runs/30348802652).

Two changes make FreeBSD work, both verified:

1. **MoarVM/libuv**: use `<libutil.h>` on FreeBSD -- PR: https://github.com/MoarVM/libuv/pull/1. With it,
   MoarVM builds and the NQP suite passes on 13.5, 14.3 and 15.1:
   [run](https://github.com/neilpang/MoarVM/actions/runs/30350124514).
2. **`build/setup.pm`**: add `util` to the FreeBSD `syslibs`. Without it
   `libmoar.so` carries an unresolved `openpty`; the build and the NQP suite still
   pass because nothing in them spawns a pty, but a pty spawn would fail at runtime
   ([run](https://github.com/neilpang/MoarVM/actions/runs/30350556243)). Adding
   `util` links `libutil.so.9` on 13.5 and `libutil.so.10` on 15.1
   ([run](https://github.com/neilpang/MoarVM/actions/runs/30350965084)).

I can send the `setup.pm` change and the FreeBSD job as a follow-up once the libuv
side is settled.

**NetBSD and OpenBSD** -- `3rdparty/zmij` does not compile:

```
3rdparty/zmij/zmij.c:2076:45: error: 'DBL_DECIMAL_DIG' undeclared
3rdparty/zmij/zmij.c:2076:63: error: 'FLT_DECIMAL_DIG' undeclared
```

and on NetBSD additionally
`zmij.c:151:24: error: expected declaration specifiers or '...' before '__builtin_constant_p'`
-- NetBSD's `<sys/bswap.h>` defines `bswap64` as a macro, colliding with zmij's
`static inline` of the same name. Runs:
[OpenBSD](https://github.com/neilpang/MoarVM/actions/runs/30347040198),
[NetBSD](https://github.com/neilpang/MoarVM/actions/runs/30347805193). This arrived
with the Ryu -> Zmij switch (#1986).

**Solaris 11.4** -- `src/core/args.c:75:33: error: implicit declaration of function 'alloca'`;
Solaris declares `alloca` in `<alloca.h>`.
[Run](https://github.com/neilpang/MoarVM/actions/runs/30347040198).

### Also in this PR

* README gains a badge for the new workflow, next to the Azure one.
* `actions/checkout@v7`, the current major.
* Both checkouts use `fetch-depth: 0` + `fetch-tags: true`: `Configure.pl` takes the
  version from `git describe --tags`, and NQP refuses a MoarVM older than its pinned
  `MOAR_REVISION`.
* The run script sets `safe.directory`, because the tree is synced into the VM and
  ends up owned by a different uid than the build runs as.
