### PR TITLE
Bump mimalloc to v2.4.4

### DIFF
--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,5 @@
 
++ Bump mimalloc to v2.4.4
 + Switch from Ryu to Żmij for our double-to-ascii implementation
 
 New in 2026.07


### PR DESCRIPTION
2026-08-01, v1.9.14, v2.4.4, v3.4.4: various bug and security fixes through Opus 5 LLM audit (issue #1271, by @Zoxc). (v3): use pthreads by default on macOS (issue #1333, issue #1327), fix glibc 2.44 crash (issue #1341), fix alignment check for realloc_aligned. (v1,v2,v3): Add initial mingw support, set errno on allocation errors, improved double-free checks and size checks in secure mode, enable build for universal windows platform and xbox (pr #1340), fix numa node detection when numa nodes are sparse.